### PR TITLE
Feature/fix uploader remove file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Removed
+### Fixed
 - Removed `this.file = []` in method `__addFiles` in `QasCustomUploader`.
 
 ## 2.14.0 - 2021-02-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Removed
+- Removed `this.file = []` in method `__addFiles` in `QasCustomUploader`.
+
 ## 2.14.0 - 2021-02-11
 
 ### Added

--- a/ui/src/components/uploader/QasCustomUploader.vue
+++ b/ui/src/components/uploader/QasCustomUploader.vue
@@ -79,7 +79,7 @@ export default {
     // overrides "__addFiles" from quasar
     async __addFiles (event, files = []) {
       const filesToUpload = event?.target?.files || files
-      //this.files = []
+      // this.files = [] - Removed for file removal deal
       this.isAddingFiles = true
 
       const filesPromise = []

--- a/ui/src/components/uploader/QasCustomUploader.vue
+++ b/ui/src/components/uploader/QasCustomUploader.vue
@@ -79,7 +79,7 @@ export default {
     // overrides "__addFiles" from quasar
     async __addFiles (event, files = []) {
       const filesToUpload = event?.target?.files || files
-      this.files = []
+      //this.files = []
       this.isAddingFiles = true
 
       const filesPromise = []

--- a/ui/src/components/uploader/QasCustomUploader.vue
+++ b/ui/src/components/uploader/QasCustomUploader.vue
@@ -79,7 +79,6 @@ export default {
     // overrides "__addFiles" from quasar
     async __addFiles (event, files = []) {
       const filesToUpload = event?.target?.files || files
-      // this.files = [] - Removed for file removal deal
       this.isAddingFiles = true
 
       const filesPromise = []


### PR DESCRIPTION
# Descrição
Em um qas-uploader multiple, fazendo um upload de um arquivo e novamente um upload de outro arquivo, o componente perde a referência do index do primeiro arquivo, (isso acontece sempre que há um upload de um arquivo novo, ele irá perder a referência dos primeiros arquivos). Dessa forma não conseguimos deletar o primeiro arquivo do upload. Descobrimos que ao remover `this.file = []` em uma tratativa de adicionar um arquivo em `__addFiles` no componente `QasCustomUploader` o bug era corrigido. Fizemos alguns testes para saber se essa alteração não prejudica a compactação do arquivo.  

## Issues

## Tipo de alteração
- [ ] Added (Novas features)
- [ ] Changed (Alterações que podem ou não haver breaking changes)
- [ ] Removed (Remoção de alguma funcionalidade, código etc)
- [x] Fixed (Alterações para corrigir bugs etc)

## Testes
- [x] Testes em dev
- [ ] Testes automatizados

## Documentação
- [ ] Documentação no storybook foi atualizada e testada?
- [ ] Caso tenha componente novo, foi criado a nova documentação?

## Checklist
- [x] Meu código segue todos os padrões de código incluindo eslint
- [x] Eu fiz um meu próprio code review antes de abrir este pull request
- [x] Eu atualizei o changelog seguindo o padrão keep changelog
- [x] Antes da alteração eu discuti sobre o pull request com o time de front end e time de design
- [x] Minhas alterações não geram erros ou warnings no console
