### PR TITLE
feature/qasAppMenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-
 - Menu default expanded when a children is selected
 - Color adjustments
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Menu default expanded when a children is selected
+- Color adjustments
+
 ## 2.7.0 - 2021-07-27
 
 ### Added

--- a/ui/src/components/app-menu/QasAppMenu.vue
+++ b/ui/src/components/app-menu/QasAppMenu.vue
@@ -2,8 +2,8 @@
   <q-drawer v-model="model" content-class="bg-primary-contrast" :mini="miniMode" :width="230" @before-hide="beforeHide">
     <q-list class="text-primary" padding>
       <div v-for="(header, index) in items" :key="index">
-        <q-expansion-item v-if="hasChildren(header)" :active-class="activeSecondaryItemClasses" expand-icon="o_keyboard_arrow_down" expand-icon-class="opacity-20 text-primary" expand-separator :icon="header.icon" :label="header.label" :to="header.to">
-          <q-item v-for="(item, itemIndex) in header.children" :key="itemIndex" :active-class="activeItemClasses"	v-ripple clickable :exact-active-class="activeItemClasses" :to="item.to">
+        <q-expansion-item v-if="hasChildren(header)" :active-class="activeSecondaryItemClasses" expand-icon="o_keyboard_arrow_down" expand-separator :icon="header.icon" :label="header.label" :to="header.to" :default-opened="shouldBeExpanded(header)">
+          <q-item v-for="(item, itemIndex) in header.children" :key="itemIndex" :active-class="activeItemClasses"	v-ripple clickable :to="item.to">
             <q-item-section v-if="item.icon" avatar>
               <q-icon :name="item.icon" />
             </q-item-section>
@@ -13,7 +13,7 @@
           </q-item>
         </q-expansion-item>
 
-        <q-item v-else :key="index" v-ripple clickable :active-class="activeItemClasses" :exact-active-class="activeItemClasses" :to="header.to">
+        <q-item v-else :key="index" v-ripple clickable :active-class="activeItemClasses" :to="header.to">
           <q-item-section v-if="header.icon" avatar>
             <q-icon :name="header.icon" />
           </q-item-section>
@@ -80,6 +80,11 @@ export default {
       return !!(children || []).length
     },
 
