### PR TITLE
hotfix/map-markers-validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unchanged
 
 ### Fixed
-- Map-makers draggable funcition only on 'create' and 'replace' pages
+- On $_createMarkers mixin, the marker is now draggable on 'create' and 'replace' pages
 
 ## 2.11.0 - 2021-10-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## Unchanged
+
+### Fixed
+- Map-makers draggable funcition only on 'create' and 'replace' pages
+
 ## 2.11.0 - 2021-10-19
 
 ### Added

--- a/ui/src/mixins/map-markers.js
+++ b/ui/src/mixins/map-markers.js
@@ -10,7 +10,7 @@ export default {
           position: { lat: +latitude, lng: +longitude },
           title: name,
           description: city,
-          draggable: !index && this.$_isEditMode,
+          draggable: !index && !!this.$_mode,
           icon
         })
       })

--- a/ui/src/mixins/map-markers.js
+++ b/ui/src/mixins/map-markers.js
@@ -5,12 +5,13 @@ export default {
 
       referencePoints.forEach((referencePoint, index) => {
         const { latitude, longitude, city, name, icon } = referencePoint
-
+        const isCreateOrEdit = !!this.$_mode
+        
         referencePointsList.push({
           position: { lat: +latitude, lng: +longitude },
           title: name,
           description: city,
-          draggable: !index && !!this.$_mode,
+          draggable: !index && isCreateOrEdit,
           icon
         })
       })


### PR DESCRIPTION
## Problema:
Não esta sendo possível fazer o drag do marcador em um mapa nas telas de create (/new)

## Solução:
A troca do `$_isEditMode` para `$_mode` no mixin de `$_createMarkers`, ou seja, ele ainda faz a tratativa de draggable sempre no primeiro elemento, porem agora em telas de crate também

Uma tela de view o retorno será `undefined`

## Changelog:
- changing draggable validation to be true on create