### PR TITLE
Support/v2.23.0 beta.6 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- `QasSelect`: added default `hint` slot to show a loading text.
+- `QasSelect`: added support to receive `loading` attribute from parent and work together with internal `isLoading`.
+  
+### Fixed
+- `QasSelect`: fixed a bug with `onFilter` update callback and AJAX requests. Now the `update` callback is called only when the options is populate using lazy loading.
+- `lazyLoadingFilterMixin`: fixed a scroll bug when the user scrolls down.
+
 ## 2.23.0-beta.5 - 2022-06-14
 
 ### Added

--- a/ui/src/components/search-box/QasSearchBox.vue
+++ b/ui/src/components/search-box/QasSearchBox.vue
@@ -91,7 +91,7 @@ export default {
 
   computed: {
     contentClasses () {
-      return ['overflow-auto', 'q-mt-xs', 'relative-position', this.$_virtualScrollClassName]
+      return ['overflow-auto', 'q-mt-xs', 'relative-position']
     },
 
     contentStyle () {

--- a/ui/src/components/select/QasSelect.vue
+++ b/ui/src/components/select/QasSelect.vue
@@ -139,18 +139,22 @@ export default {
       return this.hasFetchError || this.$attrs.error
     },
 
+    hasLoading () {
+      return this.isLoading || this.$attrs.loading
+    },
+
     attributes () {
       return {
         emitValue: true,
         mapOptions: true,
         outlined: true,
         clearable: this.isSearchable,
-        loading: this.isLoading,
         inputDebounce: this.useLazyLoading ? 500 : 0,
         ...this.$attrs,
         options: this.filteredOptions,
         useInput: this.isSearchable,
-        error: this.hasError
+        error: this.hasError,
+        loading: this.hasLoading
       }
     }
   },

--- a/ui/src/components/select/QasSelect.vue
+++ b/ui/src/components/select/QasSelect.vue
@@ -13,15 +13,10 @@
     </template>
 
     <template #no-option>
-      <slot name="no-option">
+      <slot v-if="!isLoading" name="no-option">
         <q-item>
           <q-item-section class="text-grey">
-            <template v-if="isLoading">
-              Buscando opções de {{ label }}...
-            </template>
-            <template v-else>
-              {{ noOptionLabel }}
-            </template>
+            {{ noOptionLabel }}
           </q-item-section>
         </q-item>
       </slot>
@@ -98,10 +93,6 @@ export default {
       }
     },
 
-    label () {
-      return this.$attrs.label || ''
-    },
-
     listeners () {
       const { input, ...events } = this.$listeners
 
@@ -156,7 +147,6 @@ export default {
         clearable: this.isSearchable,
         loading: this.isLoading,
         inputDebounce: this.useLazyLoading ? 500 : 0,
-        popupContentClass: this.$_virtualScrollClassName,
         ...this.$attrs,
         options: this.filteredOptions,
         useInput: this.isSearchable,
@@ -192,12 +182,16 @@ export default {
   },
 
   methods: {
-    onFilter (value, update) {
-      update(() => {
-        if (this.useLazyLoading && value !== this.search) return this.$_filterOptionsByStore(value)
+    async onFilter (value, update) {
+      if (this.useLazyLoading && value !== this.search) {
+        await this.$_filterOptionsByStore(value)
+      }
 
-        if (!this.useLazyLoading && this.searchable) this.filterOptionsByFuse(value)
-      })
+      if (!this.useLazyLoading && this.searchable) {
+        this.filterOptionsByFuse(value)
+      }
+
+      update()
     },
 
     filterOptionsByFuse (value) {

--- a/ui/src/components/select/QasSelect.vue
+++ b/ui/src/components/select/QasSelect.vue
@@ -12,6 +12,14 @@
       </slot>
     </template>
 
+    <template #hint>
+      <slot name="hint">
+        <div v-if="isLoading" class="q-pb-sm">
+          Buscando por dados...
+        </div>
+      </slot>
+    </template>
+
     <template #no-option>
       <slot v-if="!isLoading" name="no-option">
         <q-item>
@@ -145,6 +153,7 @@ export default {
 
     attributes () {
       return {
+        bottomSlots: true,
         emitValue: true,
         mapOptions: true,
         outlined: true,

--- a/ui/src/components/select/QasSelect.vue
+++ b/ui/src/components/select/QasSelect.vue
@@ -15,7 +15,7 @@
     <template #hint>
       <slot name="hint">
         <div v-if="isLoading" class="q-pb-sm">
-          Buscando por dados...
+          Buscando por opções...
         </div>
       </slot>
     </template>

--- a/ui/src/mixins/lazy-loading-filter.js
+++ b/ui/src/mixins/lazy-loading-filter.js
@@ -98,7 +98,7 @@ export default {
 
         this.$nextTick(() => {
           ref.reset()
-          ref.refresh(-1)
+          ref.refresh(lastIndex)
         })
       }
     },

--- a/ui/src/mixins/lazy-loading-filter.js
+++ b/ui/src/mixins/lazy-loading-filter.js
@@ -98,7 +98,7 @@ export default {
 
         this.$nextTick(() => {
           ref.reset()
-          ref.refresh()
+          ref.refresh(-1)
         })
       }
     },

--- a/ui/src/mixins/lazy-loading-filter.js
+++ b/ui/src/mixins/lazy-loading-filter.js
@@ -1,6 +1,5 @@
 import { decamelize } from 'humps'
 import { isEqual } from 'lodash'
-import { uid } from 'quasar'
 
 export default {
   props: {
@@ -62,11 +61,6 @@ export default {
 
     $_hasFilteredOptions () {
       return !!this.filteredOptions.length
-    },
-
-    $_virtualScrollClassName () {
-      const id = uid()
-      return `virtual-scroll-${id}`
     }
   },
 
@@ -96,17 +90,16 @@ export default {
       }
     },
 
-    async $_onVirtualScroll ({ index }) {
+    async $_onVirtualScroll ({ index, ref }) {
       const lastIndex = this.filteredOptions.length - 1
 
       if (index === lastIndex && this.$_canFetchOptions()) {
-        const { scrollContainer, top } = this.$_getScrollContainerTop()
-
         await this.$_loadMoreOptions()
 
-        setTimeout(() => {
-          scrollContainer.scrollTo({ top })
-        }, 100)
+        this.$nextTick(() => {
+          ref.reset()
+          ref.refresh()
+        })
       }
     },
 
@@ -177,17 +170,6 @@ export default {
       const hasMorePages = lastPage && page <= lastPage
 
       return hasMorePages && !this.isLoading && !this.isScrolling && this.useLazyLoading
-    },
-
-    $_getScrollContainerTop () {
-      const scrollContainer = document.querySelector(`.${this.$_virtualScrollClassName}`)
-      const scrollContainerHeight = scrollContainer.offsetHeight
-      const scrollContainerTop = scrollContainer.scrollTop
-
-      return {
-        scrollContainer,
-        top: scrollContainerTop + (scrollContainerHeight / 2)
-      }
     },
 
     $_handleOptions (options) {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
Ajustes encontrados no uso da versão beta do v2.23.0-beta.5:

- `QasSelect`: adicionado o slot padrão `hint` para mostrar um texto de carregamento.
- `QasSelect`: adicionado suporte para receber o atributo `loading` externamente e funcionar em conjunto com o `isLoading` interno.
- `QasSelect`: corrigido um bug com o retorno do callback update do evento `onFilter` e solicitações AJAX. Agora o callback `update` é chamado apenas quando as opções são populadas usando o lazy loading. [Link para uma issue parecida](https://stackoverflow.com/questions/71312696/quasar-qselect-is-not-opening-when-performing-ajax-call)
- `lazyLoadingFilterMixin`: corrigido um erro de scroll quando o usuário rola para baixo e pede por mais opções utilizando o virtual scroll.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [x] v2 -> a partir da branch `main`.
- [ ] v3 -> a partir da branch `next`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [x] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [ ] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [ ] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
