### PR TITLE
reusing prop useIconRedirect to hide actions when not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added an extra verification at the helper `filter` to prevent calling mask methods without a value.
-- Added a verification on `QasListItems` side q-item-section to reuse prop `useIconRedirect` to show actions button or not.
+- Added a prop `useSectionActions` on `QasListItems` to show actions button or not.
 
 ## 2.12.2 - 2021-12-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added an extra verification at the helper `filter` to prevent calling mask methods without a value.
+- Added a verification on `QasListItems` side q-item-section to reuse prop `useIconRedirect` to show actions button or not.
 
 ## 2.12.2 - 2021-12-09
 

--- a/ui/src/components/list-items/QasListItems.vue
+++ b/ui/src/components/list-items/QasListItems.vue
@@ -7,7 +7,7 @@
             <slot :index="index" :item="item" name="item-section-left" />
           </q-item-section>
 
-          <q-item-section side>
+          <q-item-section v-if="useIconRedirect" side>
             <slot :index="index" :item="item" name="item-section-side">
               <qas-btn flat round :to="getRedirectPayload(item)">
                 <q-icon v-bind="iconProps" />

--- a/ui/src/components/list-items/QasListItems.vue
+++ b/ui/src/components/list-items/QasListItems.vue
@@ -7,7 +7,7 @@
             <slot :index="index" :item="item" name="item-section-left" />
           </q-item-section>
 
-          <q-item-section v-if="useIconRedirect" side>
+          <q-item-section v-if="!useSectionActions" side>
             <slot :index="index" :item="item" name="item-section-side">
               <qas-btn flat round :to="getRedirectPayload(item)">
                 <q-icon v-bind="iconProps" />
@@ -51,6 +51,11 @@ export default {
 
     useIconRedirect: {
       type: Boolean
+    },
+
+    useSectionActions: {
+      type: Boolean,
+      default: true
     }
   },
 

--- a/ui/src/components/list-items/QasListItems.vue
+++ b/ui/src/components/list-items/QasListItems.vue
@@ -7,7 +7,7 @@
             <slot :index="index" :item="item" name="item-section-left" />
           </q-item-section>
 
-          <q-item-section v-if="!useSectionActions" side>
+          <q-item-section v-if="useSectionActions" side>
             <slot :index="index" :item="item" name="item-section-side">
               <qas-btn flat round :to="getRedirectPayload(item)">
                 <q-icon v-bind="iconProps" />


### PR DESCRIPTION
Motivação:
- Dentro de alguns casos, não iremos precisar de uma ação, apenas de uma listagem.
- Para o Vendas no Modular por exemplo, tenho uma listagem sem ações.
![image](https://user-images.githubusercontent.com/22224160/145826518-fd5afd60-c902-4f21-9c21-ab18ed2afed8.png)

Solução:
- Reutilizar a prop `useIconRedirect` para verificar a necessidade de colocar o botão na tela ou não.
