### PR TITLE
fix: Fixed QasTabsGenerator and QasActionsMenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,6 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasTabsGenerator`: Alterado type do `modelValue` para `[String, Number]` para aceitar numbers também.
 - `QasTableGenerator`: Alterado `counters[key]` para `counters[tab.value]` para funcionar o counters quando utilizar tabs como `array`.
 
-### Removido
-- `shadow.scss`: Removido arquivo de sombras que alteravam cores para deixar estilo original do quasar.
-
 ## 3.1.0-beta.2 - 06-09-22
 ### Modificado
 - [`QasBox`, `QasListItems`, `QasCard`, `QasAppBar`]: alterado cor shadow padrão de `shadow-14` para `shadow-2`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## 3.1.0-beta.3 - 14-09-22
+### Corrigido
+- `QasActionsMenu`: Alterado propriedade `use-label-on-small-screen` para `:use-label-on-small-screen="false"` para seguir o padrão.
+- `QasTabsGenerator`: Alterado type do `modelValue` para `[String, Number]` para aceitar numbers também.
+- `QasTableGenerator`: Alterado `counters[key]` para `counters[tab.value]` para funcionar o counters quando utilizar tabs como `array`.
+
+### Removido
+- `shadow.scss`: Removido arquivo de sombras que alteravam cores para deixar estilo original do quasar.
+
 ## 3.1.0-beta.2 - 06-09-22
 ### Modificado
 - [`QasBox`, `QasListItems`, `QasCard`, `QasAppBar`]: alterado cor shadow padrão de `shadow-14` para `shadow-2`.
@@ -145,7 +154,7 @@ Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitt
 ### Modificado
 - `QasNestedFields`: removido logica do camelize na computada `children` já que agora os fields já vem formatados.
 - `viewMixin`: `mx_setFields` usando helper `camelizeFieldsName` de forma recursiva para formatar os `names` dos `fields`.
-- `QasFilters`: Adicionados props `color="grey-9"` e `flat` para os <qas-btn /> do input de busca para deixar o estilo igual quando era com <q-btn>.
+- `QasFilters`: Adicionados props `color="grey-9"` e `flat` para os <qas-btn /> do input de busca para deixar o estilo igual quando era com <q-btn />.
 
 ## [3.0.0-beta.12] - 02-06-2022
 ### Modificado

--- a/docs/src/examples/QasTabsGenerator/TabsArray.vue
+++ b/docs/src/examples/QasTabsGenerator/TabsArray.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container q-py-lg">
-    <qas-tabs-generator v-model="model" :tabs="tabs" />
+    <qas-tabs-generator v-model="model" :counters="{ 'tab-1': 2 }" :tabs="tabs" />
 
     <div class="q-my-lg">
       model: {{ model }}

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <qas-btn class="qas-actions-menu" color="primary" :icon="icon" :label="label" outline padding="md" use-label-on-small-screen>
+  <qas-btn class="qas-actions-menu" color="primary" :icon="icon" :label="label" outline padding="md" :use-label-on-small-screen="false">
     <q-menu class="qas-actions-menu__menu">
       <q-list class="qas-actions-menu__list" separator>
         <slot v-for="(item, key) in list" :item="item" :name="key">

--- a/ui/src/components/tabs-generator/QasTabsGenerator.vue
+++ b/ui/src/components/tabs-generator/QasTabsGenerator.vue
@@ -3,7 +3,7 @@
     <slot v-for="(tab, key) in formattedTabs" :item="tab" :name="`tab-${tab.value}`">
       <q-tab :key="key" v-bind="tab" :class="tabClass" :label="tab.label" :name="tab.value">
         <slot :item="tab" :name="`tab-after-${tab.value}`">
-          <q-badge v-if="counters[key]" :label="counters[key]" v-bind="defaultCounterProps" />
+          <q-badge v-if="counters[tab.value]" :label="counters[tab.value]" v-bind="defaultCounterProps" />
         </slot>
       </q-tab>
     </slot>
@@ -39,7 +39,7 @@ export default {
 
     modelValue: {
       default: '',
-      type: String
+      type: [String, Number]
     },
 
     tabClass: {

--- a/ui/src/components/tabs-generator/QasTabsGenerator.yml
+++ b/ui/src/components/tabs-generator/QasTabsGenerator.yml
@@ -30,7 +30,8 @@ props:
 
   model-value:
     desc: Model do componente, controla qual é a tab atual selecionada.
-    type: String
+    type: [String, Number]
+    model: true
 
   tab-class:
     desc: Classe do QTab


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## 3.1.0-beta.3 - 14-09-22
### Corrigido
- `QasActionsMenu`: Alterado propriedade `use-label-on-small-screen` para `:use-label-on-small-screen="false"` para seguir o padrão.
- `QasTabsGenerator`: Alterado type do `modelValue` para `[String, Number]` para aceitar numbers também.
- `QasTableGenerator`: Alterado `counters[key]` para `counters[tab.value]` para funcionar o counters quando utilizar tabs como `array`.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
