### PR TITLE
Beta - 17 / lazy loading

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
     "QasSearchBox",
     "QasSelect",
     "QasDialog",
-    "QasField"
+    "QasField",
+    "QasSearchBox/QasSelect"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
   "vetur.format.enable": false,
   "vetur.validation.template": false,
   "conventionalCommits.scopes": [
-    "QasSearchBox"
+    "QasSearchBox",
+    "QasSelect"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,7 @@
     "QasSelect",
     "QasDialog",
     "QasField",
-    "QasSearchBox/QasSelect"
+    "QasSearchBox/QasSelect",
+    "QasInput"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
 
   "vetur.experimental.templateInterpolationService": true,
   "vetur.format.enable": false,
-  "vetur.validation.template": false
+  "vetur.validation.template": false,
+  "conventionalCommits.scopes": [
+    "QasSearchBox"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,8 @@
   "vetur.validation.template": false,
   "conventionalCommits.scopes": [
     "QasSearchBox",
-    "QasSelect"
+    "QasSelect",
+    "QasDialog",
+    "QasField"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## [3.0.0-beta.17]
+
 ## [3.0.0-beta.16] - 22-06-2022
 ## BREAKING CHANGES
 - `QasListView`: antes o que era passado por parâmetro entrava como `filters`, agora é o payload todo, então se precisar passar um filters como anteriormente usar `fetchList({ filters: {...} })`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasSearchBox`: adicionado slot loading referente ao lazy loading.
 - `QasField`: repassando `entity`, `name` e `useLazyLoading` ao componente `QasSelect`.
 - Adicionado novo helper `getNormalizedOptions`.
-- Adicionado novo mixin `lazyLoadingFilterMixin` para ser usado tanto no `QasSelect` quanto no `QasSearchBox`
+- Adicionado novo mixin `searchFilterMixin` para ser usado tanto no `QasSelect` quanto no `QasSearchBox`
 - `QasSearchBox`: Adicionado propriedade `emptyResultText` com default `Não há resultados disponíveis.`.
 
 ### Corrigido

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## [3.0.0-beta.17]
+### Adicionado
+- [`QasSelect`, `QasSearchBox`]: adicionada props: `useLazyLoading`, `name`, `entity` e `useLazyLoadingProps` para adicionar funcionalidades do lazy loading semelhante a versão 2 do asteroid: https://github.com/bildvitta/asteroid/pull/573/files
+- [`QasSelect`, `QasSearchBox`]: adicionada eventos: `@fetch-options-error`, `@fetch-options-success` e `@update:fetching` referentes ao lazy loading.
+- `QasSearchBox`: adicionado slot loading referente ao lazy loading.
+- `QasField`: repassando `entity`, `name` e `useLazyLoading` ao componente `QasSelect`.
+- Adicionado novo helper `getNormalizedOptions`.
+- Adicionado novo mixin `lazyLoadingFilterMixin` para ser usado tanto no `QasSelect` quanto no `QasSearchBox`
+- `QasSearchBox`: Adicionado propriedade `emptyResultText` com default `Não há resultados disponíveis.`.
+
+### Corrigido
+- `QasInput`: resolvido problema com mascara quando o model vinha `null`.
+- `QasSelectList`: adicionado propriedade `deep: true` no watch do `modelValue` para resolver problemas de model.
 
 ## [3.0.0-beta.16] - 22-06-2022
 ## BREAKING CHANGES
@@ -161,6 +173,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ### Corrigido
 - Corrigido `QasBtn`, quando usa a prop `hideLabelOnSmallScreen` e utiliza o slot default, quando a tela está em tamanho pequeno, o botão remove o slot default, o problema disto é que se usar com um `QMenu` dentro do botão, o `QMenu` não é chamado pois não existe mais slot default.
 
+[3.0.0-beta.17]: https://github.com/bildvitta/asteroid/compare/v3.0.0-beta.16...v3.0.0-beta.17?expand=1
 [3.0.0-beta.16]: https://github.com/bildvitta/asteroid/compare/v3.0.0-beta.15...v3.0.0-beta.16?expand=1
 [3.0.0-beta.15]: https://github.com/bildvitta/asteroid/compare/v3.0.0-beta.14...v3.0.0-beta.15?expand=1
 [3.0.0-beta.14]: https://github.com/bildvitta/asteroid/compare/v3.0.0-beta.13...v3.0.0-beta.14?expand=1

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Loggers são ativados quando a variável de ambiente `DEBUGGING` é setada.
 - [ ] Testes unitários nos componentes;
 - [ ] Desenvolver uma CLI para facilitar o desenvolvimento dentro do Asteroid;
 - [ ] Desenvolver uma CLI para facilitar o desenvolvimento fora do Asteroid.
+- [ ] Adicionar exemplos de uso com lazy loading no `QasSearchBox` e `QasSelect`.
 
 # Licença
 

--- a/docs/src/assets/menu.js
+++ b/docs/src/assets/menu.js
@@ -300,6 +300,10 @@ module.exports = [
         path: '/helpers/get-greatest-common-divisor'
       },
       {
+        name: 'getNormalizedOptions',
+        path: '/helpers/get-normalized-options'
+      },
+      {
         name: 'images',
         path: '/helpers/images'
       },

--- a/docs/src/pages/components/search-box.md
+++ b/docs/src/pages/components/search-box.md
@@ -6,6 +6,14 @@ Componente para pesquisa utilizando Fuse.js.
 
 <doc-api file="search-box/QasSearchBox" name="QasSearchBox" />
 
+:::warning
+Quando usado a propriedade `useLazyLoading` o componente depende do `Vuex`, utiliza módulos com action para manipular/recuperar os dados:
+- actions: fetchFieldOptions.
+
+Hoje Utilizamos 1 biblioteca compatível:
+[VuexStoreModule](https://github.com/bildvitta/vuex-store-module).
+:::
+
 :::tip
 Componente implementa o `QasBox` repassando todas propriedades.
 :::
@@ -14,3 +22,37 @@ Componente implementa o `QasBox` repassando todas propriedades.
 
 <doc-example file="QasSearchBox/Basic" title="Básico" />
 
+#### Lazy loading
+
+Quando usamos o `QasSearchBox` com grande quantidades de dados devemos ter um endpoint específico para buscar as suas opções, assim, eliminando o peso de retornar todas as opções do campo no _fields_ da página.
+
+Para utilizar dessa funcionalidade é necessário que dois requisitos sejam realizados, são eles: Requisitos de back-end e de front-end.
+
+##### Back-end
+O back-end deverá ter um endpoint especializado em retornar as opções paginadas, com opção de busca e preparado para receber demais parâmetros de URL. O padrão acordado e que futuramente deverá ser inserido no Navpi:
+
+**Endpoint:** :entity/options/:field-name
+**Parâmetros padrões:** limit, offset e search (deverá aceitar mais parâmetros se necessário, assim, possibilitando filtros com base em outros dados)
+**Retorno:** count, fields e results
+
+Deverá haver mudanças na entidade relacionada que retorna o campo que utiliza do lazy loading:
+* Em todos os endpoints da entidade deverá retornar no campo o parâmetro `useLazyLoading: true` e o `name`;
+* No endpoint **new** da entidade deverá retornar as opções vazias para o respectivo campo;
+* Nos endpoints **edit**, **show** e **list** deverá retornar as opções selecionadas anteriormente nas opções do campo.
+
+##### Front-end
+O front-end deverá atribuir as propriedades no uso do componentes QasSelect e QasSelectList:
+* `entity`
+* `name` (automático pelo Navpi)
+* `useLazyLoading` (automático pelo Navpi)
+* `lazyLoadingProps` (opcional)
+
+_Opcional:_ Com base nas props `entity` e `name`, a função de fetchOptions dos componentes QasSelect e QasSelectList buscará as opções na API utilizando a URL `:entity/options/:field-name`. Porém, você poderá substituir a URL padrão utilizando a propriedade `lazyLoadingProps` e passando um objeto de configuração, como, por exemplo:
+
+```js
+{
+  url: String  // URL para realizar o fetch das opções
+  params: Object, // Parâmetros que poderão ser enviados para a API
+  decamelizeFieldName: Boolean // Caso utilize da URL padrão, esse parâmetro irá transformar o `fieldName` para `field-name` no momento de montar a URL da API.
+}
+```

--- a/docs/src/pages/components/select.md
+++ b/docs/src/pages/components/select.md
@@ -10,7 +10,50 @@ Componente para select que implementa o "QSelect" repassando propriedades, slots
 Neste componente é um "wrapper" do [QSelect](https://quasar.dev/vue-components/select#introduction) o que significa que ele repassa todos os slots, eventos e propriedades.
 :::
 
+:::warning
+Quando usado a propriedade `useLazyLoading` o componente depende do `Vuex`, utiliza módulos com action para manipular/recuperar os dados:
+- actions: fetchFieldOptions.
+
+Hoje Utilizamos 1 biblioteca compatível:
+[VuexStoreModule](https://github.com/bildvitta/vuex-store-module).
+:::
+
 ## Uso
 
 <doc-example file="QasSelect/Basic" title="Básico" />
 <doc-example file="QasSelect/Searchable" title="Com pesquisa" />
+
+#### Lazy loading
+
+Quando usamos o `QasSelect` com grande quantidades de dados devemos ter um endpoint específico para buscar as suas opções, assim, eliminando o peso de retornar todas as opções do campo no _fields_ da página.
+
+Para utilizar dessa funcionalidade é necessário que dois requisitos sejam realizados, são eles: Requisitos de back-end e de front-end.
+
+##### Back-end
+O back-end deverá ter um endpoint especializado em retornar as opções paginadas, com opção de busca e preparado para receber demais parâmetros de URL. O padrão acordado e que futuramente deverá ser inserido no Navpi:
+
+**Endpoint:** :entity/options/:field-name
+**Parâmetros padrões:** limit, offset e search (deverá aceitar mais parâmetros se necessário, assim, possibilitando filtros com base em outros dados)
+**Retorno:** count, fields e results
+
+Deverá haver mudanças na entidade relacionada que retorna o campo que utiliza do lazy loading:
+* Em todos os endpoints da entidade deverá retornar no campo o parâmetro `useLazyLoading: true` e o `name`;
+* No endpoint **new** da entidade deverá retornar as opções vazias para o respectivo campo;
+* Nos endpoints **edit**, **show** e **list** deverá retornar as opções selecionadas anteriormente nas opções do campo.
+
+##### Front-end
+O front-end deverá atribuir as propriedades no uso do componentes QasSelect e QasSelectList:
+* `entity`
+* `name` (automático pelo Navpi)
+* `useLazyLoading` (automático pelo Navpi)
+* `lazyLoadingProps` (opcional)
+
+_Opcional:_ Com base nas props `entity` e `name`, a função de fetchOptions dos componentes QasSelect e QasSelectList buscará as opções na API utilizando a URL `:entity/options/:field-name`. Porém, você poderá substituir a URL padrão utilizando a propriedade `lazyLoadingProps` e passando um objeto de configuração, como, por exemplo:
+
+```js
+{
+  url: String  // URL para realizar o fetch das opções
+  params: Object, // Parâmetros que poderão ser enviados para a API
+  decamelizeFieldName: Boolean // Caso utilize da URL padrão, esse parâmetro irá transformar o `fieldName` para `field-name` no momento de montar a URL da API.
+}
+```

--- a/docs/src/pages/helpers/get-normalized-options.md
+++ b/docs/src/pages/helpers/get-normalized-options.md
@@ -1,0 +1,23 @@
+---
+title: getNormalizedOptions
+---
+
+Função para normalizar options, recebe um array de objetos, uma chave para o `label` e uma para o `value` retornando sempre um array de objetos contendo um label e value.
+
+ ```js
+import { getNormalizedOptions } from 'asteroid'
+
+getNormalizedOptions({
+  options: [
+    { name: 'Test 1', uuid: '1', email: 'example1@email.com' },
+    { name: 'Test 2', uuid: '2', email: 'example1@email.com' }
+  ],
+  label: 'name',
+  value: 'uuid'
+})
+
+// retorna: [
+//   { label: 'Test 1', value: '1', email: 'example1@email.com' },
+//   { label: 'Test 2', value: '2', email: 'example1@email.com' }
+// ]
+```

--- a/ui/src/components/dialog/QasDialog.yml
+++ b/ui/src/components/dialog/QasDialog.yml
@@ -50,7 +50,7 @@ props:
   persistent:
     desc: Define se o dialog vai fechar ou não após clicar fora do dialog.
     default: true
-    type: Object
+    type: Boolean
 
   use-close-button:
     desc: Define se vai ter ou não Ícone de fechar o dialog.

--- a/ui/src/components/field/QasField.vue
+++ b/ui/src/components/field/QasField.vue
@@ -75,8 +75,9 @@ export default {
         type,
         mask,
         maxFiles,
+        gmt,
         useSearch,
-        gmt
+        useLazyLoading
       } = this.formattedField
 
       // Default error attributes for Quasar.
@@ -143,7 +144,7 @@ export default {
 
         'signature-uploader': { is: 'qas-signature-uploader', entity, uploadLabel: label, ...error },
 
-        select: { is: 'qas-select', multiple, options, useSearch, ...input }
+        select: { is: 'qas-select', entity, name, multiple, options, useSearch, useLazyLoading, ...input }
       }
 
       return { ...(profiles[type] || profiles.default), ...this.$attrs }

--- a/ui/src/components/input/QasInput.vue
+++ b/ui/src/components/input/QasInput.vue
@@ -131,7 +131,7 @@ export default {
     },
 
     toggleMask (first, second) {
-      if (!this.modelValue.length) return
+      if (!this.modelValue?.length) return
 
       const length = first.split('#').length - 2
       return this.modelValue?.length > length ? second : first

--- a/ui/src/components/search-box/QasSearchBox.vue
+++ b/ui/src/components/search-box/QasSearchBox.vue
@@ -36,7 +36,7 @@ import { QInfiniteScroll } from 'quasar'
 import Fuse from 'fuse.js'
 
 import QasBox from '../box/QasBox.vue'
-import { lazyLoadingFilterMixin } from '../../mixins'
+import { searchFilterMixin } from '../../mixins'
 
 export default {
   name: 'QasSearchBox',
@@ -46,7 +46,7 @@ export default {
     QInfiniteScroll
   },
 
-  mixins: [lazyLoadingFilterMixin],
+  mixins: [searchFilterMixin],
 
   props: {
     emptyListHeight: {
@@ -125,10 +125,16 @@ export default {
       return { height: this.contentHeight }
     },
 
+    hasNoOptionsOnFirstFetch () {
+      console.log('🚀 ~ file: QasSearchBox.vue ~ line 131 ~ hasNoOptionsOnFirstFetch ~ this.mx_hasFilteredOptions', this.mx_hasFilteredOptions)
+      console.log('🚀 ~ file: QasSearchBox.vue ~ line 131 ~ hasNoOptionsOnFirstFetch ~ this.mx_fetchCount', this.mx_fetchCount)
+      return this.mx_fetchCount === 1 && !this.mx_hasFilteredOptions
+    },
+
     contentHeight () {
-      return this.mx_hasFilteredOptions
-        ? this.height
-        : this.showEmptyResult ? this.emptyListHeight : this.height
+      const hasEmptyList = (!this.list.length && !this.useLazyLoading) || this.hasNoOptionsOnFirstFetch
+
+      return hasEmptyList ? this.emptyListHeight : this.height
     },
 
     component () {
@@ -157,7 +163,7 @@ export default {
     },
 
     isDisabled () {
-      return (!this.useLazyLoading && !this.list.length) || this.mx_isFetching
+      return (!this.useLazyLoading && !this.list.length) || this.mx_isFetching || this.hasNoOptionsOnFirstFetch
     },
 
     showEmptyResult () {
@@ -233,7 +239,7 @@ export default {
 
     async onInfiniteScroll (_, done) {
       // Se tiver erro no primeiro fetch, retorna o "done" na proxima.
-      if ((this.mx_hasFetchError && !this.mx_hasFilteredOptions)) return done()
+      if (((this.mx_hasFetchError && !this.mx_hasFilteredOptions) || this.hasNoOptionsOnFirstFetch)) return done()
 
       if (!this.mx_hasFilteredOptions && !this.mx_search) {
         await this.mx_setFetchOptions()

--- a/ui/src/components/search-box/QasSearchBox.vue
+++ b/ui/src/components/search-box/QasSearchBox.vue
@@ -11,7 +11,7 @@
         <slot v-if="mx_hasFilteredOptions" />
       </component>
 
-      <slot v-if="mx_hasFilteredOptions && mx_isLoading" name="loading">
+      <slot v-if="mx_hasFilteredOptions && mx_isFetching" name="loading">
         <div class="flex justify-center q-pb-sm">
           <q-spinner-dots color="primary" size="20px" />
         </div>
@@ -24,7 +24,7 @@
         </div>
       </slot>
 
-      <q-inner-loading :showing="!mx_hasFilteredOptions && mx_isLoading">
+      <q-inner-loading :showing="!mx_hasFilteredOptions && mx_isFetching">
         <q-spinner color="grey" size="3em" />
       </q-inner-loading>
     </div>
@@ -117,7 +117,7 @@ export default {
         placeholder: this.placeholder,
         hideBottomSpace: true,
         error: this.mx_hasFetchError,
-        loading: this.mx_isLoading
+        loading: this.mx_isFetching
       }
     },
 
@@ -157,11 +157,11 @@ export default {
     },
 
     isDisabled () {
-      return (!this.useLazyLoading && !this.list.length) || this.mx_isLoading
+      return (!this.useLazyLoading && !this.list.length) || this.mx_isFetching
     },
 
     showEmptyResult () {
-      return this.useEmptySlot && !this.mx_hasFilteredOptions && !this.mx_isLoading
+      return this.useEmptySlot && !this.mx_hasFilteredOptions && !this.mx_isFetching
     }
   },
 

--- a/ui/src/components/search-box/QasSearchBox.vue
+++ b/ui/src/components/search-box/QasSearchBox.vue
@@ -1,5 +1,5 @@
 <template>
-  <qas-box v-bind="$attrs">
+  <qas-box>
     <qas-input v-model="mx_search" v-bind="attributes">
       <template #append>
         <q-icon color="primary" name="o_search" />

--- a/ui/src/components/search-box/QasSearchBox.vue
+++ b/ui/src/components/search-box/QasSearchBox.vue
@@ -11,7 +11,7 @@
         <slot v-if="mx_hasFilteredOptions" />
       </component>
 
-      <slot v-if="mx_hasFilteredOptions && mx_isFetching" name="loading">
+      <slot v-if="showSpinnerDots" name="loading">
         <div class="flex justify-center q-pb-sm">
           <q-spinner-dots color="primary" size="20px" />
         </div>
@@ -24,7 +24,7 @@
         </div>
       </slot>
 
-      <q-inner-loading :showing="!mx_hasFilteredOptions && mx_isFetching">
+      <q-inner-loading :showing="showInnerLoading">
         <q-spinner color="grey" size="3em" />
       </q-inner-loading>
     </div>
@@ -162,6 +162,14 @@ export default {
 
     showEmptyResult () {
       return this.useEmptySlot && !this.mx_hasFilteredOptions && !this.mx_isFetching
+    },
+
+    showSpinnerDots () {
+      return this.mx_hasFilteredOptions && this.mx_isFetching
+    },
+
+    showInnerLoading () {
+      return !this.mx_hasFilteredOptions && this.mx_isFetching
     }
   },
 

--- a/ui/src/components/search-box/QasSearchBox.vue
+++ b/ui/src/components/search-box/QasSearchBox.vue
@@ -126,8 +126,6 @@ export default {
     },
 
     hasNoOptionsOnFirstFetch () {
-      console.log('🚀 ~ file: QasSearchBox.vue ~ line 131 ~ hasNoOptionsOnFirstFetch ~ this.mx_hasFilteredOptions', this.mx_hasFilteredOptions)
-      console.log('🚀 ~ file: QasSearchBox.vue ~ line 131 ~ hasNoOptionsOnFirstFetch ~ this.mx_fetchCount', this.mx_fetchCount)
       return this.mx_fetchCount === 1 && !this.mx_hasFilteredOptions
     },
 

--- a/ui/src/components/search-box/QasSearchBox.vue
+++ b/ui/src/components/search-box/QasSearchBox.vue
@@ -1,39 +1,61 @@
 <template>
-  <qas-box>
-    <qas-input v-model="search" clearable :disable="!list.length" hide-bottom-space :placeholder="placeholder">
+  <qas-box v-bind="$attrs">
+    <qas-input v-model="mx_search" v-bind="attributes">
       <template #append>
         <q-icon color="primary" name="o_search" />
       </template>
     </qas-input>
 
-    <div class="overflow-auto q-mt-xs relative-position" :style="contentStyle">
-      <slot v-if="hasResults" />
+    <div ref="scrollContainer" class="overflow-auto q-mt-xs relative-position" :style="contentStyle">
+      <component :is="component.is" v-bind="component.props">
+        <slot v-if="mx_hasFilteredOptions" />
+      </component>
 
-      <slot v-else-if="useEmptySlot" name="empty-result">
-        <div class="absolute-center text-center">
-          <q-icon class="q-mb-sm text-center" color="primary" name="o_search" size="38px" />
-          <div>Não há resultados disponíveis.</div>
+      <slot v-if="mx_hasFilteredOptions && mx_isLoading" name="loading">
+        <div class="flex justify-center q-pb-sm">
+          <q-spinner-dots color="primary" size="20px" />
         </div>
       </slot>
+
+      <slot v-if="showEmptyResult" name="empty-result">
+        <div class="absolute-center text-center">
+          <q-icon class="q-mb-sm text-center" color="primary" name="o_search" size="38px" />
+          <div>{{ emptyResultText }}</div>
+        </div>
+      </slot>
+
+      <q-inner-loading :showing="!mx_hasFilteredOptions && mx_isLoading">
+        <q-spinner color="grey" size="3em" />
+      </q-inner-loading>
     </div>
   </qas-box>
 </template>
 
 <script>
+import { QInfiniteScroll } from 'quasar'
 import Fuse from 'fuse.js'
 
 import QasBox from '../box/QasBox.vue'
+import { lazyLoadingFilterMixin } from '../../mixins'
 
 export default {
   name: 'QasSearchBox',
 
   components: {
-    QasBox
+    QasBox,
+    QInfiniteScroll
   },
+
+  mixins: [lazyLoadingFilterMixin],
 
   props: {
     emptyListHeight: {
       default: '100px',
+      type: String
+    },
+
+    emptyResultText: {
+      default: 'Não há resultados disponíveis.',
       type: String
     },
 
@@ -81,15 +103,48 @@ export default {
 
   data () {
     return {
-      fuse: null,
-      searchResults: this.list,
-      search: ''
+      fuse: null
     }
   },
 
   computed: {
+    attributes () {
+      return {
+        clearable: true,
+        disable: this.isDisabled,
+        debounce: this.useLazyLoading ? 500 : 0,
+        outlined: true,
+        placeholder: this.placeholder,
+        hideBottomSpace: true,
+        error: this.mx_hasFetchError,
+        loading: this.mx_isLoading
+      }
+    },
+
     contentStyle () {
-      return { height: this.list.length ? this.height : this.emptyListHeight }
+      return { height: this.contentHeight }
+    },
+
+    contentHeight () {
+      return this.mx_hasFilteredOptions
+        ? this.height
+        : this.showEmptyResult ? this.emptyListHeight : this.height
+    },
+
+    component () {
+      const infiniteScrollProps = {
+        offset: 100,
+        scrollTarget: this.$refs.scrollContainer,
+        ref: 'infiniteScrollRef'
+      }
+
+      return {
+        is: this.useLazyLoading ? 'q-infinite-scroll' : 'div',
+        props: {
+          ...(this.useLazyLoading && infiniteScrollProps),
+          ...(this.useLazyLoading && { onLoad: this.onInfiniteScroll })
+        }
+      }
     },
 
     defaultFuseOptions () {
@@ -101,63 +156,96 @@ export default {
       }
     },
 
-    hasResults () {
-      return !!this.searchResults.length
+    isDisabled () {
+      return (!this.useLazyLoading && !this.list.length) || this.mx_isLoading
+    },
+
+    showEmptyResult () {
+      return this.useEmptySlot && !this.mx_hasFilteredOptions && !this.mx_isLoading
     }
   },
 
   watch: {
     defaultFuseOptions (value) {
+      if (this.useLazyLoading) return
+
       this.fuse.options = { ...this.fuse.options, ...value }
     },
 
-    hasResults (value) {
+    mx_hasFilteredOptions (value) {
       !value && this.$emit('empty-result')
     },
 
-    list: {
-      handler (value) {
-        this.fuse = new Fuse(value, this.defaultFuseOptions)
+    mx_search: {
+      async handler (value) {
+        this.$emit('update:modelValue', value)
 
-        this.setResults(this.search)
-        this.updateResultsModel(value)
-      },
+        if (this.useLazyLoading) {
+          await this.mx_filterOptionsByStore(value)
 
-      deep: true
+          this.$refs.infiniteScrollRef.resume()
+
+          return
+        }
+
+        this.filterOptionsByFuse(value)
+      }
     },
 
-    search: {
+    modelValue: {
       handler (value) {
-        this.setResults(value)
-        this.$emit('update:modelValue', value)
+        this.mx_search = value
       },
 
       immediate: true
     },
 
-    searchResults: {
-      handler (value) {
-        this.updateResultsModel(value)
+    mx_filteredOptions: {
+      handler (options) {
+        this.$emit('update:results', options)
       },
+
       immediate: true
     }
   },
 
   created () {
-    this.search = this.modelValue
+    if (this.useLazyLoading) return
+
+    this.mx_filteredOptions = this.list
     this.fuse = new Fuse(this.list, this.defaultFuseOptions)
-    this.setResults()
+
+    this.setListWatcher()
   },
 
   methods: {
-    setResults (value) {
-      this.searchResults = value
-        ? this.fuse.search(value)
-        : this.list
+    filterOptionsByFuse (value) {
+      this.mx_filteredOptions = value ? this.mx_getNormalizedFuseResults(this.fuse.search(value)) : this.list
     },
 
-    updateResultsModel (value) {
-      this.$emit('update:results', value.map(result => result.item || result))
+    async onInfiniteScroll (_, done) {
+      // Se tiver erro no primeiro fetch, retorna o "done" na proxima.
+      if ((this.mx_hasFetchError && !this.mx_hasFilteredOptions)) return done()
+
+      if (!this.mx_hasFilteredOptions && !this.mx_search) {
+        await this.mx_setFetchOptions()
+        return done()
+      }
+
+      if (this.mx_canFetchOptions()) {
+        await this.mx_loadMoreOptions()
+        return done()
+      }
+
+      done(true)
+    },
+
+    setListWatcher () {
+      this.$watch('list', value => {
+        this.fuse = new Fuse(value, this.defaultFuseOptions)
+
+        this.filterOptionsByFuse(this.mx_search)
+      }, { deep: true })
     }
   }
 }

--- a/ui/src/components/search-box/QasSearchBox.vue
+++ b/ui/src/components/search-box/QasSearchBox.vue
@@ -6,7 +6,7 @@
       </template>
     </qas-input>
 
-    <div ref="scrollContainer" class="overflow-auto q-mt-xs relative-position" :style="contentStyle">
+    <div ref="scrollContainer" class="overflow-auto q-mt-xs relative-position" :style="containerStyle">
       <component :is="component.is" v-bind="component.props">
         <slot v-if="mx_hasFilteredOptions" />
       </component>
@@ -121,15 +121,15 @@ export default {
       }
     },
 
-    contentStyle () {
-      return { height: this.contentHeight }
+    containerStyle () {
+      return { height: this.containerHeight }
     },
 
     hasNoOptionsOnFirstFetch () {
       return this.mx_fetchCount === 1 && !this.mx_hasFilteredOptions
     },
 
-    contentHeight () {
+    containerHeight () {
       const hasEmptyList = (!this.list.length && !this.useLazyLoading) || this.hasNoOptionsOnFirstFetch
 
       return hasEmptyList ? this.emptyListHeight : this.height

--- a/ui/src/components/search-box/QasSearchBox.yml
+++ b/ui/src/components/search-box/QasSearchBox.yml
@@ -117,3 +117,27 @@ events:
         desc: Novo valor do v-model:results
         default: []
         type: Array
+
+  '@update:fetching -> function (value)':
+    desc: Dispara toda vez que o campo de busca faz o fetch do lazy loading
+    params:
+      value:
+        desc: Novo valor do v-model:fetching
+        default: false
+        type: Boolean
+
+  '@fetch-options-success -> function (value)':
+    desc: Dispara toda vez que o campo de busca faz o fetch do lazy loading com sucesso.
+    params:
+      value:
+        desc: Valor retornado pela action "fetchFieldOptions"
+        default: {}
+        type: Object
+
+  '@fetch-options-error -> function (value)':
+    desc: Dispara toda vez que o campo de busca faz o fetch do lazy loading e cai em uma exceção.
+    params:
+      value:
+        desc: Valor retornado pela action "fetchFieldOptions"
+        default: {}
+        type: Object

--- a/ui/src/components/search-box/QasSearchBox.yml
+++ b/ui/src/components/search-box/QasSearchBox.yml
@@ -9,6 +9,24 @@ props:
     default: 100px
     type: String
 
+  empty-result-text:
+    desc: Define o texto dentro do box quando a lista está vazia.
+    default: 100px
+    type: String
+
+  entity:
+    desc: Entidade enviada para a action "fetchFieldOptions" (usar somente quando "useLazyLoading" estiver habilitada).
+    default: ''
+    type: String
+    examples: [users]
+
+  fetching:
+    desc: Usado para saber quando o componente está fazendo fetching (usar somente quando "useLazyLoading" estiver habilitada).
+    default: false
+    type: Boolean
+    model: true
+    examples: [v-model:fetching="isFetching"]
+
   fuse-options:
     desc: Opções do Fuse.js (https://fusejs.io/api/options.html).
     debugger: true
@@ -23,8 +41,18 @@ props:
     default: 300px
     type: String
 
+  lazy-loading-props:
+    desc: Propriedades para o lazy loading (usar somente quando "useLazyLoading" estiver habilitada).
+    debugger: true
+    default:
+      decamelizeFieldName: true
+      url: ''
+      params:
+        limit: 48
+    type: String
+
   list:
-    desc: Lista onde ocorrerá a busca (array de objetos).
+    desc: Lista onde ocorrerá a busca sendo array de objetos (usar somente quando "useLazyLoading" **NÃO** estiver habilitada).
     default: []
     type: String
 
@@ -33,6 +61,11 @@ props:
     type: String
     examples: [v-model="search"]
     model: true
+
+  name:
+    desc: Nome do campo a ser enviado para a action "fetchFieldOptions" (usar somente quando "useLazyLoading" estiver habilitada).
+    type: String
+    examples: [cities]
 
   placeholder:
     desc: Placeholder do campo de pesquisa.
@@ -51,12 +84,20 @@ props:
     default: true
     type: Boolean
 
+  use-lazy-loading:
+    desc: Controla a busca pela store "fetchFieldOptions".
+    default: false
+    type: Boolean
+
 slots:
   default:
     desc: Acesso ao conteúdo principal, só existe caso a busca retorne algum resultado.
 
   empty-result:
     desc: Acesso ao conteúdo quando a busca não retorne resultado e a prop "useEmptySlot" seja "true".
+
+  loading:
+    desc: Acesso ao conteúdo do loading que contém o "<q-spinner-dots />"..
 
 events:
   '@empty-result -> function ()':

--- a/ui/src/components/search-box/QasSearchBox.yml
+++ b/ui/src/components/search-box/QasSearchBox.yml
@@ -11,7 +11,7 @@ props:
 
   empty-result-text:
     desc: Define o texto dentro do box quando a lista está vazia.
-    default: 100px
+    default: Não há resultados disponíveis.
     type: String
 
   entity:
@@ -43,13 +43,13 @@ props:
 
   lazy-loading-props:
     desc: Propriedades para o lazy loading (usar somente quando "useLazyLoading" estiver habilitada).
+    type: Object
     debugger: true
     default:
       decamelizeFieldName: true
       url: ''
       params:
         limit: 48
-    type: String
 
   list:
     desc: Lista onde ocorrerá a busca sendo array de objetos (usar somente quando "useLazyLoading" **NÃO** estiver habilitada).

--- a/ui/src/components/select-list/QasSelectList.vue
+++ b/ui/src/components/select-list/QasSelectList.vue
@@ -107,6 +107,7 @@ export default {
         this.values = [...value]
       },
 
+      deep: true,
       immediate: true
     }
   },

--- a/ui/src/components/select/QasSelect.vue
+++ b/ui/src/components/select/QasSelect.vue
@@ -31,13 +31,13 @@
 </template>
 
 <script>
-import { lazyLoadingFilterMixin } from '../../mixins'
+import { searchFilterMixin } from '../../mixins'
 import Fuse from 'fuse.js'
 
 export default {
   name: 'QasSelect',
 
-  mixins: [lazyLoadingFilterMixin],
+  mixins: [searchFilterMixin],
 
   props: {
     fuseOptions: {
@@ -189,7 +189,7 @@ export default {
 
       const results = this.fuse.search(value)
 
-      this.mx_filteredOptions = results.map(({ item }) => item)
+      this.mx_filteredOptions = this.mx_getNormalizedFuseResults(results)
     }
   }
 }

--- a/ui/src/components/select/QasSelect.yml
+++ b/ui/src/components/select/QasSelect.yml
@@ -77,3 +77,27 @@ events:
       value:
         desc: Novo valor do v-model
         type: [Array, Object, String, Number]
+
+  '@update:fetching -> function (value)':
+    desc: Dispara toda vez que o campo de busca faz o fetch do lazy loading
+    params:
+      value:
+        desc: Novo valor do v-model:fetching
+        default: false
+        type: Boolean
+
+  '@fetch-options-success -> function (value)':
+    desc: Dispara toda vez que o campo de busca faz o fetch do lazy loading com sucesso.
+    params:
+      value:
+        desc: Valor retornado pela action "fetchFieldOptions"
+        default: {}
+        type: Object
+
+  '@fetch-options-error -> function (value)':
+    desc: Dispara toda vez que o campo de busca faz o fetch do lazy loading e cai em uma exceção.
+    params:
+      value:
+        desc: Valor retornado pela action "fetchFieldOptions"
+        default: {}
+        type: Object

--- a/ui/src/components/select/QasSelect.yml
+++ b/ui/src/components/select/QasSelect.yml
@@ -7,6 +7,19 @@ meta:
   desc: Componente para select que implementa o "QSelect" repassando propriedades, slots e eventos.
 
 props:
+  entity:
+    desc: Entidade enviada para a action "fetchFieldOptions" (usar somente quando "useLazyLoading" estiver habilitada).
+    default: ''
+    type: String
+    examples: [users]
+
+  fetching:
+    desc: Usado para saber quando o componente está fazendo fetching (usar somente quando "useLazyLoading" estiver habilitada).
+    default: false
+    type: Boolean
+    model: true
+    examples: [v-model:fetching="isFetching"]
+
   fuse-options:
     desc: Opções do Fuse.js (https://fusejs.io/api/options.html).
     type: Object
@@ -28,6 +41,11 @@ props:
     examples: [v-model="value"]
     model: true
 
+  name:
+    desc: Nome do campo a ser enviado para a action "fetchFieldOptions" (usar somente quando "useLazyLoading" estiver habilitada).
+    type: String
+    examples: [cities]
+
   no-option-label:
     desc: Rótulo padrão de quando os options estão vazios.
     default: Nenhum resultado foi encontrado.
@@ -45,6 +63,11 @@ props:
 
   use-search:
     desc: Controla se vai ou não ter campo de busca no select.
+    type: Boolean
+
+  use-lazy-loading:
+    desc: Controla a busca pela store "fetchFieldOptions".
+    default: false
     type: Boolean
 
 events:

--- a/ui/src/components/select/QasSelect.yml
+++ b/ui/src/components/select/QasSelect.yml
@@ -34,6 +34,16 @@ props:
     type: String
     examples: [label-key="name"]
 
+  lazy-loading-props:
+    desc: Propriedades para o lazy loading (usar somente quando "useLazyLoading" estiver habilitada).
+    type: Object
+    debugger: true
+    default:
+      decamelizeFieldName: true
+      url: ''
+      params:
+        limit: 48
+
   model-value:
     desc: Model do componente.
     default: []

--- a/ui/src/helpers/get-normalized-options.js
+++ b/ui/src/helpers/get-normalized-options.js
@@ -1,0 +1,20 @@
+/**
+ * param {options: object[], label: string, value: string} object
+ *
+ * @example getNormalizedOptions({
+ *  options: [{ name: 'Test 1', uuid: '1' }, { name: 'Test 2', uuid: '2' }],
+ *  label: 'name'
+ *  value: 'uuid'
+ * }) // retorna [{ label: 'Test 1', value: '1' }, { label: 'Test 2', value: '2' }]
+ */
+export default ({ options = [], label, value }) => {
+  return options.map(option => {
+    const { [label]: labelKey, [value]: valueKey, ...payload } = option
+
+    return {
+      label: option[label],
+      value: option[value],
+      ...payload
+    }
+  })
+}

--- a/ui/src/helpers/index.js
+++ b/ui/src/helpers/index.js
@@ -9,6 +9,7 @@ export { default as getGreatestCommonDivisor } from './get-greatest-common-divis
 export { default as filterObjectToArray } from './filter-object-to-array.js'
 export { default as filterListByHandle } from './filter-list-by-handle.js'
 export { default as camelizeFieldsName } from './camelize-fields-name.js'
+export { default as getNormalizedOptions } from './get-normalized-options.js'
 
 export * from './filters.js'
 export * from './images.js'

--- a/ui/src/mixins/index.js
+++ b/ui/src/mixins/index.js
@@ -1,6 +1,7 @@
 import contextMixin from './context.js'
 import formMixin from './form.js'
 import generatorMixin from './generator.js'
+import lazyLoadingFilterMixin from './lazy-loading-filter.js'
 import passwordMixin from './password.js'
 import viewMixin from './view.js'
 
@@ -8,6 +9,7 @@ export {
   contextMixin,
   formMixin,
   generatorMixin,
+  lazyLoadingFilterMixin,
   passwordMixin,
   viewMixin
 }

--- a/ui/src/mixins/index.js
+++ b/ui/src/mixins/index.js
@@ -1,7 +1,7 @@
 import contextMixin from './context.js'
 import formMixin from './form.js'
 import generatorMixin from './generator.js'
-import lazyLoadingFilterMixin from './lazy-loading-filter.js'
+import searchFilterMixin from './search-filter.js'
 import passwordMixin from './password.js'
 import viewMixin from './view.js'
 
@@ -9,7 +9,7 @@ export {
   contextMixin,
   formMixin,
   generatorMixin,
-  lazyLoadingFilterMixin,
+  searchFilterMixin,
   passwordMixin,
   viewMixin
 }

--- a/ui/src/mixins/lazy-loading-filter.js
+++ b/ui/src/mixins/lazy-loading-filter.js
@@ -31,7 +31,8 @@ export default {
     'update:modelValue',
     'update:fetching',
     'fetch-options-success',
-    'fetch-options-error'
+    'fetch-options-error',
+    'virtual-scroll'
   ],
 
   data () {
@@ -109,8 +110,6 @@ export default {
 
     async mx_onVirtualScroll ({ index, ref }) {
       const lastIndex = this.mx_filteredOptions.length - 1
-
-      console.log('kk eae man')
 
       if (index === lastIndex && this.mx_canFetchOptions()) {
         await this.mx_loadMoreOptions()

--- a/ui/src/mixins/lazy-loading-filter.js
+++ b/ui/src/mixins/lazy-loading-filter.js
@@ -1,0 +1,223 @@
+import { decamelize } from 'humps'
+import { isEqual } from 'lodash'
+
+export default {
+  props: {
+    entity: {
+      default: '',
+      type: String
+    },
+
+    lazyLoadingProps: {
+      default: () => ({}),
+      type: Object
+    },
+
+    name: {
+      default: '',
+      type: String
+    },
+
+    useLazyLoading: {
+      type: Boolean
+    },
+
+    fetching: {
+      type: Boolean
+    }
+  },
+
+  emits: [
+    'update:modelValue',
+    'update:fetching',
+    'fetch-options-success',
+    'fetch-options-error'
+  ],
+
+  data () {
+    return {
+      mx_filteredOptions: [],
+      mx_hasFetchError: false,
+      mx_isLoading: false,
+      mx_isScrolling: false,
+      mx_search: '',
+      mx_pagination: {
+        page: 1,
+        lastPage: null,
+        hasCount: true,
+        hasNextPage: false
+      }
+    }
+  },
+
+  computed: {
+    mx_defaultLazyLoadingProps () {
+      const {
+        url,
+        params,
+        decamelizeFieldName
+      } = this.lazyLoadingProps
+
+      const defaultParams = { limit: 48 }
+
+      return {
+        url: url || '',
+        params: {
+          ...defaultParams,
+          ...params
+        },
+        decamelizeFieldName: decamelizeFieldName === undefined ? true : decamelizeFieldName
+      }
+    },
+
+    mx_hasFilteredOptions () {
+      return !!this.mx_filteredOptions.length
+    },
+
+    mx_isFilterByFuse () {
+      return !this.useLazyLoading
+    }
+  },
+
+  watch: {
+    lazyLoadingProps: {
+      handler (value, oldValue) {
+        if (isEqual(value, oldValue)) return
+
+        this.mx_filterOptionsByStore('')
+        this.$emit('update:modelValue', '')
+      }
+    }
+  },
+
+  methods: {
+    async mx_filterOptionsByStore (search) {
+      this.mx_resetFilter(search)
+      await this.mx_setFetchOptions()
+    },
+
+    mx_resetFilter (search) {
+      this.mx_filteredOptions = []
+      this.mx_search = search
+      this.mx_pagination = {
+        page: 1,
+        lastPage: null,
+        hasCount: true,
+        hasNextPage: false
+      }
+    },
+
+    async mx_onVirtualScroll ({ index, ref }) {
+      const lastIndex = this.mx_filteredOptions.length - 1
+
+      console.log('kk eae man')
+
+      if (index === lastIndex && this.mx_canFetchOptions()) {
+        await this.mx_loadMoreOptions()
+
+        this.$nextTick(() => {
+          ref.reset()
+          ref.refresh(lastIndex)
+        })
+      }
+    },
+
+    async mx_loadMoreOptions () {
+      this.mx_isScrolling = true
+
+      const options = await this.mx_fetchOptions()
+      this.mx_filteredOptions.push(...options)
+
+      // this is to prevent the virtual-scroll event to be fired again
+      this.$nextTick(() => {
+        this.mx_isScrolling = false
+      })
+    },
+
+    async mx_fetchOptions () {
+      try {
+        if (!this.entity) this.mx_setMissingPropsMessage('entity')
+        if (!this.name) this.mx_setMissingPropsMessage('name')
+
+        this.mx_hasFetchError = false
+        this.mx_isLoading = true
+
+        this.$emit('update:fetching', true)
+
+        const { params, decamelizeFieldName } = this.mx_defaultLazyLoadingProps
+        // const { url, params, decamelizeFieldName } = this.mx_defaultLazyLoadingProps
+
+        const { data } = await this.$store.dispatch(`${this.entity}/fetchFieldOptions`, {
+          url: 'https://api-dev-produto.nave.dev/api/properties/options/property-holders',
+          // url,
+          field: decamelizeFieldName ? decamelize(this.name, { separator: '-' }) : this.name,
+          params: {
+            ...params,
+            search: this.mx_search,
+            offset: (this.mx_pagination.page - 1) * params.limit
+          }
+        })
+
+        const { results, count, hasNextPage } = data
+        const hasCount = count !== undefined
+
+        this.mx_pagination = {
+          page: this.mx_pagination.page + 1,
+          lastPage: hasCount ? Math.ceil(count / params.limit) : null,
+          hasCount,
+          hasNextPage
+        }
+
+        this.$emit('fetch-options-success', data)
+
+        return this.mx_handleOptions(results)
+      } catch (error) {
+        this.$qas.logger.group(
+          `Mixin: lazyLoadingFilter - mx_fetchOptions -> exceção da action ${this.entity}/fetchFieldOptions`,
+          [error],
+          { error: true }
+        )
+
+        this.mx_hasFetchError = true
+        this.$emit('fetch-options-error', error)
+
+        return []
+      } finally {
+        this.mx_isLoading = false
+        this.$emit('update:fetching', true)
+      }
+    },
+
+    async mx_setFetchOptions () {
+      this.mx_filteredOptions = await this.mx_fetchOptions()
+    },
+
+    mx_canFetchOptions () {
+      const { lastPage, page, hasCount, hasNextPage } = this.mx_pagination
+
+      const hasMorePages = hasCount ? lastPage && page <= lastPage : hasNextPage
+
+      return hasMorePages && !this.mx_isLoading && !this.mx_isScrolling && this.useLazyLoading
+    },
+
+    mx_handleOptions (options) {
+      if (this.labelKey && this.valueKey && this.renameKey) {
+        return options.map(item => this.renameKey(item))
+      }
+
+      return options
+    },
+
+    mx_getMissingPropsMessage (prop) {
+      return `A propriedade "${prop}" é obrigatória quando a propriedade "useLazyLoading" está ativa.`
+    },
+
+    mx_setMissingPropsMessage (prop) {
+      throw new Error(this.mx_getMissingPropsMessage(prop))
+    },
+
+    mx_getNormalizedFuseResults (results = []) {
+      return results.map(result => result.item)
+    }
+  }
+}

--- a/ui/src/mixins/search-filter.js
+++ b/ui/src/mixins/search-filter.js
@@ -42,6 +42,7 @@ export default {
       mx_isFetching: false,
       mx_isScrolling: false,
       mx_search: '',
+      mx_fetchCount: 0,
       mx_pagination: {
         page: 1,
         lastPage: null,
@@ -134,6 +135,8 @@ export default {
     },
 
     async mx_fetchOptions () {
+      this.mx_fetchCount++
+
       try {
         if (!this.entity) this.mx_setMissingPropsMessage('entity')
         if (!this.name) this.mx_setMissingPropsMessage('name')
@@ -170,7 +173,7 @@ export default {
         return this.mx_handleOptions(results)
       } catch (error) {
         this.$qas.logger.group(
-          `Mixin: lazyLoadingFilter - mx_fetchOptions -> exceção da action ${this.entity}/fetchFieldOptions`,
+          `Mixin: searchFilterMixin - mx_fetchOptions -> exceção da action ${this.entity}/fetchFieldOptions`,
           [error],
           { error: true }
         )
@@ -218,7 +221,7 @@ export default {
     },
 
     mx_getNormalizedFuseResults (results = []) {
-      return results.map(result => result.item)
+      return results.map(({ item }) => item)
     }
   }
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## [3.0.0-beta.17]
### Adicionado
- [`QasSelect`, `QasSearchBox`]: adicionada props: `useLazyLoading`, `name`, `entity` e `useLazyLoadingProps` para adicionar funcionalidades do lazy loading semelhante a versão 2 do asteroid: https://github.com/bildvitta/asteroid/pull/573/files
- [`QasSelect`, `QasSearchBox`]: adicionada eventos: `@fetch-options-error`, `@fetch-options-success` e `@update:fetching` referentes ao lazy loading.
- `QasSearchBox`: adicionado slot loading referente ao lazy loading.
- `QasField`: repassando `entity`, `name` e `useLazyLoading` ao componente `QasSelect`.
- Adicionado novo helper `getNormalizedOptions`.
- Adicionado novo mixin `lazyLoadingFilterMixin` para ser usado tanto no `QasSelect` quanto no `QasSearchBox`
- `QasSearchBox`: Adicionado propriedade `emptyResultText` com default `Não há resultados disponíveis.`.

### Corrigido
- `QasInput`: resolvido problema com mascara quando o model vinha `null`.
- `QasSelectList`: adicionado propriedade `deep: true` no watch do `modelValue` para resolver problemas de model.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `main`.
- [x] v3 -> a partir da branch `next`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [x] Helpers
- [x] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
