### PR TITLE
NestedFields - Treating snake or kebab-case to camel-case inside childrens

### DIFF
--- a/ui/src/components/nested-fields/QasNestedFields.vue
+++ b/ui/src/components/nested-fields/QasNestedFields.vue
@@ -65,6 +65,7 @@ import QasInput from '../input/QasInput'
 import QasLabel from '../label/QasLabel'
 
 import { extend } from 'quasar'
+import { camelize } from 'humps'
 import { set } from 'lodash'
 
 export default {
@@ -198,7 +199,7 @@ export default {
 
     children () {
      for (const key in this.field?.children) {
-       this.field.children[key].name = this.camelize(this.field.children[key].name)
+       this.field.children[key].name = camelize(this.field.children[key].name)
      }
 
       return this.field?.children
@@ -237,13 +238,6 @@ export default {
   },
 
   methods: {
-    camelize(str){
-      return str.replace(/([-_][a-z])/g, (group) => group.toUpperCase()
-        .replace('-', '')
-        .replace('_', '')
-      )
-    },
-
     add (row = {}) {
       this.nested.push({ ...this.rowObject, ...row })
 

--- a/ui/src/components/nested-fields/QasNestedFields.vue
+++ b/ui/src/components/nested-fields/QasNestedFields.vue
@@ -197,6 +197,10 @@ export default {
     },
 
     children () {
+     for (const key in this.field?.children) {
+       this.field.children[key].name = this.camelize(this.field.children[key].name)
+     }
+
       return this.field?.children
     },
 
@@ -233,6 +237,13 @@ export default {
   },
 
   methods: {
+    camelize(str){
+      return str.replace(/([-_][a-z])/g, (group) => group.toUpperCase()
+        .replace('-', '')
+        .replace('_', '')
+      )
+    },
+
     add (row = {}) {
       this.nested.push({ ...this.rowObject, ...row })
 


### PR DESCRIPTION
Esse foi um bug encontrado durante o desenvolvimento do nested fields dentro do hub-client.

Basicamente ele não estava transformando de snake case (nome-da-parada) para camel case (nomeDaParada) dentro dos "childrens" de um fields com nested, creio eu que o humps e a aplicação dele se limita aos campos de dentro de fields, e não vai até o fields.children (que é como apresentamos os campos de um nested fields) para alterar o modelo da propriedade name para o padrão que utilizamos
![image](https://user-images.githubusercontent.com/444696/116885539-5f122680-abfe-11eb-8d63-3e6c300c68e1.png)

