### PR TITLE
Removing asset from qas-avatar inside AppBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.2 - 2021-05-24
+
+### Changes
+- Change the avatar image prop, not running into asset function
 ## 2.1.0 - 2021-05-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 - Change the avatar image prop, not running into asset function
+- Change qas-avatar letter weight to bold
+
 ## 2.1.0 - 2021-05-15
 
 ### Added

--- a/ui/src/components/app-bar/QasAppBar.vue
+++ b/ui/src/components/app-bar/QasAppBar.vue
@@ -23,7 +23,7 @@
       <slot name="tools" />
 
       <div v-if="isAuth" class="cursor-pointer items-center q-mr-sm qas-toolbar__user row" :title="user.name || user.givenName">
-        <qas-avatar color="white" dark :image="asset(user.photo)" rounded size="36px" text-color="primary" :title="user.name || user.givenName" />
+        <qas-avatar color="white" dark :image="user.photo" rounded size="36px" text-color="primary" :title="user.name || user.givenName" />
 
         <div class="q-pl-xs q-pr-sm qas-toolbar__user-data qs-lh-sm">
           <div class="ellipsis">{{ user.name || user.givenName }}</div>
@@ -34,7 +34,7 @@
           <div class="qas-toolbar__user-menu">
             <div class="q-pa-lg text-center">
               <button class="unset" @click="goToProfile">
-                <qas-avatar :image="asset(user.photo)" size="145px" :title="user.name || user.givenName" />
+                <qas-avatar :image="user.photo" size="145px" :title="user.name || user.givenName" />
               </button>
 
               <div class="ellipsis q-mt-lg qs-lh-sm text-bold text-subtitle1">{{ user.name || user.givenName }}</div>
@@ -58,8 +58,6 @@
 </template>
 
 <script>
-import { asset } from '../../helpers'
-
 import QasAppsMenu from '../apps-menu/QasAppsMenu'
 import QasAvatar from '../avatar/QasAvatar'
 import QasBtn from '../btn/QasBtn'
@@ -133,8 +131,6 @@ export default {
   },
 
   methods: {
-    asset,
-
     goToProfile () {
       return this.$router.push(this.user.to)
     },

--- a/ui/src/components/avatar/QasAvatar.vue
+++ b/ui/src/components/avatar/QasAvatar.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-avatar :class="classes" rounded v-bind="$attrs" v-on="$listeners">
+  <q-avatar class="text-bold" :class="classes" rounded v-bind="$attrs" v-on="$listeners">
     <q-img v-if="hasImage" :alt="title" :ratio="1" spinner-color="primary" spinner-size="16px" :src="image" @error="onImageLoadedError" />
     <template v-else-if="hasTitle">{{ firstLetter }}</template>
     <q-icon v-else :name="icon" />
@@ -51,8 +51,8 @@ export default {
 
       return [
         this.dark
-          ? `bg-${this.color} text-${contrastColor} text-bold`
-          : `bg-${contrastColor} text-${this.color} text-bold`
+          ? `bg-${this.color} text-${contrastColor}`
+          : `bg-${contrastColor} text-${this.color}`
       ]
     },
 

--- a/ui/src/components/avatar/QasAvatar.vue
+++ b/ui/src/components/avatar/QasAvatar.vue
@@ -51,8 +51,8 @@ export default {
 
       return [
         this.dark
-          ? `bg-${this.color} text-${contrastColor}`
-          : `bg-${contrastColor} text-${this.color}`
+          ? `bg-${this.color} text-${contrastColor} text-bold`
+          : `bg-${contrastColor} text-${this.color} text-bold`
       ]
     },
 


### PR DESCRIPTION
We are receiving the url from backend inside our user requests, I don't feel the nececity of running into the humanaze 'asset' function.

Perhaps shoud run this request inside the client aplication, not here


---
Estamos recebendo a url do backend dentro de nossas solicitações de usuário, não sinto a necessidade de executar a função de 'ativo' humanaze.

Talvez deva executar esta solicitação dentro da aplicação do cliente, não aqui 