### PR TITLE
fix: Small fix on virtual scroll for lazy loading selects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- `QasSelect`: added new attribute `virtualScrollItemSize` for better calculation of virtual scroll.
+
+### Fixed
+- `lazyLoadingFilterMixin`: removed `ref.reset()` from `$_onVirtualScroll` method because this is causing render issues.
+
 ## 2.23.0-beta.6 - 2022-06-15
 
 ### Added

--- a/ui/src/components/select/QasSelect.vue
+++ b/ui/src/components/select/QasSelect.vue
@@ -159,6 +159,7 @@ export default {
         outlined: true,
         clearable: this.isSearchable,
         inputDebounce: this.useLazyLoading ? 500 : 0,
+        virtualScrollItemSize: 48,
         ...this.$attrs,
         options: this.filteredOptions,
         useInput: this.isSearchable,

--- a/ui/src/mixins/lazy-loading-filter.js
+++ b/ui/src/mixins/lazy-loading-filter.js
@@ -97,7 +97,6 @@ export default {
         await this.$_loadMoreOptions()
 
         this.$nextTick(() => {
-          ref.reset()
           ref.refresh(lastIndex)
         })
       }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- (Remova este texto de descrição.) -->
Ajustes encontrados no uso da versão beta do v2.23.0-beta.6:
* Calculo automático do tamanho de itens do virtual scroll é afetado com grande quantidade de dados, adicionado `virtualScrollItemSize` definindo o tamanho padrão.
* Removido `ref.reset()` do método `$_onVirtualScroll`. Isso estava causando problema na renderização da listagem de opções (lista não sendo carregada).

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [x] v2 -> a partir da branch `main`.
- [ ] v3 -> a partir da branch `next`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [x] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [ ] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [ ] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
