### PR TITLE
removing qas-box from maps / refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### 2.7.3 - 2021-08-20
+### Unreleased
 
 ### Changed
 - Changed implementation of `$_createMarkers` on `map-markers.js` mixin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### 2.7.3 - 2021-08-20
+
+### Changed
+- Changed implementation of `$_createMarkers` on `map-markers.js` mixin
+
 ### 2.7.2 - 2021-08-06
 
 ### Fixed

--- a/ui/src/components/map/QasMap.vue
+++ b/ui/src/components/map/QasMap.vue
@@ -1,5 +1,5 @@
 <template>
-  <qas-box class="qas-map">
+  <div class="qas-map">
     <!-- TODO descomentar quando implementar o input de pesquisa -->
     <!-- <div v-if="hasSearch" class="items-center no-wrap row">
       <gmap-autocomplete class="q-field__native q-placeholder" placeholder="Pesquisar..." />
@@ -13,7 +13,7 @@
         </gmap-info-window>
       </gmap-marker>
     </gmap-map>
-  </qas-box>
+  </div>
 </template>
 
 <script>

--- a/ui/src/mixins/map-markers.js
+++ b/ui/src/mixins/map-markers.js
@@ -1,9 +1,9 @@
 export default {
   methods: {
     $_createMarkers (referencePoints) {
+      const referencePointsList = []
       
       for (const index in referencePoints) {
-        const referencePointsList = []
         const { latitude, longitude, city, name } = referencePoints[index]
 
         referencePointsList.push({

--- a/ui/src/mixins/map-markers.js
+++ b/ui/src/mixins/map-markers.js
@@ -1,17 +1,16 @@
 export default {
   methods: {
     $_createMarkers (referencePoints) {
-      const _referencePoints = []
+      
+      for (const index in referencePoints) {
+        const { latitude, longitude, city, name } = referencePoints[index]
 
-      for (const referencePoint in referencePoints) {
         _referencePoints.push({
-          position: { lat: +referencePoints[referencePoint].latitude, lng: +referencePoints[referencePoint].longitude },
-          title: referencePoints[referencePoint].name,
-          description: referencePoints[referencePoint].city,
-          draggable: referencePoint < 1 && this.$_isEditMode,
-          icon: referencePoint > 0
-            ? require('images/marker.png')
-            : ''
+          position: { lat: +latitude, lng: +longitude },
+          title: name,
+          description: city,
+          draggable: !index && this.$_isEditMode,
+          icon: index ? require('images/marker.png') : ''
         })
       }
 

--- a/ui/src/mixins/map-markers.js
+++ b/ui/src/mixins/map-markers.js
@@ -3,9 +3,10 @@ export default {
     $_createMarkers (referencePoints) {
       
       for (const index in referencePoints) {
+        const referencePointsList = []
         const { latitude, longitude, city, name } = referencePoints[index]
 
-        _referencePoints.push({
+        referencePointsList.push({
           position: { lat: +latitude, lng: +longitude },
           title: name,
           description: city,
@@ -14,7 +15,7 @@ export default {
         })
       }
 
-      return _referencePoints
+      return referencePointsList
     },
 
     $_position (lat, lng) {

--- a/ui/src/mixins/map-markers.js
+++ b/ui/src/mixins/map-markers.js
@@ -2,9 +2,9 @@ export default {
   methods: {
     $_createMarkers (referencePoints) {
       const referencePointsList = []
-      
-      for (const index in referencePoints) {
-        const { latitude, longitude, city, name } = referencePoints[index]
+
+      referencePoints.forEach((referencePoint, index) => {
+        const { latitude, longitude, city, name } = referencePoint
 
         referencePointsList.push({
           position: { lat: +latitude, lng: +longitude },
@@ -13,8 +13,8 @@ export default {
           draggable: !index && this.$_isEditMode,
           icon: index ? require('images/marker.png') : ''
         })
-      }
-
+      })
+        
       return referencePointsList
     },
 

--- a/ui/src/mixins/map-markers.js
+++ b/ui/src/mixins/map-markers.js
@@ -1,19 +1,21 @@
 export default {
   methods: {
-    $_createMarkers (values) {
-      const markers = []
+    $_createMarkers (referencePoints) {
+      const _referencePoints = []
 
-      values.forEach(value => {
-        markers.push({
-          position: this.$_position(value.latitude, value.longitude),
-          title: value.title,
-          description: value.description,
-          draggable: value.draggable,
-          icon: value.icon
+      for (const referencePoint in referencePoints) {
+        _referencePoints.push({
+          position: { lat: +referencePoints[referencePoint].latitude, lng: +referencePoints[referencePoint].longitude },
+          title: referencePoints[referencePoint].name,
+          description: referencePoints[referencePoint].city,
+          draggable: referencePoint < 1 && this.$_isEditMode,
+          icon: referencePoint > 0
+            ? require('images/marker.png')
+            : ''
         })
-      })
+      }
 
-      return markers
+      return _referencePoints
     },
 
     $_position (lat, lng) {


### PR DESCRIPTION
O QasMaps estava carregando internamente um QasBox, deixei isso para a página controlar.
O mixin $_createMarkers não estava funcionando corretamente, substituí por uma implementação já com os tratamentos necessários sobre o que é location e o que é ponto de referência. Incluindo tratamento de draggable e de icon.