### PR TITLE
Feature/next/view components hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## [3.0.0-beta.14]
+### Adicionado
+- `QasFormView`: adicionado propriedade `beforeSubmit` para controlar o submit, ex: mostrar um modal de confirmação antes de fazer o submit do formulário.
+
+### Modificado
+- `QasFormView`: adicionado um handler `submitHandler` para o controle do submit junto a propriedade `beforeSubmit`.
+
 ## [3.0.0-beta.13] - 02-06-2022
 ### Adicionado
 - Adicionado helper `camelizeFieldsName` para formatar os `names` dos fields em camelCase.
@@ -126,6 +133,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ### Corrigido
 - Corrigido `QasBtn`, quando usa a prop `hideLabelOnSmallScreen` e utiliza o slot default, quando a tela está em tamanho pequeno, o botão remove o slot default, o problema disto é que se usar com um `QMenu` dentro do botão, o `QMenu` não é chamado pois não existe mais slot default.
 
+[3.0.0-beta.14]: https://github.com/bildvitta/asteroid/compare/v3.0.0-beta.13...v3.0.0-beta.14?expand=1
 [3.0.0-beta.13]: https://github.com/bildvitta/asteroid/compare/v3.0.0-beta.12...v3.0.0-beta.13?expand=1
 [3.0.0-beta.12]: https://github.com/bildvitta/asteroid/compare/v3.0.0-beta.11...v3.0.0-beta.12?expand=1
 [3.0.0-beta.11]: https://github.com/bildvitta/asteroid/compare/v3.0.0-beta.10...v3.0.0-beta.11?expand=1

