### PR TITLE
Added new prop paramKey to QasListItems.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new prop `paramKey` to `QasListItems`.
 
 ### Changed
-- baseURL in `QasResizer`. 
+- `QasResizer` changed baseURL 'https://d17ouzaofz81f3.cloudfront.net/' to 'https://image-resize.nave.dev/'
 
 ## 2.14.1 - 2022-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## Unreleased
+
+### Added
+- Added new prop `paramKey` to `QasListItems`.
+
 ## 2.14.1 - 2022-03-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added new prop `paramKey` to `QasListItems`.
 
+### Changed
+- baseURL in `QasResizer`. 
+
 ## 2.14.1 - 2022-03-21
 
 ### Fixed

--- a/ui/dev/src/pages/TestListItems.vue
+++ b/ui/dev/src/pages/TestListItems.vue
@@ -22,6 +22,15 @@
         <pre>{{ item }}</pre>
       </template>
     </qas-list-items>
+
+    <qas-label label="Teste redirect" />
+    <qas-list-items :list="results" redirect-key="uuid" :to="{ name: 'path' }">
+      <template #item-section-left="{ item }">
+        <div class="items-center row">
+          <span class="q-mr-sm text-black text-weight-bold">{{ item.name }}</span>
+        </div>
+      </template>
+    </qas-list-items>
   </q-page>
 </template>
 

--- a/ui/dev/src/pages/TestResizer.vue
+++ b/ui/dev/src/pages/TestResizer.vue
@@ -1,0 +1,5 @@
+<template>
+  <q-page class="container flex">
+    <qas-resizer size="100x100" source="bild-vitta.png" />
+  </q-page>
+</template>

--- a/ui/src/components/list-items/QasListItems.stories.js
+++ b/ui/src/components/list-items/QasListItems.stories.js
@@ -38,7 +38,12 @@ export default {
 
     redirectKey: {
       control: null,
-      description: 'Key to define the id redirect.'
+      description: 'Item key that will be the value of the redirect.'
+    },
+
+    paramKey: {
+      control: null,
+      description: 'Redirect parameter key.'
     },
 
     useIconRedirect: {

--- a/ui/src/components/list-items/QasListItems.vue
+++ b/ui/src/components/list-items/QasListItems.vue
@@ -44,6 +44,11 @@ export default {
       type: String
     },
 
+    paramKey: {
+      default: 'id',
+      type: String
+    },
+
     to: {
       default: () => ({}),
       type: Object
@@ -61,7 +66,7 @@ export default {
 
     getRedirectPayload (item) {
       return {
-        params: { [this.redirectKey]: item[this.redirectKey] },
+        params: { [this.paramKey]: item[this.redirectKey] },
         ...this.to
       }
     }

--- a/ui/src/components/resizer/QasResizer.vue
+++ b/ui/src/components/resizer/QasResizer.vue
@@ -9,7 +9,7 @@
 <script>
 import { greatestCommonDivisor } from '../../helpers'
 
-const baseURL = 'https://d17ouzaofz81f3.cloudfront.net/'
+const baseURL = 'https://image-resize.nave.dev/'
 
 export default {
   name: 'QasResizer',


### PR DESCRIPTION
# Descrição
Foi encontrado uma limitação do componente quando precisávamos com que o `redirect-key` fosse algum outro valor q fosse diferente de `id`, causava q a rota que iria ser redirecionado, esperava  o valor dessa chave em seu `params`, fazendo com que o vue-router e o single-view se perca. Criamos uma nova prop para que o valor e a chave do params não seja unificado. 

## Issues

## Tipo de alteração
- [x] Added (Novas features)
- [ ] Changed (Alterações que podem ou não haver breaking changes)
- [ ] Removed (Remoção de alguma funcionalidade, código etc)
- [ ] Fixed (Alterações para corrigir bugs etc)

## Testes
- [x] Testes em dev
- [ ] Testes automatizados

## Documentação
- [x] Documentação no storybook foi atualizada e testada?
- [ ] Caso tenha componente novo, foi criado a nova documentação?

## Checklist
- [x] Meu código segue todos os padrões de código incluindo eslint
- [x] Eu fiz um meu próprio code review antes de abrir este pull request
- [x] Eu atualizei o changelog seguindo o padrão keep changelog
- [x] Antes da alteração eu discuti sobre o pull request com o time de front end e time de design
- [x] Minhas alterações não geram erros ou warnings no console
