### PR TITLE
Feature/next/beta 19

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,7 @@
     "QasUploader",
     "DocLayout",
     "filters",
-    "QasTabsGenerator"
+    "QasTabsGenerator",
+    "QasLayout"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,7 @@
     "DocLayout",
     "filters",
     "QasTabsGenerator",
-    "QasLayout"
+    "QasLayout",
+    "QasListView"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,7 @@
     "QasFormGenerator",
     "QasFormView",
     "QasUploader",
-    "DocLayout"
+    "DocLayout",
+    "filters"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,7 @@
     "QasFormView",
     "QasUploader",
     "DocLayout",
-    "filters"
+    "filters",
+    "QasTabsGenerator"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
+## BREAKING CHANGES
+- `QasFormView`: alterado parâmetro `params` para `externalPayload`, agora ele sobrescreve todo o payload do `fetchSingle` e não somente o `params`.
+- `QasFormView`: alterado nome do método de `fetch` para `fetchSingle` para manter padrão dos outros componentes de `view`.
+
 ### Adicionado
 - `filters`: adicionado novos tipos money e decimal na função `humanize`.
 
@@ -18,6 +22,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasTabsGenerator`: alterado `name` do `QTab` para `tab.value` ao invés de `key`.
 - `QasTabsGenerator`: adicionado novo type `Array` na propriedade `tabs`.
 - `QasLayout`: componente agora começa com menu lateral aberto a partir de telas maiores que "tablet", sem a necessidade de fazer este controla manual.
+- `QasListView`: alterado execução do método `fetchList` para `mx_fetchHandler` dentro do `refresh`.
 
 ### Corrigido
 - `QasNestedFields`: corrigido propriedade `useDestroyAlways`, não estava sendo removido a ultima linha (row) do nested, alterado onde o método `setDefaultNestedValue` é chamado.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,14 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ### Adicionado
 - `filters`: adicionado novos tipos money e decimal na função `humanize`.
 - `QasDialog`: adicionado nova propriedade `useValidationAllAtOnce` para validar todos os campos de uma única vez.
+- `handleProcess`: Adicionado novo `helper` que lida com `process.env`.
 
 ### Modificado
 - `QasTabsGenerator`: alterado `name` do `QTab` para `tab.value` ao invés de `key`.
 - `QasTabsGenerator`: adicionado novo type `Array` na propriedade `tabs`.
 - `QasLayout`: componente agora começa com menu lateral aberto a partir de telas maiores que "tablet", sem a necessidade de fazer este controla manual.
 - `QasListView`: alterado execução do método `fetchList` para `mx_fetchHandler` dentro do `refresh`.
+- `api.js`: alterado boot do `api` para validar quando intercepta o `axios` e fazer o `camelize`.
 
 ### Corrigido
 - `QasNestedFields`: corrigido propriedade `useDestroyAlways`, não estava sendo removido a ultima linha (row) do nested, alterado onde o método `setDefaultNestedValue` é chamado.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ### Modificado
 - `QasTabsGenerator`: alterado `name` do `QTab` para `tab.value` ao invés de `key`.
 - `QasTabsGenerator`: adicionado novo type `Array` na propriedade `tabs`.
+- `QasLayout`: componente agora começa com menu lateral aberto a partir de telas maiores que "tablet", sem a necessidade de fazer este controla manual.
 
 ### Corrigido
 - `QasNestedFields`: corrigido propriedade `useDestroyAlways`, não estava sendo removido a ultima linha (row) do nested, alterado onde o método `setDefaultNestedValue` é chamado.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasNestedFields`: corrigido propriedade `useDestroyAlways`, não estava sendo removido a ultima linha (row) do nested, alterado onde o método `setDefaultNestedValue` é chamado.
+- `QasNestedFields`: corrigido propriedade `useRemoveOnDestroy`, não estava funcionando quando valor era `false` por uma validação errada no método `destroy`.
+- `QasField`: alterado atributo `gmt` para `useIso` para o componente `QasDateTimeInput`.
+
+### Removido
+- `QasNestedFields`: removido `leaveActiveClass: 'animated slideOutUp'` animação na "volta" não funcionava e apenas dava um delay desnecessário e parecia que o componente estava lento.
+
 ## [3.0.0-beta.18] - 02-08-2022
 ### Adicionado
 - `QasFormGenerator`: adicionado propriedade `fieldset` para agrupar elementos por rótulo (label).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ### Adicionado
 - `filters`: adicionado novos tipos money e decimal na função `humanize`.
 