+    shouldBeExpanded ({ children, to }) {
+      if (!children?.length) { return false }
+      return this.$route.matched.some(item => item.path === to.path)
+    },
+
     beforeHide () {
       if (this.$_isLarge) {
         this.model = true
@@ -89,3 +94,16 @@ export default {
   }
 }
 </script>
+
+<style lang="scss">
+.q-expansion-item {
+  .bg-secondary-contrast .q-expansion-item__toggle-icon {
+    color: white !important;
+    opacity: 100%;
+  }
+  .q-expansion-item__toggle-icon {
+    color: var(--q-color-primary);
+    opacity: 20%;
+  }
+}
+</style>

--- a/ui/src/components/app-menu/QasAppMenu.vue
+++ b/ui/src/components/app-menu/QasAppMenu.vue
@@ -98,12 +98,12 @@ export default {
 .q-expansion-item {
   .active .q-expansion-item__toggle-icon {
     color: white !important;
-    opacity: 100%;
+    opacity: 1;
   }
 
   .q-expansion-item__toggle-icon {
     color: $primary;
-    opacity: 20%;
+    opacity: 0.2;
   }
 }
 </style>

--- a/ui/src/components/app-menu/QasAppMenu.vue
+++ b/ui/src/components/app-menu/QasAppMenu.vue
@@ -81,8 +81,7 @@ export default {
     },
 
     shouldExpand ({ children, to }) {
-      return children?.length &&
-        this.$route.matched.some(item => item.path === to.path)
+      return children?.length && this.$route.matched.some(item => item.path === to.path)
     },
 
     beforeHide () {
@@ -101,6 +100,7 @@ export default {
     color: white !important;
     opacity: 100%;
   }
+  
   .q-expansion-item__toggle-icon {
     color: var(--q-color-primary);
     opacity: 20%;

--- a/ui/src/components/app-menu/QasAppMenu.vue
+++ b/ui/src/components/app-menu/QasAppMenu.vue
@@ -61,7 +61,7 @@ export default {
     },
 
     activeSecondaryItemClasses () {
-      return 'bg-secondary-contrast text-primary'
+      return 'bg-secondary-contrast text-primary-contrast'
     },
 
     model: {

--- a/ui/src/components/app-menu/QasAppMenu.vue
+++ b/ui/src/components/app-menu/QasAppMenu.vue
@@ -2,7 +2,7 @@
   <q-drawer v-model="model" content-class="bg-primary-contrast" :mini="miniMode" :width="230" @before-hide="beforeHide">
     <q-list class="text-primary" padding>
       <div v-for="(header, index) in items" :key="index">
-        <q-expansion-item v-if="hasChildren(header)" :active-class="activeSecondaryItemClasses" expand-icon="o_keyboard_arrow_down" expand-separator :icon="header.icon" :label="header.label" :to="header.to" :default-opened="shouldBeExpanded(header)">
+        <q-expansion-item v-if="hasChildren(header)" :active-class="activeSecondaryItemClasses" expand-icon="o_keyboard_arrow_down" expand-separator :default-opened="shouldExpand(header)" :icon="header.icon" :label="header.label" :to="header.to">
           <q-item v-for="(item, itemIndex) in header.children" :key="itemIndex" :active-class="activeItemClasses"	v-ripple clickable :to="item.to">
             <q-item-section v-if="item.icon" avatar>
               <q-icon :name="item.icon" />
@@ -61,7 +61,7 @@ export default {
     },
 
     activeSecondaryItemClasses () {
-      return 'bg-secondary-contrast text-primary-contrast'
+      return 'active bg-secondary-contrast text-primary-contrast'
     },
 
     model: {
@@ -80,9 +80,9 @@ export default {
       return !!(children || []).length
     },
 
-    shouldBeExpanded ({ children, to }) {
-      if (!children?.length) { return false }
-      return this.$route.matched.some(item => item.path === to.path)
+    shouldExpand ({ children, to }) {
+      return children?.length &&
+        this.$route.matched.some(item => item.path === to.path)
     },
 
     beforeHide () {
@@ -97,7 +97,7 @@ export default {
 
 <style lang="scss">
 .q-expansion-item {
-  .bg-secondary-contrast .q-expansion-item__toggle-icon {
+  .active .q-expansion-item__toggle-icon {
     color: white !important;
     opacity: 100%;
   }

--- a/ui/src/components/app-menu/QasAppMenu.vue
+++ b/ui/src/components/app-menu/QasAppMenu.vue
@@ -2,8 +2,8 @@
   <q-drawer v-model="model" content-class="bg-primary-contrast" :mini="miniMode" :width="230" @before-hide="beforeHide">
     <q-list class="text-primary" padding>
       <div v-for="(header, index) in items" :key="index">
-        <q-expansion-item v-if="hasChildren(header)" expand-icon="o_keyboard_arrow_down" expand-icon-class="opacity-20 text-primary" expand-separator :icon="header.icon" :label="header.label">
-          <q-item v-for="(item, itemIndex) in header.children" :key="itemIndex" v-ripple clickable :exact-active-class="activeItemClasses" :to="item.to">
+        <q-expansion-item v-if="hasChildren(header)" :active-class="activeSecondaryItemClasses" expand-icon="o_keyboard_arrow_down" expand-icon-class="opacity-20 text-primary" expand-separator :icon="header.icon" :label="header.label" :to="header.to">
+          <q-item v-for="(item, itemIndex) in header.children" :key="itemIndex" :active-class="activeItemClasses"	v-ripple clickable :exact-active-class="activeItemClasses" :to="item.to">
             <q-item-section v-if="item.icon" avatar>
               <q-icon :name="item.icon" />
             </q-item-section>
@@ -13,7 +13,7 @@
           </q-item>
         </q-expansion-item>
 
-        <q-item v-else :key="index" v-ripple clickable :exact-active-class="activeItemClasses" :to="header.to">
+        <q-item v-else :key="index" v-ripple clickable :active-class="activeItemClasses" :exact-active-class="activeItemClasses" :to="header.to">
           <q-item-section v-if="header.icon" avatar>
             <q-icon :name="header.icon" />
           </q-item-section>
@@ -58,6 +58,10 @@ export default {
   computed: {
     activeItemClasses () {
       return 'bg-primary text-primary-contrast'
+    },
+
+    activeSecondaryItemClasses () {
+      return 'bg-secondary-contrast text-primary'
     },
 
     model: {

--- a/ui/src/components/app-menu/QasAppMenu.vue
+++ b/ui/src/components/app-menu/QasAppMenu.vue
@@ -102,7 +102,7 @@ export default {
   }
 
   .q-expansion-item__toggle-icon {
-    color: var(--q-color-primary);
+    color: $primary;
     opacity: 20%;
   }
 }

--- a/ui/src/components/app-menu/QasAppMenu.vue
+++ b/ui/src/components/app-menu/QasAppMenu.vue
@@ -3,7 +3,7 @@
     <q-list class="text-primary" padding>
       <div v-for="(header, index) in items" :key="index">
         <q-expansion-item v-if="hasChildren(header)" :active-class="activeSecondaryItemClasses" expand-icon="o_keyboard_arrow_down" expand-separator :default-opened="shouldExpand(header)" :icon="header.icon" :label="header.label" :to="header.to">
-          <q-item v-for="(item, itemIndex) in header.children" :key="itemIndex" :active-class="activeItemClasses"	v-ripple clickable :to="item.to">
+          <q-item v-for="(item, itemIndex) in header.children" :key="itemIndex" :active-class="activeItemClasses" v-ripple clickable :to="item.to">
             <q-item-section v-if="item.icon" avatar>
               <q-icon :name="item.icon" />
             </q-item-section>
@@ -100,7 +100,7 @@ export default {
     color: white !important;
     opacity: 100%;
   }
-  
+
   .q-expansion-item__toggle-icon {
     color: var(--q-color-primary);
     opacity: 20%;


### PR DESCRIPTION
Algumas mudanças no comportamento do qasAppMenu

- Novas cores para Links "pai" (aqueles que contem children e `q-expansion-item`)
- Agora o `q-expansion-item` recebe um `:to` para funcionar como link tambem
- Filhos recebem o `active-class` alem do exact para melhorar o feedback para o usuário
- Inicio do uso do `bg-secondary-contrast`

