### PR TITLE
Feature/nested rows

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,8 +7,9 @@ Inclua uma pequena descrição explicando o motivo do _pull request_ e o número
 
 ## Versão do asteroid
 
-- [ ] v2 -> a partir da branch `main`.
-- [ ] v3 -> a partir da branch `next`.
+- [ ] v2 -> a partir da branch `v2`.
+- [ ] v3-beta.x -> a partir da branch `main-homolog`.
+- [ ] v3-stable -> a partir da branch `main`.
 
 ## Tipo de alteração
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ## Não publicado
 ### Adicionado
 Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitta/store-adapter` e `@bildvitta/store-module`.
+- `QasFormGenerator`: adicionado propriedade `disabled` para desativar todos os campos de uma vez.
+- `QasNestedFields`: adicionado propriedade `disableRows`com esta propriedade é possível desabilitar rows (linhas) especificas passando um array com chaves identificadoras, ou caso queira desativar todas passando um boolean "true" (isto vai remover todos os botões da linha, duplicar e excluir).
+- `QasNestedFields`: adicionado propriedade `useAdd` para controla quando vai ter seção de "adicionar" novas rows (linhas).
 
 ## 3.0.0 - 22-08-22
 ## Versão estável lançada

--- a/docs/src/examples/QasNestedFields/Basic.vue
+++ b/docs/src/examples/QasNestedFields/Basic.vue
@@ -3,7 +3,7 @@
     <div class="full-width">
       <div class="q-mt-lg text-center">
         <div>
-          <qas-nested-fields v-model="model" class="full-width" :field="nested" :fields-props="fieldsProps" :form-columns="formColumns" :row-object="rowObject" />
+          <qas-nested-fields v-model="model" class="full-width" :disabled-rows="[1]" :field="nested" :fields-props="fieldsProps" :form-columns="formColumns" :row-object="rowObject" />
         </div>
 
         <div class="q-my-lg">

--- a/docs/src/examples/QasNestedFields/Basic.vue
+++ b/docs/src/examples/QasNestedFields/Basic.vue
@@ -3,7 +3,7 @@
     <div class="full-width">
       <div class="q-mt-lg text-center">
         <div>
-          <qas-nested-fields v-model="model" class="full-width" :disabled-rows="[1]" :field="nested" :fields-props="fieldsProps" :form-columns="formColumns" :row-object="rowObject" />
+          <qas-nested-fields v-model="model" class="full-width" :field="nested" :fields-props="fieldsProps" :form-columns="formColumns" :row-object="rowObject" />
         </div>
 
         <div class="q-my-lg">

--- a/docs/src/examples/QasNestedFields/DisabledRows.vue
+++ b/docs/src/examples/QasNestedFields/DisabledRows.vue
@@ -1,0 +1,107 @@
+<template>
+  <div class="container spaced">
+    <div class="full-width">
+      <div class="q-mt-lg text-center">
+        <div>
+          <qas-nested-fields v-model="model" class="full-width" :disabled-rows="[1, 3]" :field="nested" :fields-props="fieldsProps" :form-columns="formColumns" :row-object="rowObject" />
+        </div>
+
+        <div class="q-my-lg">
+          Model: <qas-debugger :inspect="[model]" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+const nested = {
+  name: 'nested',
+  type: 'nested',
+  label: 'Meu nested',
+  children: {
+    name: {
+      name: 'name',
+      type: 'text',
+      label: 'Nome'
+    },
+    email: {
+      name: 'email',
+      type: 'email',
+      label: 'E-mail'
+    },
+    cities: {
+      name: 'cities',
+      type: 'select',
+      options: [
+        {
+          label: 'Cidade 1',
+          value: 1
+        },
+        {
+          label: 'Cidade 2',
+          value: 2
+        },
+        {
+          label: 'Cidade 3',
+          value: 3
+        }
+      ]
+    }
+  }
+}
+
+export default {
+  data () {
+    return {
+      nested: nested,
+      model: [
+        {
+          name: 'John',
+          email: 'john@teste.com',
+          cities: 1,
+          uuid: 1
+        },
+        {
+          name: 'John 2',
+          email: 'john@teste.com',
+          cities: 2,
+          uuid: 2
+        },
+        {
+          name: 'John 3',
+          email: 'john@teste.com',
+          cities: 2,
+          uuid: 3
+        }
+      ]
+    }
+  },
+
+  computed: {
+    rowObject () {
+      return {
+        name: '',
+        email: '',
+        cities: []
+      }
+    },
+
+    formColumns () {
+      return {
+        name: { col: 12 },
+        email: { col: 12 },
+        cities: { col: 12 }
+      }
+    },
+
+    fieldsProps () {
+      return {
+        name: {
+          label: 'Novo label'
+        }
+      }
+    }
+  }
+}
+</script>

--- a/docs/src/pages/components/nested-fields.md
+++ b/docs/src/pages/components/nested-fields.md
@@ -83,6 +83,7 @@ Para saber mais clique [aqui](https://v3-migration.vuejs.org/breaking-changes/li
 ## Uso
 
 <doc-example file="QasNestedFields/Basic" title="Básico" />
+<doc-example file="QasNestedFields/DisabledRows" title="Linhas desabilitadas" />
 <doc-example file="QasNestedFields/InlineActions" title="Propriedade useInlineActions" />
 <doc-example file="QasNestedFields/SlotDynamic" title="Slot field-[nome-da-chave]" />
 <doc-example file="QasNestedFields/SlotFields" title="Slot fields" />

--- a/ui/src/components/form-generator/QasFormGenerator.vue
+++ b/ui/src/components/form-generator/QasFormGenerator.vue
@@ -9,14 +9,14 @@
         <div :class="mx_classes">
           <div v-for="(field, key) in fieldsetItem.fields.visible" :key="key" :class="mx_getFieldClass(key)">
             <slot :field="field" :name="`field-${field.name}`">
-              <qas-field :disable="disabled" v-bind="fieldsProps[field.name]" :error="errors[key]" :field="field" :model-value="modelValue[field.name]" @update:model-value="updateModelValue(field.name, $event)" />
+              <qas-field :disable="disable" v-bind="fieldsProps[field.name]" :error="errors[key]" :field="field" :model-value="modelValue[field.name]" @update:model-value="updateModelValue(field.name, $event)" />
             </slot>
           </div>
         </div>
 
         <div v-for="(field, key) in fieldsetItem.fields.hidden" :key="key">
           <slot :field="field" :name="`field-${field.name}`">
-            <qas-field :disable="disabled" v-bind="fieldsProps[field.name]" :field="field" :model-value="modelValue[field.name]" @update:model-value="updateModelValue(field.name, $event)" />
+            <qas-field :disable="disable" v-bind="fieldsProps[field.name]" :field="field" :model-value="modelValue[field.name]" @update:model-value="updateModelValue(field.name, $event)" />
           </slot>
         </div>
       </div>
@@ -72,7 +72,7 @@ export default {
       }
     },
 
-    disabled: {
+    disable: {
       type: Boolean
     }
   },

--- a/ui/src/components/form-generator/QasFormGenerator.vue
+++ b/ui/src/components/form-generator/QasFormGenerator.vue
@@ -9,14 +9,14 @@
         <div :class="mx_classes">
           <div v-for="(field, key) in fieldsetItem.fields.visible" :key="key" :class="mx_getFieldClass(key)">
             <slot :field="field" :name="`field-${field.name}`">
-              <qas-field v-bind="fieldsProps[field.name]" :error="errors[key]" :field="field" :model-value="modelValue[field.name]" @update:model-value="updateModelValue(field.name, $event)" />
+              <qas-field :disable="disabled" v-bind="fieldsProps[field.name]" :error="errors[key]" :field="field" :model-value="modelValue[field.name]" @update:model-value="updateModelValue(field.name, $event)" />
             </slot>
           </div>
         </div>
 
         <div v-for="(field, key) in fieldsetItem.fields.hidden" :key="key">
           <slot :field="field" :name="`field-${field.name}`">
-            <qas-field v-bind="fieldsProps[field.name]" :field="field" :model-value="modelValue[field.name]" @update:model-value="updateModelValue(field.name, $event)" />
+            <qas-field :disable="disabled" v-bind="fieldsProps[field.name]" :field="field" :model-value="modelValue[field.name]" @update:model-value="updateModelValue(field.name, $event)" />
           </slot>
         </div>
       </div>
@@ -70,6 +70,10 @@ export default {
       validator: value => {
         return typeof value === 'boolean' || ['xs', 'sm', 'md', 'lg', 'xl'].includes(value)
       }
+    },
+
+    disabled: {
+      type: Boolean
     }
   },
 

--- a/ui/src/components/form-generator/QasFormGenerator.yml
+++ b/ui/src/components/form-generator/QasFormGenerator.yml
@@ -10,6 +10,11 @@ props:
     type: [Array, String, Object]
     examples: ["{ name: { sm: 6, md: 12 } }", "[{ sm: 6, md: 12 }]"]
 
+  disabled:
+    desc: Deixa os campos desabilitados enviando a prop "disable" para cada campo.
+    default: "false"
+    type: Boolean
+
   error:
     desc: Objeto contendo propriedades contendo a mensagem de erro.
     default: {}

--- a/ui/src/components/form-generator/QasFormGenerator.yml
+++ b/ui/src/components/form-generator/QasFormGenerator.yml
@@ -10,7 +10,7 @@ props:
     type: [Array, String, Object]
     examples: ["{ name: { sm: 6, md: 12 } }", "[{ sm: 6, md: 12 }]"]
 
-  disabled:
+  disable:
     desc: Deixa os campos desabilitados enviando a prop "disable" para cada campo.
     default: "false"
     type: Boolean

--- a/ui/src/components/nested-fields/QasNestedFields.vue
+++ b/ui/src/components/nested-fields/QasNestedFields.vue
@@ -20,7 +20,7 @@
 
               <div ref="formGenerator" class="col-12 justify-between q-col-gutter-x-md row">
                 <slot :errors="transformedErrors" :fields="children" :index="index" name="fields" :update-value="updateValuesFromInput">
-                  <qas-form-generator v-model="nested[index]" :class="formClasses" :columns="formColumns" :disabled="isDisabledRow(row)" :errors="transformedErrors[index]" :fields="children" :fields-props="fieldsProps" @update:model-value="updateValuesFromInput($event, index)">
+                  <qas-form-generator v-model="nested[index]" :class="formClasses" :columns="formColumns" :disable="isDisabledRow(row)" :errors="transformedErrors[index]" :fields="children" :fields-props="fieldsProps" @update:model-value="updateValuesFromInput($event, index)">
                     <template v-for="(slot, key) in $slots" #[key]="scope">
                       <slot v-bind="scope" :disabled="isDisabledRow(row)" :errors="transformedErrors" :index="index" :name="key" />
                     </template>

--- a/ui/src/components/nested-fields/QasNestedFields.vue
+++ b/ui/src/components/nested-fields/QasNestedFields.vue
@@ -12,22 +12,22 @@
               <div class="flex items-center justify-between q-py-xs">
                 <qas-label v-if="!useSingleLabel" :label="getRowLabel(index)" />
 
-                <div v-if="!useInlineActions" class="q-gutter-x-sm">
-                  <qas-btn v-if="useDuplicate" v-bind="buttonDuplicateProps" @click="add(row)" />
-                  <qas-btn v-if="showDestroyBtn" v-bind="buttonDestroyProps" @click="destroy(index, row)" />
+                <div v-if="hasBlockActions(row)" class="q-gutter-x-sm">
+                  <qas-btn v-if="useDuplicate" v-bind="buttonDuplicateProps" :disabled="isDisabledRow(row)" @click="add(row)" />
+                  <qas-btn v-if="showDestroyBtn" v-bind="buttonDestroyProps" :disabled="isDisabledRow(row)" @click="destroy(index, row)" />
                 </div>
               </div>
 
               <div ref="formGenerator" class="col-12 justify-between q-col-gutter-x-md row">
                 <slot :errors="transformedErrors" :fields="children" :index="index" name="fields" :update-value="updateValuesFromInput">
-                  <qas-form-generator v-model="nested[index]" :class="formClasses" :columns="formColumns" :errors="transformedErrors[index]" :fields="children" :fields-props="fieldsProps" @update:model-value="updateValuesFromInput($event, index)">
+                  <qas-form-generator v-model="nested[index]" :class="formClasses" :columns="formColumns" :disabled="isDisabledRow(row)" :errors="transformedErrors[index]" :fields="children" :fields-props="fieldsProps" @update:model-value="updateValuesFromInput($event, index)">
                     <template v-for="(slot, key) in $slots" #[key]="scope">
-                      <slot v-bind="scope" :errors="transformedErrors" :index="index" :name="key" />
+                      <slot v-bind="scope" :disabled="isDisabledRow(row)" :errors="transformedErrors" :index="index" :name="key" />
                     </template>
                   </qas-form-generator>
                 </slot>
 
-                <div v-if="useInlineActions" class="flex items-center qas-nested-fields__actions">
+                <div v-if="hasInlineActions(row)" class="flex items-center qas-nested-fields__actions">
                   <div class="col-auto">
                     <qas-btn v-if="useDuplicate" color="primary" flat icon="o_content_copy" round @click="add(row)" />
                   </div>
@@ -45,7 +45,7 @@
         </div>
       </component>
 
-      <div class="q-mt-md">
+      <div v-if="useAdd" class="q-mt-md">
         <slot :add="add" name="add-input">
           <div v-if="useInlineActions" class="cursor-pointer items-center q-col-gutter-x-md q-mt-md row" @click="add()">
             <div class="col">
@@ -125,6 +125,11 @@ export default {
       default: 'destroyed'
     },
 
+    disabledRows: {
+      type: [Array, Boolean],
+      default: false
+    },
+
     errors: {
       type: [Array, Object],
       default: () => ({})
@@ -172,6 +177,11 @@ export default {
     rowObject: {
       type: Object,
       default: () => ({})
+    },
+
+    useAdd: {
+      type: Boolean,
+      default: true
     },
 
     useAnimation: {
@@ -347,6 +357,22 @@ export default {
       }
 
       return this.fieldLabel
+    },
+
+    isDisabledRow (row) {
+      if (!this.disabledRows) return false
+
+      if (typeof this.disabledRows === 'boolean') return true
+
+      return this.disabledRows.includes(row[this.identifierItemKey])
+    },
+
+    hasBlockActions (row) {
+      return !this.useInlineActions && !this.isDisabledRow(row)
+    },
+
+    hasInlineActions (row) {
+      return this.useInlineActions && !this.isDisabledRow(row)
     }
   }
 }

--- a/ui/src/components/nested-fields/QasNestedFields.vue
+++ b/ui/src/components/nested-fields/QasNestedFields.vue
@@ -13,8 +13,8 @@
                 <qas-label v-if="!useSingleLabel" :label="getRowLabel(index)" />
 
                 <div v-if="hasBlockActions(row)" class="q-gutter-x-sm">
-                  <qas-btn v-if="useDuplicate" v-bind="buttonDuplicateProps" :disabled="isDisabledRow(row)" @click="add(row)" />
-                  <qas-btn v-if="showDestroyBtn" v-bind="buttonDestroyProps" :disabled="isDisabledRow(row)" @click="destroy(index, row)" />
+                  <qas-btn v-if="useDuplicate" v-bind="buttonDuplicateProps" @click="add(row)" />
+                  <qas-btn v-if="showDestroyBtn" v-bind="buttonDestroyProps" @click="destroy(index, row)" />
                 </div>
               </div>
 

--- a/ui/src/components/nested-fields/QasNestedFields.yml
+++ b/ui/src/components/nested-fields/QasNestedFields.yml
@@ -26,6 +26,12 @@ props:
     default: destroyed
     type: String
 
+  disabled-rows:
+    desc: Com esta propriedade é possível desabilitar rows (linhas) especificas passando um array com chaves identificadoras, ou caso queira desativar todas passando um boolean "true" (isto vai remover todos os botões da linha, duplicar e excluir).
+    default: "false"
+    type: [Array, Boolean]
+    examples: ["['my-uuid-from-row-1']", true]
+
   errors:
     desc: Propriedade de erros para mostrar nos campos gerados.
     default: {}
@@ -78,6 +84,11 @@ props:
     default: {}
     type: Object
     examples: ["{ name: '', cities: [] }"]
+
+  use-add:
+    desc: Controla quando vai ter seção de "adicionar" novas rows (linhas).
+    default: true
+    type: Boolean
 
   use-animation:
     desc: Controla a animação na hora de setar o scroll.

--- a/ui/src/components/nested-fields/QasNestedFields.yml
+++ b/ui/src/components/nested-fields/QasNestedFields.yml
@@ -184,7 +184,7 @@ slots:
         type: Number
 
       errors:
-        desc: Errors dos campos
+        desc: Erros dos campos
         type: Number
 
       'updateValue -> function(value, index)':

--- a/ui/src/components/nested-fields/QasNestedFields.yml
+++ b/ui/src/components/nested-fields/QasNestedFields.yml
@@ -175,12 +175,16 @@ slots:
   'field-[nome-da-chave]':
     desc: Repassa todos os slots e escopos do "QasFormGenerator".
     scope:
+      disabled:
+        desc: Retorna se a linha esta desabilitada
+        type: boolean
+
       index:
         desc: Index atual dos campos
         type: Number
 
       errors:
-        desc: Index atual dos campos
+        desc: Errors dos campos
         type: Number
 
       'updateValue -> function(value, index)':


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

- `QasFormGenerator`: adicionado propriedade `disabled` para desativar todos os campos de uma vez.
- `QasNestedFields`: adicionado propriedade `disableRows`com esta propriedade é possível desabilitar rows (linhas) especificas passando um array com chaves identificadoras, ou caso queira desativar todas passando um boolean "true" (isto vai remover todos os botões da linha, duplicar e excluir).
- `QasNestedFields`: adicionado propriedade `useAdd` para controla quando vai ter seção de "adicionar" novas rows (linhas).

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