+### Modificado
+- `QasTabsGenerator`: alterado `name` do `QTab` para `tab.value` ao invés de `key`.
+- `QasTabsGenerator`: adicionado novo type `Array` na propriedade `tabs`.
+
 ### Corrigido
 - `QasNestedFields`: corrigido propriedade `useDestroyAlways`, não estava sendo removido a ultima linha (row) do nested, alterado onde o método `setDefaultNestedValue` é chamado.
 - `QasNestedFields`: corrigido propriedade `useRemoveOnDestroy`, não estava funcionando quando valor era `false` por uma validação errada no método `destroy`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ### Adicionado
 - `filters`: adicionado novos tipos money e decimal na função `humanize`.
+- `QasDialog`: adicionado nova propriedade `useValidationAllAtOnce` para validar todos os campos de uma única vez.
 
 ### Modificado
 - `QasTabsGenerator`: alterado `name` do `QTab` para `tab.value` ao invés de `key`.
@@ -28,6 +29,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasNestedFields`: corrigido propriedade `useDestroyAlways`, não estava sendo removido a ultima linha (row) do nested, alterado onde o método `setDefaultNestedValue` é chamado.
 - `QasNestedFields`: corrigido propriedade `useRemoveOnDestroy`, não estava funcionando quando valor era `false` por uma validação errada no método `destroy`.
 - `QasField`: alterado atributo `gmt` para `useIso` para o componente `QasDateTimeInput`.
+- [`QasDateTimeInput`, `QasInput`, `QasField`, `QasPasswordInput`]: removido div "pai" dos elementos deixando os próprios elementos sendo o "pai", resolvendo alguns problemas referentes ao `$attrs`.
 
 ### Removido
 - `QasNestedFields`: removido `leaveActiveClass: 'animated slideOutUp'` animação na "volta" não funcionava e apenas dava um delay desnecessário e parecia que o componente estava lento.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
+### Adicionado
+- `filters`: adicionado novos tipos money e decimal na função `humanize`.
+
 ### Corrigido
 - `QasNestedFields`: corrigido propriedade `useDestroyAlways`, não estava sendo removido a ultima linha (row) do nested, alterado onde o método `setDefaultNestedValue` é chamado.
 - `QasNestedFields`: corrigido propriedade `useRemoveOnDestroy`, não estava funcionando quando valor era `false` por uma validação errada no método `destroy`.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Observação: Alguns componentes do Quasar precisam ser importados manualmente d
 | `DEBUGGING` | Habilita os loggers dos componentes |
 | `MAPS_API_KEY` | Key do google maps |
 | `SERVER_TIMEOUT` | Tempo que a API vai tentar finalizar até dar timeout |
-| `API_CASE_TYPE` | Tipo de convenção de nomenclatura que API vai utilizar, possíveis valores: `snake_case` (default) e `camelCase` |
 
 ## Componentes com logger
 Loggers são ativados quando a variável de ambiente `DEBUGGING` é setada.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Observação: Alguns componentes do Quasar precisam ser importados manualmente d
 | `DEBUGGING` | Habilita os loggers dos componentes |
 | `MAPS_API_KEY` | Key do google maps |
 | `SERVER_TIMEOUT` | Tempo que a API vai tentar finalizar até dar timeout |
+| `API_CASE_TYPE` | Tipo de convenção de nomenclatura que API vai utilizar, possíveis valores: `snake_case` (default) e `camelCase` |
 
 ## Componentes com logger
 Loggers são ativados quando a variável de ambiente `DEBUGGING` é setada.
@@ -98,8 +99,9 @@ Loggers são ativados quando a variável de ambiente `DEBUGGING` é setada.
 - [ ] Refatoração de código dos componentes para uma melhorar a performance;
 - [ ] Testes unitários nos componentes;
 - [ ] Desenvolver uma CLI para facilitar o desenvolvimento dentro do Asteroid;
-- [ ] Desenvolver uma CLI para facilitar o desenvolvimento fora do Asteroid.
-- [ ] Adicionar exemplos de uso com lazy loading no `QasSearchBox` e `QasSelect`.
+- [ ] Desenvolver uma CLI para facilitar o desenvolvimento fora do Asteroid;
+- [ ] Adicionar exemplos de uso com lazy loading no `QasSearchBox` e `QasSelect`;
+- [ ] Adicionar `handleProcess` em todas variáveis de ambiente que não são obrigatórias.
 
 # Licença
 

--- a/app-extension/src/index.js
+++ b/app-extension/src/index.js
@@ -33,7 +33,6 @@ function extendQuasar (quasar) {
   // Adiciona todas as classes de animação do Animate.css ao quasar
   // https://animate.style/
   const animations = [
-    'slideOutUp',
     'slideInDown'
   ]
 

--- a/docs/src/assets/menu.js
+++ b/docs/src/assets/menu.js
@@ -304,6 +304,10 @@ module.exports = [
         path: '/helpers/get-normalized-options'
       },
       {
+        name: 'handleProcess',
+        path: '/helpers/handle-process'
+      },
+      {
         name: 'images',
         path: '/helpers/images'
       },

--- a/docs/src/examples/QasLayout/Basic.vue
+++ b/docs/src/examples/QasLayout/Basic.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- Ignore este <q-layout />, ele é usado apenas para funcionar na documentação. -->
-  <q-layout class="flex items-center justify-center" container style="height: 600px;">
-    <qas-layout :app-bar-props="appBarProps" :app-menu-props="appMenuProps" :model-value="false" />
+  <q-layout class="basic flex items-center justify-center" container>
+    <qas-layout :app-bar-props="appBarProps" :app-menu-props="appMenuProps" />
   </q-layout>
 </template>
 
@@ -79,3 +79,15 @@ export default {
   }
 }
 </script>
+
+<!-- NÃO COPIAR, ADICIONADO POR CAUSA DA DOCUMENTAÇÃO -->
+<style lang="scss">
+.basic {
+  height: 600px;
+}
+
+.q-body--fullscreen-mixin,
+.q-body--prevent-scroll {
+  position: initial !important;
+}
+</style>

--- a/docs/src/examples/QasTabsGenerator/TabsArray.vue
+++ b/docs/src/examples/QasTabsGenerator/TabsArray.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="container q-py-lg">
+    <qas-tabs-generator v-model="model" :tabs="tabs" />
+
+    <div class="q-my-lg">
+      model: {{ model }}
+    </div>
+
+    <qas-btn @click="model = 'tab2'">Mudar o model</qas-btn>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      model: 'tab-1'
+    }
+  },
+
+  computed: {
+    tabs () {
+      return [
+        { label: 'tab 1', value: 'tab-1' },
+        { label: 'tab 2', value: 'tab-2' },
+        { label: 'tab 3', value: 'tab-3' }
+      ]
+    }
+  }
+}
+</script>

--- a/docs/src/pages/components/tabs-generator.md
+++ b/docs/src/pages/components/tabs-generator.md
@@ -11,4 +11,5 @@ Trunca um texto baseado no tamanho do elemento pai e adiciona um rotulo "ver mai
 <doc-example file="QasTabsGenerator/Basic" title="Básico" />
 <doc-example file="QasTabsGenerator/CustomSlotTab" title="Slot: tab-[nome-da-chave]" />
 <doc-example file="QasTabsGenerator/CustomSlotAfter" title="Slot: tab-after-[nome-da-chave]" />
+<doc-example file="QasTabsGenerator/TabsArray" title="Tabs como array" />
 

--- a/docs/src/pages/helpers/handle-process.md
+++ b/docs/src/pages/helpers/handle-process.md
@@ -1,0 +1,12 @@
+---
+title: handleProcess
+---
+
+Função para recuperar o `process.env` mesmo que ele não esteja declarado no `quasar.config.js`, no quasar v2, caso não esteja declarado no quasar.config.js, é disparado um erro. Usando esta função, não precisa passar o env caso não seja necessário.
+
+```js
+import { handleProcess } from 'asteroid'
+
+const myEnv = handleProcess(() => process.env.MY_ENV, 'meu-valor-default')
+// retorna o valor de "process.env.MY_ENV" caso exista senão retorna "meu-valor-default".
+```

--- a/docs/src/pages/helpers/handle-process.md
+++ b/docs/src/pages/helpers/handle-process.md
@@ -2,7 +2,7 @@
 title: handleProcess
 ---
 
-Função para recuperar o `process.env` mesmo que ele não esteja declarado no `quasar.config.js`, no quasar v2, caso não esteja declarado no quasar.config.js, é disparado um erro. Usando esta função, não precisa passar o env caso não seja necessário.
+Função para recuperar o `process.env` mesmo que ele não esteja declarado no `quasar.config.js`, no quasar v2, caso não esteja declarado no quasar.config.js, é disparado um erro.
 
 ```js
 import { handleProcess } from 'asteroid'

