### PR TITLE
unsaved-changes for delete actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Mixin changes on `unsaved-changes` for not show the edit dialog when is a delete action
+
 ## 2.9.5 - 2021-09-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-
 - Mixin changes on `unsaved-changes` for not show the edit dialog when is a delete action
 
 ## 2.9.5 - 2021-09-21

--- a/ui/src/components/form-view/QasFormView.vue
+++ b/ui/src/components/form-view/QasFormView.vue
@@ -185,15 +185,15 @@ export default {
   },
 
   methods: {
-    beforeRouteLeave (to, from, next) {
+    beforeRouteLeave (to, from, next, fromDelete) {
       if (!this.showDialogOnUnsavedChanges) {
         return null
       }
 
-      if (isEqual(this.value, this.cachedResult)) {
+      if (fromDelete || isEqual(this.value, this.cachedResult)) {
         return next()
       }
-
+      
       this.handleDialog(next)
     },
 

--- a/ui/src/mixins/unsaved-changes.js
+++ b/ui/src/mixins/unsaved-changes.js
@@ -17,7 +17,7 @@ export default {
   },
 
   methods: {
-    $_deleteSuccess (param) {
+    $_deleteSuccess () {
       this.$_fromDelete = true
     }
   }

--- a/ui/src/mixins/unsaved-changes.js
+++ b/ui/src/mixins/unsaved-changes.js
@@ -1,4 +1,10 @@
 export default {
+  data () {
+    return {
+      $_fromDelete: false
+    }
+  },
+
   beforeRouteLeave (to, from, next) {
     if (!this.$refs.formView) {
       throw new Error(
@@ -7,6 +13,12 @@ export default {
       )
     }
 
-    this.$refs.formView.beforeRouteLeave(to, from, next)
+    this.$refs.formView.beforeRouteLeave(to, from, next, this.$_fromDelete)
+  },
+
+  methods: {
+    $_deleteSuccess (param) {
+      this.$_fromDelete = true
+    }
   }
 }


### PR DESCRIPTION
## Problema:
Ao deletar um "objeto" dentro de uma tela de edit, um dos comportamentos mais comuns no deleteSuccess pode da mudança de rota, com o `router.push` por exemplo, se em algum momento, o values ficar diferente do que estava inicialmente na tela, ele faz a função de deletar e logo após isso (na mudança de rota do deleteSuccess) ele abre o modal do edit, travando a mudança da rota.

Nesse momento, ao clicar em "Continuar editando" o sistema quebra, afinal de contas, ele deletou o item que ele esta tentando continuar editando

## Solução:
Em conversa com o @DouglasCalora, foi criado dentro do mixin do `unsaved-changes` um metodo para avisar quando será acionado um method de delete para passar por cima dessas mudanças no edit

```
deleteSuccess () {
      this.$_deleteSuccess()
      this.$router.push({ name: 'RealEstateDevelopmentsTypologiesList' })
    },
```

## Changelog:
### [Added]
- Mixin changes on `unsaved-changes` for not show the edit dialog when is a delete action