### PR TITLE
feature/nested-destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Fixed
+### Changed
 - On `nested-fields`, adjusting the destoy method when row does not have uuid
 
 ## 2.9.1 - 2021-09-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- On `nested-fields`, adjusting the destoy method when row does not have uuid
+
 ## 2.9.1 - 2021-09-02
 
 ### Changed

--- a/ui/src/components/nested-fields/QasNestedFields.vue
+++ b/ui/src/components/nested-fields/QasNestedFields.vue
@@ -281,8 +281,10 @@ export default {
       return this.$emit('input', value || this.nested)
     },
 
-    destroy (index, row) {
-      this.nested.splice(index, 1, { [this.destroyKey]: true, ...row })
+   destroy (index, row) {
+      row.uuid
+        ? this.nested.splice(index, 1, { [this.destroyKey]: true, ...row })
+        : this.nested.splice(index, 1)
 
       return this.emitter()
     },


### PR DESCRIPTION
Adjusting destroy method

Atualmente, ao destruir algo no nested, ele adiciona uma prop de "destroy: true", mesmo se não tiver um objeto previamente criado.