--- a/docs/src/pages/start/usage.md
+++ b/docs/src/pages/start/usage.md
@@ -49,4 +49,3 @@ Abaixo temos uma lista de variáveis de ambiente, as que estão marcadas como `o
 | `DEBUGGING` * | Habilita os loggers dos componentes **(OBRIGATÓRIO)** |
 | `MAPS_API_KEY` * | Key do google maps **(OBRIGATÓRIO)** |
 | `SERVER_TIMEOUT` * | Tempo que a API vai tentar finalizar até dar timeout **(OBRIGATÓRIO)** |
-| `API_CASE_TYPE` | Tipo de convenção de nomenclatura que API vai utilizar, possíveis valores: `snake_case` (default) e `camelCase` **(NÃO OBRIGATÓRIO)** |

--- a/docs/src/pages/start/usage.md
+++ b/docs/src/pages/start/usage.md
@@ -38,3 +38,15 @@ $secondary-contrast: #3691BF80;
 @include set-brand(primary-contrast, $primary-contrast);
 @include set-brand(secondary-contrast, $secondary-contrast);
 ```
+
+## Variáveis de ambiente
+Abaixo temos uma lista de variáveis de ambiente, as que estão marcadas como `obrigatório` precisa ser adicionadas no `quasar.config.js`
+
+| Variável | Descrição |
+| ------------ | ------------ |
+| `BUCKET_URL` * | Endereço de hospedagem dos arquivos **(OBRIGATÓRIO)** |
+| `SERVER_BASE_URL` * | Endereço base de acesso do servidor **(OBRIGATÓRIO)** |
+| `DEBUGGING` * | Habilita os loggers dos componentes **(OBRIGATÓRIO)** |
+| `MAPS_API_KEY` * | Key do google maps **(OBRIGATÓRIO)** |
+| `SERVER_TIMEOUT` * | Tempo que a API vai tentar finalizar até dar timeout **(OBRIGATÓRIO)** |
+| `API_CASE_TYPE` | Tipo de convenção de nomenclatura que API vai utilizar, possíveis valores: `snake_case` (default) e `camelCase` **(NÃO OBRIGATÓRIO)** |

