### PR TITLE
feature/card-carousel-icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unchanged
+
+### Changed
+- Changed q-carousel dotnav icons on qas-card to highlight visible image
+
 ## 2.9.6 - 2021-09-22
 
 ### Added

--- a/ui/src/components/card/QasCard.vue
+++ b/ui/src/components/card/QasCard.vue
@@ -4,6 +4,10 @@
       <div v-if="useHeader" class="overflow-hidden relative-position w-full">
         <slot name="header">
           <q-carousel v-model="slideImage" animated class="cursor-pointer" height="205px" infinite :navigation="hasImages" navigation-icon="o_fiber_manual_record" swipeable>
+            <template v-slot:navigation-icon="{ active, btnProps, onClick }">
+              <q-btn v-if="active" size="sm" icon="radio_button_checked" color="white" flat round dense @click="onClick"></q-btn>
+              <q-btn v-else size="sm" :icon="btnProps.icon" color="white" flat round dense @click="onClick"></q-btn>
+            </template>
             <q-carousel-slide v-for="(item, index) in imagesList" :key="index" class="bg-no-repeat" :class="bgImagePositionClasses" :img-src="item" :name="index" />
           </q-carousel>
           <div class="absolute-top flex items-center q-pa-md">


### PR DESCRIPTION
## Problema:
Ao visualizar o comportamento do card, fica evidente que a apresentação no dotnav da imagem que esta sendo mostrada no q-carousel não esta clara
![image](https://user-images.githubusercontent.com/444696/135634064-dfaca96b-9fdb-414f-9cc5-5d99ed85d730.png)

## Solução:
Aparentemente o erro se dá por conta do pacote de icones que estamos utilizando... o padrão seria utilizar `material-icons filled`, porem por escolha do time de design, estamos usando o `material-icons outlined`... por conta disso, alinhei com o Moraes para que, o icon selecionado seja o `radio_button_checked`, apresentando dessa maneira:
![image](https://user-images.githubusercontent.com/444696/135635157-f5716d19-a3a5-475b-b1ff-0e5cba71ab96.png)

## Changelog:
### Changed
- Changed q-carousel dotnav icons on qas-card to highlight visible image