### PR TITLE
fix: :bug:(QasAppBar) added no-wrap class in user-menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasAppBar`: adicionado classe `no-wrap` para não quebrar o menu de usuário.
+
 ## [3.2.0-beta.2] - 18-10-2022
 ## BREAKING CHANGES
 - `QasAppMenu`: removido logo do modular no menu.

--- a/ui/src/components/app-bar/QasAppBar.vue
+++ b/ui/src/components/app-bar/QasAppBar.vue
@@ -22,10 +22,10 @@
       <div class="items-center no-wrap q-gutter-md row">
         <slot name="tools" />
 
-        <div v-if="hasUser" class="cursor-pointer items-center qas-app-bar__user-content rounded-borders row text-grey-9" :title="userName">
+        <div v-if="hasUser" class="cursor-pointer items-center no-wrap qas-app-bar__user-content rounded-borders row text-grey-9" :title="userName">
           <qas-avatar color="white" dark :image="user.photo" rounded size="42px" text-color="primary" :title="userName" />
 
-          <div class="q-ml-md qas-app-bar__user-data qs-lh-lg">
+          <div class="q-ml-md q-pr-sm qas-app-bar__user-data qs-lh-lg">
             <div class="ellipsis q-mb-xs qas-app-bar__user-name">{{ userName }}</div>
             <div class="ellipsis qas-app-bar__user-email">{{ user.email }}</div>
           </div>


### PR DESCRIPTION
## Não publicado
### Corrigido
- `QasAppBar`: adicionado classe `no-wrap` para não quebrar o menu de usuário.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