--- a/ui/src/components/date-time-input/QasDateTimeInput.vue
+++ b/ui/src/components/date-time-input/QasDateTimeInput.vue
@@ -1,21 +1,19 @@
 <template>
-  <div>
-    <qas-input ref="input" v-bind="attributes" v-model="currentValue" :unmasked-value="false" @update:model-value="updateModelValue">
-      <template #append>
-        <q-icon v-if="!useTimeOnly" class="cursor-pointer" name="o_event">
-          <q-popup-proxy ref="dateProxy" transition-hide="scale" transition-show="scale">
-            <q-date v-model="currentValue" v-bind="dateProps" :mask="maskDate" @update:model-value="updateModelValue" />
-          </q-popup-proxy>
-        </q-icon>
+  <qas-input ref="input" v-bind="attributes" v-model="currentValue" :unmasked-value="false" @update:model-value="updateModelValue">
+    <template #append>
+      <q-icon v-if="!useTimeOnly" class="cursor-pointer" name="o_event">
+        <q-popup-proxy ref="dateProxy" transition-hide="scale" transition-show="scale">
+          <q-date v-model="currentValue" v-bind="dateProps" :mask="maskDate" @update:model-value="updateModelValue" />
+        </q-popup-proxy>
+      </q-icon>
 
-        <q-icon v-if="!useDateOnly" class="cursor-pointer q-ml-md" name="o_access_time">
-          <q-popup-proxy ref="timeProxy" transition-hide="scale" transition-show="scale">
-            <q-time v-model="currentValue" v-bind="timeProps" format24h :mask="maskDate" @update:model-value="updateModelValue" />
-          </q-popup-proxy>
-        </q-icon>
-      </template>
-    </qas-input>
-  </div>
+      <q-icon v-if="!useDateOnly" class="cursor-pointer q-ml-md" name="o_access_time">
+        <q-popup-proxy ref="timeProxy" transition-hide="scale" transition-show="scale">
+          <q-time v-model="currentValue" v-bind="timeProps" format24h :mask="maskDate" @update:model-value="updateModelValue" />
+        </q-popup-proxy>
+      </q-icon>
+    </template>
+  </qas-input>
 </template>
 
 <script>
