### PR TITLE
Fix/tabs and input adjusts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Slots `tab-` and `tab-slot` are using `tab.value`.  
+- Document mask in `qas-input` toggleMask. 
+
 ## 2.9.6 - 2021-09-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Slots `tab` and `tab-after` are using `tab.value`.  
-- Document mask in `qas-input` toggleMask. 
 
 ## 2.9.6 - 2021-09-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `QasUploader` new props: (acceptResizeTypes, picaResizeOptions, sizeLimit, useResize).
 
 ### Changed
-- Changed slot name `tab-slot-[tab.label]` to `tab-after[tab.value]`.
+- Changed slot name `tab-slot-[tab.label]` to `tab-after-[tab.value]`.
 - Changed slot `tab-[tab.label]` to `tab-[tab.value]`.
 - Updated `vue` and `vue-template-compiler` to `v2.6.14` for fixing storybook error.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Slots `tab-` and `tab-slot` are using `tab.value`.  
+- Slots `tab` and `tab-after` are using `tab.value`.  
 - Document mask in `qas-input` toggleMask. 
 
 ## 2.9.6 - 2021-09-22

--- a/ui/src/components/input/QasInput.vue
+++ b/ui/src/components/input/QasInput.vue
@@ -55,7 +55,7 @@ export default {
     masks () {
       return {
         'company-document': () => '##.###.###/####-##',
-        document: () => this.toggleMask('###.###.###-###', '##.###.###/####-##'),
+        document: () => this.toggleMask('###.###.###-##', '##.###.###/####-##'),
         'personal-document': () => '###.###.###-##',
         phone: () => this.toggleMask('(##) ####-#####', '(##) #####-####'),
         'postal-code': () => '#####-###'

--- a/ui/src/components/input/QasInput.vue
+++ b/ui/src/components/input/QasInput.vue
@@ -55,7 +55,7 @@ export default {
     masks () {
       return {
         'company-document': () => '##.###.###/####-##',
-        document: () => this.toggleMask('###.###.###-##', '##.###.###/####-##'),
+        document: () => this.toggleMask('###.###.###-###', '##.###.###/####-##'),
         'personal-document': () => '###.###.###-##',
         phone: () => this.toggleMask('(##) ####-#####', '(##) #####-####'),
         'postal-code': () => '#####-###'

--- a/ui/src/components/tabs-generator/QasTabsGenerator.vue
+++ b/ui/src/components/tabs-generator/QasTabsGenerator.vue
@@ -1,10 +1,10 @@
 <template>
   <q-tabs v-model="currentTab" v-bind="$attrs" :active-color="activeColor" :class="bgColorClass" :indicator-color="indicatorColor" outside-arrows v-on="$listeners">
     <!-- TODO: O name slot da aba não pode ser o label, pois pode conter espaço. -->
-    <slot v-for="(tab, key) in formattedTabs" :item="tab" :name="`tab-${tab.label}`">
+    <slot v-for="(tab, key) in formattedTabs" :item="tab" :name="`tab-${tab.value}`">
       <q-tab :key="key" v-bind="tab" :class="colorClass" :label="tab.label" :name="key">
         <!-- TODO: Renomear para tab-after- -->
-        <slot :item="tab" :name="`tab-slot-${tab.label}`">
+        <slot :item="tab" :name="`tab-slot-${tab.value}`">
           <q-badge v-if="counters[key]" color="negative" floating :label="counters[key]" />
         </slot>
       </q-tab>

--- a/ui/src/components/tabs-generator/QasTabsGenerator.vue
+++ b/ui/src/components/tabs-generator/QasTabsGenerator.vue
@@ -1,10 +1,8 @@
 <template>
   <q-tabs v-model="currentTab" v-bind="$attrs" :active-color="activeColor" :class="bgColorClass" :indicator-color="indicatorColor" outside-arrows v-on="$listeners">
-    <!-- TODO: O name slot da aba não pode ser o label, pois pode conter espaço. -->
     <slot v-for="(tab, key) in formattedTabs" :item="tab" :name="`tab-${tab.value}`">
       <q-tab :key="key" v-bind="tab" :class="colorClass" :label="tab.label" :name="key">
-        <!-- TODO: Renomear para tab-after- -->
-        <slot :item="tab" :name="`tab-slot-${tab.value}`">
+        <slot :item="tab" :name="`tab-after-${tab.value}`">
           <q-badge v-if="counters[key]" color="negative" floating :label="counters[key]" />
         </slot>
       </q-tab>


### PR DESCRIPTION
Correção em `qas-tabs` -  Alteração do nome do slot `tab-slot` para `tab-after` e nome dos slots usando `tab.value`.
Correção em `qas-input` - Correção na mask de CPF.  