### PR TITLE
Added new prop forceRefetch to QasFilters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added new prop `forceRefetch` to `QasFilters`.
 
+### Removed
+- Removed action `@before-show="fetchFilters"` from `q-menu` inside `QasFilters`. Apparently this action was never necessary for the component to work properly.
+
 ## 2.17.1 - 2022-04-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Added new prop `forceRefetch` to `QasFilters`.
+
 ## 2.17.1 - 2022-04-11
 
 ### Fixed

--- a/ui/src/components/filters/QasFilters.stories.js
+++ b/ui/src/components/filters/QasFilters.stories.js
@@ -52,6 +52,10 @@ export default {
       description: 'Ignore entity and specify another endpoint.'
     },
 
+    forceRefetch: {
+      description: 'Force refetching of filters data.'
+    },
+
     // Events
     'fetch-error': {
       description: 'Fires when occur an error fetching value.',

--- a/ui/src/components/filters/QasFilters.vue
+++ b/ui/src/components/filters/QasFilters.vue
@@ -16,7 +16,7 @@
 
       <slot v-if="showFilterButton" :filter="filter" name="filter-button">
         <q-btn v-if="!noFilterButton" :color="filterButtonColor" flat icon="o_filter_list" :label="filterButtonLabel">
-          <q-menu @before-show="fetchFilters">
+          <q-menu>
             <div v-if="isFetching" class="q-pa-xl text-center">
               <q-spinner color="grey" size="2em" />
             </div>
@@ -61,6 +61,7 @@ export default {
   },
 
   mixins: [contextMixin],
+
   props: {
     badges: {
       default: true,
@@ -95,6 +96,10 @@ export default {
     url: {
       default: '',
       type: String
+    },
+
+    forceRefetch: {
+      type: Boolean
     }
   },
 
@@ -220,7 +225,7 @@ export default {
     },
 
     async fetchFilters () {
-      if (this.hasFields || this.noFilterButton) {
+      if (!this.forceRefetch && (this.hasFields || this.noFilterButton)) {
         return null
       }
 


### PR DESCRIPTION
# Descrição
Inserção de uma nova propriedade `forceRefetch` no componente `QasFilters`. Essa propriedade força a atualização dos filtros sempre ao mudar de página. 

Removida a ação `@before-show="fetchFilters"` da tag `q-menu` no componente `QasFilters`. Aparentemente esta ação nunca foi necessária para que o componente funcionasse corretamente.

## Issues

## Tipo de alteração
- [x] Added (Novas features)
- [ ] Changed (Alterações que podem ou não haver breaking changes)
- [x] Removed (Remoção de alguma funcionalidade, código etc)
- [ ] Fixed (Alterações para corrigir bugs etc)

## Testes
- [x] Testes em dev
- [ ] Testes automatizados

## Documentação
- [x] Documentação no storybook foi atualizada e testada?
- [ ] Caso tenha componente novo, foi criado a nova documentação?

## Checklist
- [x] Meu código segue todos os padrões de código incluindo eslint
- [x] Eu fiz um meu próprio code review antes de abrir este pull request
- [x] Eu atualizei o changelog seguindo o padrão keep changelog
- [x] Antes da alteração eu discuti sobre o pull request com o time de front end e time de design
- [x] Minhas alterações não geram erros ou warnings no console