@@ -24,8 +22,6 @@ import { date as dateFn } from '../../helpers/filters'
 
 export default {
   name: 'QasDateTimeInput',
-
-  inheritAttrs: false,
 
   props: {
     dateMask: {

--- a/ui/src/components/dialog/QasDialog.vue
+++ b/ui/src/components/dialog/QasDialog.vue
@@ -102,6 +102,10 @@ export default {
 
     useCloseButton: {
       type: Boolean
+    },
+
+    useValidationAllAtOnce: {
+      type: Boolean
     }
   },
 
@@ -148,7 +152,25 @@ export default {
 
   methods: {
     async submitHandler () {
-      this.useForm && this.$emit('validate', await this.$refs.form.validate())
+      if (!this.useForm) return
+
+      if (this.useValidationAllAtOnce) {
+        let isAllComponentValid = true
+        const components = this.$refs.form.getValidationComponents() || []
+
+        for (const component of components) {
+          const isValid = component?.validate?.()
+
+          if (!isValid) {
+            isAllComponentValid = false
+          }
+        }
+
+        this.$emit('validate', isAllComponentValid)
+        return
+      }
+
+      this.$emit('validate', await this.$refs.form.validate())
     },
 
     // método para funcionar como plugin

--- a/ui/src/components/dialog/QasDialog.vue
+++ b/ui/src/components/dialog/QasDialog.vue
@@ -167,6 +167,7 @@ export default {
         }
 
         this.$emit('validate', isAllComponentValid)
+
         return
       }
 

--- a/ui/src/components/dialog/QasDialog.yml
+++ b/ui/src/components/dialog/QasDialog.yml
@@ -60,8 +60,11 @@ props:
     desc: Define se a tag onde fica a descrição no dialog vai ser um "<q-form />" ou "<div />".
     type: Boolean
 
-slots:
+  use-validation-at-once:
+    desc: Valida todos os campos de uma única vez, ao invés de ser um por vez (que é o padrão).
+    type: Boolean
 
+slots:
   actions:
     desc: Slot para ações (botões por exemplo).
 

--- a/ui/src/components/field/QasField.vue
+++ b/ui/src/components/field/QasField.vue
@@ -75,7 +75,7 @@ export default {
         type,
         mask,
         maxFiles,
-        gmt,
+        useIso,
         useSearch,
         useLazyLoading
       } = this.formattedField
@@ -99,11 +99,11 @@ export default {
         minlength,
         suffix,
         prefix,
-        gmt
+        useIso
       }
 
       const numericInput = { is: 'qas-numeric-input', ...input }
-      const datetimeInput = { is: 'qas-date-time-input', gmt, ...input }
+      const datetimeInput = { is: 'qas-date-time-input', useIso, ...input }
 
       // It'll generate a list of acceptable files extensions.
       const accept = extensions && extensions.length ? extensions.map(extension => `.${extension}`).join(',') : ''

--- a/ui/src/components/field/QasField.vue
+++ b/ui/src/components/field/QasField.vue
@@ -1,11 +1,9 @@
 <template>
-  <div>
-    <component :is="component.is" v-bind="component" :data-cy="field.name" :model-value="formattedValue" @update:model-value="updateModel">
-      <template v-for="(_, name) in $slots" #[name]="context">
-        <slot :name="name" v-bind="context || {}" />
-      </template>
-    </component>
-  </div>
+  <component :is="component.is" v-bind="component" :data-cy="field.name" :model-value="formattedValue" @update:model-value="updateModel">
+    <template v-for="(_, name) in $slots" #[name]="context">
+      <slot :name="name" v-bind="context || {}" />
+    </template>
+  </component>
 </template>
 
 <script>

--- a/ui/src/components/form-view/QasFormView.vue
+++ b/ui/src/components/form-view/QasFormView.vue
@@ -209,7 +209,7 @@ export default {
 
     window.addEventListener('delete-success', this.setIgnoreRouterGuard)
 
-    this.mx_fetchHandler({ form: true, id: this.id, url: this.fetchURL }, this.fetch)
+    this.mx_fetchHandler({ form: true, id: this.id, url: this.fetchURL }, this.fetchSingle)
   },
 
   onUnmounted () {
@@ -254,14 +254,19 @@ export default {
       this.handleCancelRoute()
     },
 
-    async fetch (params) {
+    async fetchSingle (externalPayload = {}) {
       this.mx_isFetching = true
 
       try {
-        const payload = { form: true, id: this.id, params, url: this.fetchURL }
+        const payload = {
+          form: true,
+          id: this.id,
+          url: this.fetchURL,
+          ...externalPayload
+        }
 
         this.$qas.logger.group(
-          `QasFormView - fetch -> payload do parâmetro do ${this.entity}/fetchSingle`, [payload]
+          `QasFormView - fetchSingle -> payload do parâmetro do ${this.entity}/fetchSingle`, [payload]
         )
 
         const response = await this.$store.dispatch(`${this.entity}/fetchSingle`, payload)
@@ -283,24 +288,24 @@ export default {
         result && Object.assign(modelValue, result)
 
         this.$qas.logger.group(
-          `QasFormView - fetch -> resposta da action ${this.entity}/fetchSingle`, [response]
+          `QasFormView - fetchSingle -> resposta da action ${this.entity}/fetchSingle`, [response]
         )
 
         if (this.useDialogOnUnsavedChanges) {
           this.cachedResult = extend(true, {}, result || modelValue)
-          this.$qas.logger.group('QasFormView - fetch -> cachedResult', [this.cachedResult])
+          this.$qas.logger.group('QasFormView - fetchSingle -> cachedResult', [this.cachedResult])
         }
 
         this.$emit('update:modelValue', modelValue)
         this.$emit('fetch-success', response, this.modelValue)
 
-        this.$qas.logger.group('QasFormView - fetch -> modelValue', [modelValue])
+        this.$qas.logger.group('QasFormView - fetchSingle -> modelValue', [modelValue])
       } catch (error) {
         this.mx_fetchError(error)
         this.$emit('fetch-error', error)
 
         this.$qas.logger.group(
-          `QasFormView - fetch -> exceção da action ${this.entity}/fetchSingle`,
+          `QasFormView - fetchSingle -> exceção da action ${this.entity}/fetchSingle`,
           [error],
           { error: true }
         )
@@ -388,7 +393,12 @@ export default {
       this.isSubmitting = true
 
       try {
-        const payload = { id: this.id, payload: this.modelValue, url: this.url, ...externalPayload }
+        const payload = {
+          id: this.id,
+          payload: this.modelValue,
+          url: this.url,
+          ...externalPayload
+        }
 
         this.$qas.logger.group(
           `QasFormView - submit -> payload do ${this.entity}/${this.mode}`, [payload]
@@ -424,7 +434,7 @@ export default {
         this.$emit('submit-error', error)
 
         this.$qas.logger.group(
-          `QasFormView - fetch -> exceção da action ${this.entity}/${this.mode}`,
+          `QasFormView - submit -> exceção da action ${this.entity}/${this.mode}`,
           [error],
           { error: true }
         )

--- a/ui/src/components/input/QasInput.vue
+++ b/ui/src/components/input/QasInput.vue
@@ -1,18 +1,14 @@
 <template>
-  <div>
-    <q-input ref="input" v-model="model" bottom-slots :error="errorData" v-bind="$attrs" :error-message="errorMessageData" :mask="mask" :outlined="outlined" :unmasked-value="unmaskedValue" @paste="onPaste">
-      <template v-for="(_, name) in $slots" #[name]="context">
-        <slot :name="name" v-bind="context || {}" />
-      </template>
-    </q-input>
-  </div>
+  <q-input ref="input" v-model="model" bottom-slots :error="errorData" v-bind="$attrs" :error-message="errorMessageData" :mask="mask" :outlined="outlined" :unmasked-value="unmaskedValue" @paste="onPaste">
+    <template v-for="(_, name) in $slots" #[name]="context">
+      <slot :name="name" v-bind="context || {}" />
+    </template>
+  </q-input>
 </template>
 
 <script>
 export default {
   name: 'QasInput',
-
-  inheritAttrs: false,
 
   props: {
     error: {

--- a/ui/src/components/layout/QasLayout.vue
+++ b/ui/src/components/layout/QasLayout.vue
@@ -71,6 +71,10 @@ export default {
     }
   },
 
+  mounted () {
+    this.menuDrawer = !this.$qas.screen.untilMedium
+  },
+
   methods: {
     toggleMenuDrawer () {
       this.menuDrawer = !this.menuDrawer

--- a/ui/src/components/list-view/QasListView.vue
+++ b/ui/src/components/list-view/QasListView.vue
@@ -196,7 +196,7 @@ export default {
     },
 
     async refresh (done) {
-      await this.fetchList()
+      await this.mx_fetchHandler({ ...this.mx_context, url: this.url }, this.fetchList)
 
       if (typeof done === 'function') {
         done()

--- a/ui/src/components/nested-fields/QasNestedFields.vue
+++ b/ui/src/components/nested-fields/QasNestedFields.vue
@@ -256,8 +256,7 @@ export default {
 
       return {
         tag: 'div',
-        enterActiveClass: 'animated slideInDown',
-        leaveActiveClass: 'animated slideOutUp'
+        enterActiveClass: 'animated slideInDown'
       }
     }
   },
@@ -266,7 +265,12 @@ export default {
     modelValue: {
       handler (value) {
         this.nested = extend(true, [], value)
+      },
+      immediate: true
+    },
 
+    rowObject: {
+      handler () {
         if (!this.nested.length) return this.setDefaultNestedValue()
       },
       immediate: true
@@ -306,7 +310,7 @@ export default {
     },
 
     destroy (index, row) {
-      !row[this.identifierItemKey] || this.useRemoveOnDestroy
+      !row[this.identifierItemKey] && this.useRemoveOnDestroy
         ? this.nested.splice(index, 1)
         : this.nested.splice(index, 1, { [this.destroyKey]: true, ...row })
 

--- a/ui/src/components/password-input/QasPasswordInput.vue
+++ b/ui/src/components/password-input/QasPasswordInput.vue
@@ -1,19 +1,17 @@
 <template>
-  <div>
-    <qas-input v-model="model" :bottom-slots="false" color="negative" v-bind="$attrs" :type="type" use-remove-error-on-type>
-      <template #append>
-        <q-icon class="cursor-pointer" :color="iconColor" :name="icon" @click="toggle" />
-      </template>
+  <qas-input v-model="model" :bottom-slots="false" color="negative" v-bind="$attrs" :type="type" use-remove-error-on-type>
+    <template #append>
+      <q-icon class="cursor-pointer" :color="iconColor" :name="icon" @click="toggle" />
+    </template>
 
-      <template v-for="(_, name) in $slots" #[name]="context">
-        <slot :name="name" v-bind="context || {}" />
-      </template>
+    <template v-for="(_, name) in $slots" #[name]="context">
+      <slot :name="name" v-bind="context || {}" />
+    </template>
 
-      <template v-if="useStrengthChecker" #hint>
-        <qas-password-strength-checker v-bind="strengthCheckerProps" :password="model" />
-      </template>
-    </qas-input>
-  </div>
+    <template v-if="useStrengthChecker" #hint>
+      <qas-password-strength-checker v-bind="strengthCheckerProps" :password="model" />
+    </template>
+  </qas-input>
 </template>
 
 <script>

--- a/ui/src/components/tabs-generator/QasTabsGenerator.vue
+++ b/ui/src/components/tabs-generator/QasTabsGenerator.vue
@@ -1,7 +1,7 @@
 <template>
   <q-tabs v-model="model" :active-color="activeColor" :indicator-color="indicatorColor" outside-arrows>
     <slot v-for="(tab, key) in formattedTabs" :item="tab" :name="`tab-${tab.value}`">
-      <q-tab :key="key" v-bind="tab" :class="tabClass" :label="tab.label" :name="key">
+      <q-tab :key="key" v-bind="tab" :class="tabClass" :label="tab.label" :name="tab.value">
         <slot :item="tab" :name="`tab-after-${tab.value}`">
           <q-badge v-if="counters[key]" :label="counters[key]" v-bind="defaultCounterProps" />
         </slot>
@@ -50,7 +50,7 @@ export default {
     tabs: {
       default: () => ({}),
       required: true,
-      type: Object
+      type: [Object, Array]
     }
   },
 

--- a/ui/src/components/tabs-generator/QasTabsGenerator.yml
+++ b/ui/src/components/tabs-generator/QasTabsGenerator.yml
@@ -38,9 +38,9 @@ props:
     type: String
 
   tabs:
-    desc: Objeto contendo todas as tabs a serem geradas.
+    desc: Objeto ou Array contendo todas as tabs a serem geradas.
     default: {}
-    type: Object
+    type: [Object, Array]
     examples: ["{ tab1: 'tab1', tab2: 'tab2' }"]
 
 slots:

--- a/ui/src/helpers/filters.js
+++ b/ui/src/helpers/filters.js
@@ -114,6 +114,8 @@ function humanize (field = {}, value) {
     case 'time': return time(value)
     case 'radio': return selectLabel(field.options, value)
     case 'percent': return formatPercent(value)
+    case 'money': return money(value)
+    case 'decimal': return decimal(value)
     default: return value
   }
 }

--- a/ui/src/helpers/handle-process.js
+++ b/ui/src/helpers/handle-process.js
@@ -1,0 +1,13 @@
+/**
+ * @param {function} processEnv função que retorna o process.env.
+ * @param {string} defaultValue valor default caso não exista a process.env
+ *
+ * @example handleProcess(() => process.env.MY_ENV, 'meu-valor-default')
+ */
+export default (processEnv = () => {}, defaultValue) => {
+  try {
+    return processEnv() || defaultValue
+  } catch {
+    return defaultValue
+  }
+}

--- a/ui/src/helpers/index.js
+++ b/ui/src/helpers/index.js
@@ -10,6 +10,7 @@ export { default as filterObjectToArray } from './filter-object-to-array.js'
 export { default as filterListByHandle } from './filter-list-by-handle.js'
 export { default as camelizeFieldsName } from './camelize-fields-name.js'
 export { default as getNormalizedOptions } from './get-normalized-options.js'
+export { default as handleProcess } from './handle-process.js'
 
 export * from './filters.js'
 export * from './images.js'


### PR DESCRIPTION
## BREAKING CHANGES
- `QasFormView`: alterado parâmetro `params` para `externalPayload`, agora ele sobrescreve todo o payload do `fetchSingle` e não somente o `params`.
- `QasFormView`: alterado nome do método de `fetch` para `fetchSingle` para manter padrão dos outros componentes de `view`.

### Adicionado
- `filters`: adicionado novos tipos money e decimal na função `humanize`.
- `QasDialog`: adicionado nova propriedade `useValidationAllAtOnce` para validar todos os campos de uma única vez.
- `handleProcess`: Adicionado novo `helper` que lida com `process.env`.

### Modificado
- `QasTabsGenerator`: alterado `name` do `QTab` para `tab.value` ao invés de `key`.
- `QasTabsGenerator`: adicionado novo type `Array` na propriedade `tabs`.
- `QasLayout`: componente agora começa com menu lateral aberto a partir de telas maiores que "tablet", sem a necessidade de fazer este controla manual.
- `QasListView`: alterado execução do método `fetchList` para `mx_fetchHandler` dentro do `refresh`.
- `api.js`: alterado boot do `api` para validar quando intercepta o `axios` e fazer o `camelize`.

### Corrigido
- `QasNestedFields`: corrigido propriedade `useDestroyAlways`, não estava sendo removido a ultima linha (row) do nested, alterado onde o método `setDefaultNestedValue` é chamado.
- `QasNestedFields`: corrigido propriedade `useRemoveOnDestroy`, não estava funcionando quando valor era `false` por uma validação errada no método `destroy`.
- `QasField`: alterado atributo `gmt` para `useIso` para o componente `QasDateTimeInput`.
- [`QasDateTimeInput`, `QasInput`, `QasField`, `QasPasswordInput`]: removido div "pai" dos elementos deixando os próprios elementos sendo o "pai", resolvendo alguns problemas referentes ao `$attrs`.

### Removido
- `QasNestedFields`: removido `leaveActiveClass: 'animated slideOutUp'` animação na "volta" não funcionava e apenas dava um delay desnecessário e parecia que o componente estava lento.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `main`.
- [x] v3 -> a partir da branch `next`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [x] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [x] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [ ] Fiz meu próprio _code review_ antes de abrir este _pull request_.
