### PR TITLE
fix: insert method destroy in historyHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.x.x - 2021-04-2228
+
+### Added
+- Added method in historyHandler for destroy routes by names list
+
 ## 1.x.x - 2021-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.x.x - 2021-04-2228
-
-### Changed
-- Added method in historyHandler for destroy routes by names list
-
 ## 1.x.x - 2021-04-22
 
 ### Added
 - Added mixin `screen`
 - Added QasTextTruncate component in `ui/src/component`
+
+### Changed
+- Added method in historyHandler for destroy routes by names list
 
 ## 1.8.0 - 2021-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 1.x.x - 2021-04-2228
 
-### Added
+### Changed
 - Added method in historyHandler for destroy routes by names list
 
 ## 1.x.x - 2021-04-22

--- a/ui/src/helpers/historyHandler.js
+++ b/ui/src/helpers/historyHandler.js
@@ -35,7 +35,7 @@ function handleHistory () {
         return null
       }
 
-      routes.forEach((route) => {
+      routes.forEach(route => {
         const index = history.list.findIndex(item => item.name === route)
 
         if (~index) {

--- a/ui/src/helpers/historyHandler.js
+++ b/ui/src/helpers/historyHandler.js
@@ -28,6 +28,20 @@ function handleHistory () {
 
       history.list.push(route)
       history.hasPreviousRoute = history.list.length > 1
+    },
+
+    destroy (routes) {
+      if (!history.list.length) {
+        return null
+      }
+
+      routes.forEach((route) => {
+        const index = history.list.findIndex(item => item.name === route)
+
+        if (~index) {
+          history.list.splice(index, 1)
+        }
+      })
     }
   }
 }


### PR DESCRIPTION
## 1.x.x - 2021-04-27

### Fixed
- Added method in `historyHandler` for destroy routes by names list

Closes #197 