### PR TITLE
fix(QasNestedFields): :bug: fixed bug on destroy row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## 3.1.0 - 19-09-22
+## [3.1.1-beta.0] - 23-09-22
+### Corrigido
+- `QasNestedFields`: Corrigido botão de excluir ao adicionar um novo item sem salvar ele não removia o item independente da prop useRemoveOnDestroy.
+
+## [3.1.0] - 19-09-22
 ### Adicionado
 Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitta/store-adapter` e `@bildvitta/store-module`.
 - `QasFormGenerator`: adicionado propriedade `disabled` para desativar todos os campos de uma vez.
@@ -32,17 +36,17 @@ Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitt
 ### Removido
 - `shadow.scss`: Removido arquivo de sombras que alteravam cores para deixar estilo original do quasar.
 
-## 3.1.0-beta.4 - 15-09-22
+## [3.1.0-beta.4] - 15-09-22
 ### Corrigido
 - `QasNestedFields`: Adicionado prop `deep: true` no watch no `modelValue` para resolver bug quando usa um custom slot, ou altera o v-model e perde a reatividade.
 
-## 3.1.0-beta.3 - 14-09-22
+## [3.1.0-beta.3] - 14-09-22
 ### Corrigido
 - `QasActionsMenu`: Alterado propriedade `use-label-on-small-screen` para `:use-label-on-small-screen="false"` para seguir o padrão.
 - `QasTabsGenerator`: Alterado type do `modelValue` para `[String, Number]` para aceitar numbers também.
 - `QasTableGenerator`: Alterado `counters[key]` para `counters[tab.value]` para funcionar o counters quando utilizar tabs como `array`.
 
-## 3.1.0-beta.2 - 06-09-22
+## [3.1.0-beta.2] - 06-09-22
 ### Modificado
 - [`QasBox`, `QasListItems`, `QasCard`, `QasAppBar`]: alterado cor shadow padrão de `shadow-14` para `shadow-2`.
 - `QasListItems`: alterado como usa shadow para resolver problema de borda que cortava o shadow, agora o componente usa o `QasBox` e removido prop `bordered`.
@@ -50,12 +54,12 @@ Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitt
 ### Removido
 - `shadow.scss`: Removido arquivo de sombras que alteravam cores para deixar estilo original do quasar.
 
-## 3.1.0-beta.1 - 02-09-22
+## [3.1.0-beta.1] - 02-09-22
 ### Adicionado
 - `QasFilters`: adicionado data-cy no input, dropdown e botões
 - `QasGridGenerator`: adicionado data-cy nos campos e resultados
 
-## 3.1.0-beta.0 - 02-09-22
+## [3.1.0-beta.0] - 02-09-22
 ### Adicionado
 Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitta/store-adapter` e `@bildvitta/store-module`.
 - `QasFormGenerator`: adicionado propriedade `disabled` para desativar todos os campos de uma vez.
@@ -286,6 +290,13 @@ Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitt
 ### Corrigido
 - Corrigido `QasBtn`, quando usa a prop `hideLabelOnSmallScreen` e utiliza o slot default, quando a tela está em tamanho pequeno, o botão remove o slot default, o problema disto é que se usar com um `QMenu` dentro do botão, o `QMenu` não é chamado pois não existe mais slot default.
 
+[3.1.1-beta.0]: https://github.com/bildvitta/asteroid/compare/3.1.0...3.1.1-beta.0?expand=1
+[3.1.0]: https://github.com/bildvitta/asteroid/compare/3.0.0...3.1.0?expand=1
+[3.1.0-beta.4]: https://github.com/bildvitta/asteroid/compare/3.1.0-beta.3...3.1.0-beta.4?expand=1
+[3.1.0-beta.3]: https://github.com/bildvitta/asteroid/compare/3.1.0-beta.2...3.1.0-beta.3?expand=1
+[3.1.0-beta.2]: https://github.com/bildvitta/asteroid/compare/3.1.0-beta.1...3.1.0-beta.2?expand=1
+[3.1.0-beta.1]: https://github.com/bildvitta/asteroid/compare/3.1.0-beta.0...3.1.0-beta.1?expand=1
+[3.1.0-beta.0]: https://github.com/bildvitta/asteroid/compare/v3.0.0...3.1.0-beta.0?expand=1
 [3.0.0]: https://github.com/bildvitta/asteroid/compare/v3.0.0-beta.20...v3.0.0?expand=1
 [3.0.0-beta.20]: https://github.com/bildvitta/asteroid/compare/v3.0.0-beta.19...v3.0.0-beta.20?expand=1
 [3.0.0-beta.19]: https://github.com/bildvitta/asteroid/compare/v3.0.0-beta.18...v3.0.0-beta.19?expand=1

--- a/docs/src/examples/QasNestedFields/Basic.vue
+++ b/docs/src/examples/QasNestedFields/Basic.vue
@@ -59,12 +59,14 @@ export default {
         {
           name: 'John',
           email: 'john@teste.com',
-          cities: 1
+          cities: 1,
+          uuid: 'uuid-1'
         },
         {
           name: 'John 2',
           email: 'john@teste.com',
-          cities: 2
+          cities: 2,
+          uuid: 'uuid-2'
         }
       ]
     }

--- a/docs/src/pages/components/nested-fields.md
+++ b/docs/src/pages/components/nested-fields.md
@@ -2,7 +2,7 @@
 title: QasNestedFields
 ---
 
-Componente para gerar dinâmicamente campos nested.
+Componente para gerar dinamicamente campos nested.
 
 <doc-api file="nested-fields/QasNestedFields" name="QasNestedFields" />
 

--- a/ui/src/components/nested-fields/QasNestedFields.vue
+++ b/ui/src/components/nested-fields/QasNestedFields.vue
@@ -320,8 +320,16 @@ export default {
       return this.$emit('update:modelValue', value || this.nested)
     },
 
+    /*
+    * Se o item que for removido não tiver o identificador (uuid por ex) e "useRemoveOnDestroy" for "false"
+    * ou "useRemoveOnDestroy" for "true" removemos o item do array, senão adicionamos a flag [destroyKey]
+    * no item referente do array.
+    *
+    * Ex: ao adicionar um item e remover sem salvar, mesmo que useRemoveOnDestroy for false ele será removido
+    * ao invés de adicionar a flag [destroyKey]
+    */
     destroy (index, row) {
-      !row[this.identifierItemKey] && this.useRemoveOnDestroy
+      (!row[this.identifierItemKey] && !this.useRemoveOnDestroy) || this.useRemoveOnDestroy
         ? this.nested.splice(index, 1)
         : this.nested.splice(index, 1, { [this.destroyKey]: true, ...row })
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## [3.1.1-beta.0] - 23-09-22
### Corrigido
- `QasNestedFields`: Corrigido botão de excluir ao adicionar um novo item sem salvar ele não removia o item independente da prop useRemoveOnDestroy.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
