### PR TITLE
QasCopy - changes on icon default size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.1 - 2021-05-21
+
+### Changes
+- Adjustments on `QasCopy` icon size to respect design system
+
 ## 2.1.0 - 2021-05-15
 
 ### Added

--- a/ui/src/components/copy/QasCopy.stories.js
+++ b/ui/src/components/copy/QasCopy.stories.js
@@ -19,6 +19,10 @@ export default {
 
     label: {
       description: 'Text to be copied.'
+    },
+
+    size: {
+      description: 'Size of your icon'
     }
   }
 }

--- a/ui/src/components/copy/QasCopy.vue
+++ b/ui/src/components/copy/QasCopy.vue
@@ -2,7 +2,7 @@
   <span>
     <slot>{{ label }}</slot>
 
-    <q-btn class="q-ml-xs" color="grey-5" flat :icon="icon" round size="xs" @click="copy">
+    <q-btn class="q-ml-xs" color="grey-5" flat :icon="icon" round :size="size" @click="copy">
       <q-tooltip>Copiar</q-tooltip>
     </q-btn>
   </span>
@@ -21,6 +21,11 @@ export default {
 
     label: {
       required: true,
+      type: String
+    },
+
+    size: {
+      default: 'sm',
       type: String
     }
   },


### PR DESCRIPTION
Requerido por Lucas Tomazini para o Design System: o tamanho default do ícone do `QasCopy` deve ser `sm`, e não `xs` como anteriormente

Houve mudanças no componente, aceitando agora uma prop para o size (caso queira mandar outro tamanho) e como default o `sm` e mudanças no arquivo do story desse componente para explicar como usar a prop