### PR TITLE
fix: :bug: inheritAttrs with value false added to some components

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,6 +22,7 @@
     "filters",
     "QasTabsGenerator",
     "QasLayout",
-    "QasListView"
+    "QasListView",
+    "QasDateTimeInput"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ## Não publicado
 ### Modificado
 - `QasSearchBox`: modificado watch `mx_search` para realizar o focus do input de pesquisa após retornar dados do lazy loading.
+- [`QasDateTimeInput`, `QasField`, `QasInput`, `QasPasswordInput`]: modificado componente para não herdar todos os atributos. Para isso foi adicionado `inheritAttrs` com o valor `false`.
+
+### Removido
+- `QasPasswordInput`: removido propriedade `color` com o valor `negative` por padrão.
 
 ## 3.0.0-beta.19 - 08-08-2022
 ## BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasSearchBox`: modificado watch `mx_search` para realizar o focus do input de pesquisa após retornar dados do lazy loading.
 - [`QasDateTimeInput`, `QasField`, `QasInput`, `QasPasswordInput`]: modificado componente para não herdar todos os atributos. Para isso foi adicionado `inheritAttrs` com o valor `false`.
 
+### Corrigido
+- `QasFormGenerator`: corrigido problema ao adicionar validação no `field` do `normalizedFields`  quando o valor é `undefined`.
+
 ### Removido
 - `QasPasswordInput`: removido propriedade `color` com o valor `negative` por padrão.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ### Corrigido
 - `QasFormGenerator`: corrigido problema ao adicionar validação no `field` do `normalizedFields`  quando o valor é `undefined`.
+- `QasDateTimeInput`: corrigido problema do `valueLength` quando o valor é `undefined` adicionando `optional chaining`.
 
 ### Removido
 - `QasPasswordInput`: removido propriedade `color` com o valor `negative` por padrão.

--- a/docs/src/components/DocApiEntry.vue
+++ b/docs/src/components/DocApiEntry.vue
@@ -7,7 +7,7 @@
         <q-item-section>
           <q-item-label>
             <span class="doc-api-entry__item-name">{{ name }}</span>
-            <q-badge v-for="type in parseTypes(data.type)" :key="type" class="doc-api-entry__item-type q-ml-xs" color="grey-4" :label="type" text-color="grey-9" />
+            <q-badge v-for="item in parseTypes(data.type)" :key="item" class="doc-api-entry__item-type q-ml-xs" color="grey-4" :label="item" text-color="grey-9" />
             <span v-if="data.required" class="doc-api-entry__item-required q-ml-xs">Obrigatório</span>
             <span v-if="data.model" class="doc-api-entry__item-model q-ml-xs">Model</span>
           </q-item-label>
@@ -16,7 +16,7 @@
 
           <q-item-label v-if="hasExamples(data.examples)">
             <div class="doc-api-entry__item-example-title q-mt-xs">Exemplos:</div>
-            <q-badge v-for="(example, index) in data.examples" :key="index" class="doc-api-entry__item-example-badge q-ml-xs" color="grey-7" :label="example" outline />
+            <q-badge v-for="(example, index) in data.examples" :key="index" class="doc-api-entry__item-example-badge q-ml-xs" color="grey-7" :label="toString(example)" outline />
           </q-item-label>
 
           <q-item-label v-if="getChildren(data)">
@@ -78,6 +78,12 @@ export default {
 
     getChildrenLabel ({ scope, params }) {
       return scope ? 'Escopo' : params ? 'Parâmetros' : ''
+    },
+
+    toString (value) {
+      const types = ['number', 'boolean']
+
+      return types.includes(typeof value) ? String(value) : value
     }
   }
 }

--- a/ui/src/components/date-time-input/QasDateTimeInput.vue
+++ b/ui/src/components/date-time-input/QasDateTimeInput.vue
@@ -129,7 +129,7 @@ export default {
 
     updateModelValue (value) {
       this.currentValue = value
-      const valueLength = value.replace(/_/g, '').length
+      const valueLength = value?.replace?.(/_/g, '')?.length
 
       if (value === '' || valueLength === this.mask.length) {
         this.lastValue = this.useTimeOnly ? value : this.toISOString(value)

--- a/ui/src/components/date-time-input/QasDateTimeInput.vue
+++ b/ui/src/components/date-time-input/QasDateTimeInput.vue
@@ -23,6 +23,8 @@ import { date as dateFn } from '../../helpers/filters'
 export default {
   name: 'QasDateTimeInput',
 
+  inheritAttrs: false,
+
   props: {
     dateMask: {
       default: 'DD/MM/YYYY',

--- a/ui/src/components/field/QasField.vue
+++ b/ui/src/components/field/QasField.vue
@@ -34,6 +34,8 @@ export default {
     QasSignatureUploader
   },
 
+  inheritAttrs: false,
+
   props: {
     error: {
       default: '',

--- a/ui/src/components/form-generator/QasFormGenerator.vue
+++ b/ui/src/components/form-generator/QasFormGenerator.vue
@@ -121,6 +121,8 @@ export default {
         for (const fieldName of fieldsetItem.fields) {
           const field = this.fields[fieldName]
 
+          if (!field) continue
+
           Object.assign(
             fields[fieldsetKey].fields[
               field.type === 'hidden' ? 'hidden' : 'visible'

--- a/ui/src/components/input/QasInput.vue
+++ b/ui/src/components/input/QasInput.vue
@@ -10,6 +10,8 @@
 export default {
   name: 'QasInput',
 
+  inheritAttrs: false,
+
   props: {
     error: {
       type: Boolean

--- a/ui/src/components/password-input/QasPasswordInput.vue
+++ b/ui/src/components/password-input/QasPasswordInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <qas-input v-model="model" :bottom-slots="false" color="negative" v-bind="$attrs" :type="type" use-remove-error-on-type>
+  <qas-input v-model="model" :bottom-slots="false" v-bind="$attrs" :type="type" use-remove-error-on-type>
     <template #append>
       <q-icon class="cursor-pointer" :color="iconColor" :name="icon" @click="toggle" />
     </template>
@@ -26,6 +26,8 @@ export default {
   },
 
   mixins: [passwordMixin],
+
+  inheritAttrs: false,
 
   props: {
     useStrengthChecker: {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

Correção de um bug causado na versão beta.19. Esse bug se origina na retirada das divs que englobavam alguns componentes, como: `QasField`, `QasInput` e mais. 

Esse bug causava um problema em que todos os atributos eram herdados automaticamente aos componentes, sendo que, já há um `v-bind` nesses componentes com os atributos tratados.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `main`.
- [x] v3 -> a partir da branch `next`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [x] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [ ] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
