### PR TITLE
Support/v2.23.0 beta.5 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- `lazyLoadingFilterMixin`: added new event `fetching` when fetching data from API.
+
+### Fixed
+- `lazyLoadingFilterMixin`: watch `lazyLoadingProps` change to reset the filter.
+- `lazyLoadingFilterMixin`: change virtual scroll class name to a unique one.
+
 ## 2.23.0-beta.4 - 2022-06-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `lazyLoadingFilterMixin`: added new event `fetching` when fetching data from API.
 
+### Changed
+- `QasSelect`: changed the default text for `loading` slot.
+
 ### Fixed
 - `lazyLoadingFilterMixin`: watch `lazyLoadingProps` change to reset the filter.
 - `lazyLoadingFilterMixin`: change virtual scroll class name to a unique one.
+- `QasSelectList`: return with the `q-list` wrapper to all `q-item`s.
 
 ## 2.23.0-beta.4 - 2022-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `lazyLoadingFilterMixin`: watch `lazyLoadingProps` change to reset the filter.
 - `lazyLoadingFilterMixin`: change virtual scroll class name to a unique one.
-- `QasSelectList`: return with the `q-list` wrapper to all `q-item`s.
+- `QasSelectList`: return with the `q-list` wrapper to all `q-item`.
 
 ## 2.23.0-beta.4 - 2022-06-13
 

--- a/ui/src/components/search-box/QasSearchBox.stories.js
+++ b/ui/src/components/search-box/QasSearchBox.stories.js
@@ -112,6 +112,10 @@ export default {
       }
     },
 
+    fetching: {
+      description: 'Fires when fetching the options.',
+    },
+
     input: {
       description: 'Fires when the result changes.',
       table: noSummary

--- a/ui/src/components/search-box/QasSearchBox.stories.js
+++ b/ui/src/components/search-box/QasSearchBox.stories.js
@@ -113,7 +113,7 @@ export default {
     },
 
     fetching: {
-      description: 'Fires when fetching the options.',
+      description: 'Fires when fetching the options.'
     },
 
     input: {

--- a/ui/src/components/select-list/QasSelectList.vue
+++ b/ui/src/components/select-list/QasSelectList.vue
@@ -1,21 +1,23 @@
 <template>
   <qas-search-box v-bind="$attrs" class="q-pa-md" :fuse-options="fuseOptions" :list="sortedOptions">
     <template #default="{ results }">
-      <q-item v-for="(item, index) in results" :key="index">
-        <slot name="item" v-bind="self">
-          <slot name="item-section" :result="item">
-            <q-item-section class="items-start text-bold">
-              <div :class="labelClass" @click="redirectRoute(item)">{{ item.label }}</div>
+      <q-list separator>
+        <q-item v-for="(item, index) in results" :key="index">
+          <slot name="item" v-bind="self">
+            <slot name="item-section" :result="item">
+              <q-item-section class="items-start text-bold">
+                <div :class="labelClass" @click="redirectRoute(item)">{{ item.label }}</div>
+              </q-item-section>
+            </slot>
+
+            <q-item-section avatar>
+              <slot name="item-action" v-bind="self">
+                <qas-btn hide-mobile-label v-bind="setButtonProps(item)" size="sm" @click="handleClick(item)" />
+              </slot>
             </q-item-section>
           </slot>
-
-          <q-item-section avatar>
-            <slot name="item-action" v-bind="self">
-              <qas-btn hide-mobile-label v-bind="setButtonProps(item)" size="sm" @click="handleClick(item)" />
-            </slot>
-          </q-item-section>
-        </slot>
-      </q-item>
+        </q-item>
+      </q-list>
     </template>
   </qas-search-box>
 </template>

--- a/ui/src/components/select/QasSelect.stories.js
+++ b/ui/src/components/select/QasSelect.stories.js
@@ -110,7 +110,7 @@ export default {
     },
 
     fetching: {
-      description: 'Fires when fetching the options.',
+      description: 'Fires when fetching the options.'
     },
 
     input: {

--- a/ui/src/components/select/QasSelect.stories.js
+++ b/ui/src/components/select/QasSelect.stories.js
@@ -109,6 +109,10 @@ export default {
       }
     },
 
+    fetching: {
+      description: 'Fires when fetching the options.',
+    },
+
     input: {
       description: 'Fires when model changes. Also used by `v-model`.'
     },

--- a/ui/src/components/select/QasSelect.vue
+++ b/ui/src/components/select/QasSelect.vue
@@ -17,7 +17,7 @@
         <q-item>
           <q-item-section class="text-grey">
             <template v-if="isLoading">
-              Buscando por {{ label }}...
+              Buscando opções de {{ label }}...
             </template>
             <template v-else>
               {{ noOptionLabel }}

--- a/ui/src/mixins/lazy-loading-filter.js
+++ b/ui/src/mixins/lazy-loading-filter.js
@@ -1,4 +1,5 @@
 import { decamelize } from 'humps'
+import { isEqual } from 'lodash'
 
 export default {
   props: {
@@ -71,7 +72,7 @@ export default {
   watch: {
     lazyLoadingProps: {
       handler (value, oldValue) {
-        if (JSON.stringify(value) === JSON.stringify(oldValue)) return
+        if (isEqual(value, oldValue)) return
 
         this.$_resetFilter()
         this.$emit('input', '')

--- a/ui/src/mixins/lazy-loading-filter.js
+++ b/ui/src/mixins/lazy-loading-filter.js
@@ -63,7 +63,19 @@ export default {
     },
 
     $_virtualScrollClassName () {
-      return `virtual-scroll-${this.name}`
+      const uuid = Date.now()
+      return `virtual-scroll-${this.name}-${uuid}`
+    }
+  },
+
+  watch: {
+    lazyLoadingProps: {
+      handler (value, oldValue) {
+        if (JSON.stringify(value) === JSON.stringify(oldValue)) return
+
+        this.$_resetFilter()
+        this.$emit('input', '')
+      }
     }
   },
 
@@ -114,7 +126,9 @@ export default {
         if (!this.name) throw new Error(this.$_getMissingPropsMessage('name'))
 
         this.hasFetchError = false
+
         this.isLoading = true
+        this.$emit('fetching', true)
 
         const { url, params, decamelizeFieldName } = this.$_defaultLazyLoadingProps
 
@@ -148,6 +162,7 @@ export default {
         return []
       } finally {
         this.isLoading = false
+        this.$emit('fetching', false)
       }
     },
 

--- a/ui/src/mixins/lazy-loading-filter.js
+++ b/ui/src/mixins/lazy-loading-filter.js
@@ -1,5 +1,6 @@
 import { decamelize } from 'humps'
 import { isEqual } from 'lodash'
+import { uid } from 'quasar'
 
 export default {
   props: {
@@ -64,8 +65,8 @@ export default {
     },
 
     $_virtualScrollClassName () {
-      const uuid = Date.now()
-      return `virtual-scroll-${this.name}-${uuid}`
+      const id = uid()
+      return `virtual-scroll-${id}`
     }
   },
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
Ajustes encontrados no uso da versão beta do v2.23.0-beta.4:

* Limpeza do filtro ao mudar os parâmetros de url e query do lazy loading;
* Novo evento de `fetching` ao buscar por novas opções na API;
* Melhoria no texto de loading do QasSelect;
* Adicionado q-list wrapper para os q-item no componente QasSelectList.

## Versão do asteroid

- [x] v2 -> a partir da branch `main`.
- [ ] v3 -> a partir da branch `next`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [x] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [ ] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