--- a/docs/src/examples/QasFormView/BeforeSubmit.vue
+++ b/docs/src/examples/QasFormView/BeforeSubmit.vue
@@ -1,0 +1,99 @@
+<template>
+  <!-- Descartar essa div -->
+  <div class="container spaced">
+    <qas-form-view v-model="values" v-model:errors="errors" v-model:fields="fields" :before-submit="onBeforeSubmit" :cancel-route="cancelRoute" :custom-id="customId" :entity="entity" mode="replace" :use-boundary="false" @submit-success="onSubmitSuccess">
+      <template #header>
+        <qas-page-header :breadcrumbs="breadcrumbs" title="Editar usuário">
+          <qas-actions-menu :delete-props="{ entity: 'users', customId: 'custom-id-test' }" />
+        </qas-page-header>
+      </template>
+
+      <template #filter>
+        <div class="bg-positive q-my-lg q-pa-lg">
+          Template do filter.
+        </div>
+      </template>
+
+      <template #default>
+        <div>
+          <qas-form-generator v-model="values" :errors="errors" :fields="fields" />
+        </div>
+      </template>
+    </qas-form-view>
+
+    v-model: <qas-debugger :inspect="[values]" />
+
+    <qas-box v-if="isFormSubmitted">Item foi editado com sucesso!</qas-box>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'UsersList',
+
+  data () {
+    return {
+      fields: {},
+      errors: {},
+      values: {},
+      metadata: {},
+      isFormSubmitted: false
+    }
+  },
+
+  computed: {
+    entity () {
+      return 'users'
+    },
+
+    // USAR SOMENTE SE NECESSÁRIO, AQUI PEGAMOS O ID DO USUÁRIO NO NOSSO MOCK DE DADOS
+    customId () {
+      return '31362c39-2cb5-4fe2-982a-c270f88d2462'
+    },
+
+    // ESTAMOS USANDO O CANCEL ROUTE NESTE CASO SOMENTE POR CAUSA DA DOCUMENTAÇÃO
+    // USE SOMENTE SE NECESSÁRIO
+    cancelRoute () {
+      return '/'
+    },
+
+    breadcrumbs () {
+      return [
+        {
+          label: 'Início',
+          route: { path: '/' }
+        },
+        {
+          label: 'Algum caminho',
+          route: { path: '/' }
+        },
+        {
+          label: 'Users'
+        }
+      ]
+    }
+  },
+
+  methods: {
+    onSubmitSuccess () {
+      this.isFormSubmitted = true
+    },
+
+    onBeforeSubmit ({ resolve }) {
+      this.$qas.dialog({
+        card: {
+          title: 'Atenção',
+          description: 'Você tem certeza que deseja continuar com esta ação?'
+        },
+        cancel: {
+          label: 'Não'
+        },
+        ok: {
+          label: 'Sim',
+          onClick: resolve
+        }
+      })
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QasFormView/Edit.vue
+++ b/docs/src/examples/QasFormView/Edit.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- Descartar essa div -->
   <div class="container spaced">
-    <qas-form-view v-model="values" v-model:errors="errors" v-model:fields="fields" :cancel-route="cancelRoute" :custom-id="customId" :entity="entity" mode="replace" :use-boundary="false" @submit-success="onSubmitSuccess">
+    <qas-form-view v-model="values" v-model:errors="errors" v-model:fields="fields" :before-submit="onBeforeSubmit" :cancel-route="cancelRoute" :custom-id="customId" :entity="entity" mode="replace" :use-boundary="false" @submit-success="onSubmitSuccess">
       <template #header>
         <qas-page-header :breadcrumbs="breadcrumbs" title="Editar usuário">
           <qas-actions-menu :delete-props="{ entity: 'users', customId: 'custom-id-test' }" />
@@ -77,6 +77,16 @@ export default {
   methods: {
     onSubmitSuccess () {
       this.isFormSubmitted = true
+    },
+
+    onBeforeSubmit ({ payload, resolve }) {
+      console.log(payload)
+
+      resolve({
+        errors: {
+          name: 'Precisa ser maior que 3'
+        }
+      })
     }
   }
 }

--- a/docs/src/examples/QasFormView/Edit.vue
+++ b/docs/src/examples/QasFormView/Edit.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- Descartar essa div -->
   <div class="container spaced">
-    <qas-form-view v-model="values" v-model:errors="errors" v-model:fields="fields" :before-submit="onBeforeSubmit" :cancel-route="cancelRoute" :custom-id="customId" :entity="entity" mode="replace" :use-boundary="false" @submit-success="onSubmitSuccess">
+    <qas-form-view v-model="values" v-model:errors="errors" v-model:fields="fields" :cancel-route="cancelRoute" :custom-id="customId" :entity="entity" mode="replace" :use-boundary="false" @submit-success="onSubmitSuccess">
       <template #header>
         <qas-page-header :breadcrumbs="breadcrumbs" title="Editar usuário">
           <qas-actions-menu :delete-props="{ entity: 'users', customId: 'custom-id-test' }" />
@@ -77,16 +77,6 @@ export default {
   methods: {
     onSubmitSuccess () {
       this.isFormSubmitted = true
-    },
-
-    onBeforeSubmit ({ payload, resolve }) {
-      console.log(payload)
-
-      resolve({
-        errors: {
-          name: 'Precisa ser maior que 3'
-        }
-      })
     }
   }
 }

--- a/docs/src/pages/components/form-view.md
+++ b/docs/src/pages/components/form-view.md
@@ -19,7 +19,7 @@ Para fazer esses exemplos na documentação, estamos utilizando o `VuexOffline`,
 :::
 
 :::warning
-Estamos utilizando nos exemplos um `custom-id` pois é necessario para conseguir utilizar os mocks de dados, **não** significa que você precisa sempre utiliza-lo para lidar com o id, na verdade na maioria das vezes você não vai precisar do `custom-id`, ele é para quando precisa de um caso de uso mais específico.
+Estamos utilizando nos exemplos um `custom-id` pois é necessário para conseguir utilizar os mocks de dados, **não** significa que você precisa sempre utiliza-lo para lidar com o id, na verdade na maioria das vezes você não vai precisar do `custom-id`, ele é para quando precisa de um caso de uso mais específico.
 :::
 
 :::tip
@@ -34,3 +34,22 @@ Aqui está alguns exemplos de como normalmente utilizamos este componente, lembr
 <doc-example file="QasFormView/Create" title="Modo de criação (create)" />
 
 <doc-example file="QasFormView/Edit" title="Modo de edição (replace)" />
+
+:::tip
+O callback do `beforeSubmit` recebe 2 parâmetros, `:before-submit="onBeforeSubmit({ payload, resolve })"`
+
+##### payload: `Object` -> { id, payload, url }
+Retorna `id`, `payload` e `url` que serão enviados por parâmetros para a action do submit.
+
+##### resolve: `Function` -> resolve({ ...payload })
+Função que executa o método `submit` dentro do `QasFormView`, você pode enviar como parâmetro algum payload para ser enviada para a action de submit, adicionando ou sobrescrevendo os parâmetros atuais.
+Por exemplo, sobrescrever a url enviada para a action:
+
+```js
+resolve({ url: 'minha-url-personalizada' })
+```
+
+Agora ao fazer o submit, o valor da url enviada para a action do submit será `minha-url-personalizada`.
+:::
+
+<doc-example file="QasFormView/BeforeSubmit" title="Controlando submit" />

--- a/ui/src/components/form-view/QasFormView.vue
+++ b/ui/src/components/form-view/QasFormView.vue
@@ -4,7 +4,8 @@
       <slot name="header" />
     </header>
 
-    <q-form ref="form" @submit="submit">
+    <q-form ref="form" @submit="submitHandler">
+      <!-- <q-form ref="form" @submit="submit"> -->
       <slot />
 
       <slot v-if="useActions" name="actions">
@@ -122,6 +123,11 @@ export default {
     useSubmitButton: {
       default: true,
       type: Boolean
+    },
+
+    beforeSubmit: {
+      default: null,
+      type: Function
     }
   },
 
@@ -369,17 +375,38 @@ export default {
       })
     },
 
-    async submit (event) {
+    submitHandler (event) {
       if (this.disable) return null
 
       if (event) {
         event.preventDefault()
       }
 
+      const hasBeforeSubmit = typeof this.beforeSubmit === 'function'
+
+      if (hasBeforeSubmit) {
+        return this.beforeSubmit({
+          payload: { id: this.id, payload: this.modelValue, url: this.url },
+          resolve: payload => this.submit(payload)
+        })
+      }
+
+      this.submit()
+    },
+
+    async submit (externalPayload = {}) {
+      // if (this.disable) return null
+
+      // if (event) {
+      //   event.preventDefault()
+      // }
+
       this.isSubmitting = true
 
       try {
-        const payload = { id: this.id, payload: this.modelValue, url: this.url }
+        const payload = { id: this.id, payload: this.modelValue, url: this.url, ...externalPayload }
+
+        console.log(payload, '>>> payload')
 
         this.$qas.logger.group(
           `QasFormView - submit -> payload do ${this.entity}/${this.mode}`, [payload]

--- a/ui/src/components/form-view/QasFormView.vue
+++ b/ui/src/components/form-view/QasFormView.vue
@@ -5,7 +5,6 @@
     </header>
 
     <q-form ref="form" @submit="submitHandler">
-      <!-- <q-form ref="form" @submit="submit"> -->
       <slot />
 
       <slot v-if="useActions" name="actions">

--- a/ui/src/components/form-view/QasFormView.vue
+++ b/ui/src/components/form-view/QasFormView.vue
@@ -375,9 +375,12 @@ export default {
       })
     },
 
+    /**
+     * Se existe a propriedade com callback "beforeSubmit", então o controle de quando e como chamar o método "submit"
+     * está sendo controlado fora do QasFormView, se não existir a propriedade "beforeSubmit", então o controle do método
+     * submit é feito pelo próprio QasFormView, chamado pelo evento @submit.
+    */
     submitHandler (event) {
-      if (this.disable) return null
-
       if (event) {
         event.preventDefault()
       }
@@ -395,18 +398,12 @@ export default {
     },
 
     async submit (externalPayload = {}) {
-      // if (this.disable) return null
-
-      // if (event) {
-      //   event.preventDefault()
-      // }
+      if (this.disable) return null
 
       this.isSubmitting = true
 
       try {
         const payload = { id: this.id, payload: this.modelValue, url: this.url, ...externalPayload }
-
-        console.log(payload, '>>> payload')
 
         this.$qas.logger.group(
           `QasFormView - submit -> payload do ${this.entity}/${this.mode}`, [payload]

--- a/ui/src/components/form-view/QasFormView.yml
+++ b/ui/src/components/form-view/QasFormView.yml
@@ -4,6 +4,12 @@ meta:
   desc: Componente para C.R.U.D. responsável pela pela criação (Create) e edição (Update).
 
 props:
+  before-submit:
+    desc: Callback para controlar como funciona o comportamento do submit.
+    default: null
+    type: Function
+    examples: ['beforeSubmit({ payload, resolve })']
+
   cancel-button-label:
     desc: Rótulo do botão "cancelar".
     default: Cancelar


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

Adicionado nova propriedade  `beforeSubmit` para controlar o submit. Antes precisava sobrescrever o slot `actions` e controlar a propriedade `disable`, agora da para utilizar o callback do beforeSubmit para isto.

## Versão do asteroid

- [ ] v2 -> a partir da branch `main`.
- [x] v3 -> a partir da branch `next`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
