### PR TITLE
Feature/main homolog/v3.3.0 beta.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,7 +25,8 @@
     "QasListView",
     "QasDateTimeInput",
     "QasNestedFields",
-    "QasTreeGenerator"
+    "QasTreeGenerator",
+    "QasGallery"
   ],
   "cSpell.words": [
     "Nunito"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ### Adicionado
 - `QasDialog`: adicionado nova propriedade `useFullMaxWidth` para utilizar `100% do maxWidth`.
 - `QasGallery`: adicionado funcionalidade para deletar imagem a partir da galeria.
+- `QasGallery`: adicionado propriedade `customId` usada para deletar a imagem da galeria.
+- `QasGallery`: adicionado propriedade `dialogProps` usada para configurar dialog de deleção.
+- `QasGallery`: adicionado propriedade `entity` usada para deletar a imagem da galeria.
+- `QasGallery`: adicionado propriedade `modelValue` usada para controlar as imagens.
+- `QasGallery`: adicionado propriedade `modelKey` usada para deletar a imagem da galeria.
+- `QasGallery`: adicionado propriedade `url` usada para deletar a imagem da galeria.
+- `QasGallery`: adicionado propriedade `entity` usada para deletar a imagem da galeria.
 - `QasGallery`: adicionado evento `@update:modelValue` para atualização do model.
 - `QasGallery`: adicionado evento `@delete-success` que é disparado quando acontece uma deleção com sucesso.
 - `QasGallery`: adicionado evento `@delete-error` que é a deleção falha.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,35 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+## BREAKING CHANGES
+- `QasGallery`: propriedade `images` substituída para `modelValue` uma vez que agora é possível excluir itens da galeria.
+- `QasGallery`: propriedade `height` removida para padronização.
+- `QasGallery`: propriedade `carouselNextIcon` removida para padronização.
+- `QasGallery`: propriedade `carouselPreviousIcon` removida para padronização.
+- `QasGallery`: propriedade `loadSize` removida, agora o tamanho de carregamento de imagens é relativo ao `initialSize`.
+
+### Adicionado
+- `QasDialog`: adicionado nova propriedade `useFullMaxWidth` para utilizar `100% do maxWidth`.
+- `QasGallery`: adicionado funcionalidade para deletar imagem a partir da galeria.
+- `QasGallery`: adicionado evento `@update:modelValue` para atualização do model.
+- `QasGallery`: adicionado evento `@delete-success` que é disparado quando acontece uma deleção com sucesso.
+- `QasGallery`: adicionado evento `@delete-error` que é a deleção falha.
+
+### Modificado
+- `QasGallery`: alterado estilos/comportamento quando é imagem única do componente.
+- `QasGallery`: refatoração de código.
+
+### Corrigido
+- `QasGallery`: resolvido pequeno problema referente a tamanhos
+
+### Removido
+- `QasGallery`: propriedade `images` substituída para `modelValue` uma vez que agora é possível excluir itens da galeria.
+- `QasGallery`: propriedade `height` removida para padronização.
+- `QasGallery`: propriedade `carouselNextIcon` removida para padronização.
+- `QasGallery`: propriedade `carouselPreviousIcon` removida para padronização.
+- `QasGallery`: propriedade `loadSize` removida, agora o tamanho de carregamento de imagens é relativo ao `initialSize`.
+
 ## [3.2.0] - 21-10-2022
 ## BREAKING CHANGES
 - `QasAppMenu`: removido logo do modular no menu.

--- a/docs/src/examples/QasGallery/Basic.vue
+++ b/docs/src/examples/QasGallery/Basic.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container spaced">
     <div>
-      <qas-gallery :images="images" :initial-size="4" />
+      <qas-gallery v-model="images" />
     </div>
   </div>
 </template>
@@ -10,13 +10,7 @@
 export default {
   data () {
     return {
-      model: ''
-    }
-  },
-
-  computed: {
-    images () {
-      return [
+      images: [
         'https://via.placeholder.com/200x300/ff0000/969696',
         'https://via.placeholder.com/200x300/09ff00/969696',
         'https://via.placeholder.com/200x300/0044ff/969696',
@@ -29,26 +23,6 @@ export default {
         'https://via.placeholder.com/200x300/ff0000/969696',
         'https://via.placeholder.com/200x300/09ff00/969696',
         'https://via.placeholder.com/200x300/0044ff/969696'
-      ]
-    },
-
-    images2 () {
-      return [
-        {
-          name: 'Imagem vermelha',
-          url: 'https://via.placeholder.com/200x300/ff0000/969696',
-          uuid: 'imagem-vermelha'
-        },
-        {
-          name: 'Imagem verde',
-          url: 'https://via.placeholder.com/200x300/09ff00/969696',
-          uuid: 'imagem-verde'
-        },
-        {
-          name: 'Imagem azul',
-          url: 'https://via.placeholder.com/200x300/0044ff/969696',
-          uuid: 'imagem-azul'
-        }
       ]
     }
   }

--- a/docs/src/examples/QasGallery/Basic.vue
+++ b/docs/src/examples/QasGallery/Basic.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container spaced">
     <div>
-      <qas-gallery :images="images" />
+      <qas-gallery :images="images" :initial-size="4" />
     </div>
   </div>
 </template>
@@ -29,6 +29,26 @@ export default {
         'https://via.placeholder.com/200x300/ff0000/969696',
         'https://via.placeholder.com/200x300/09ff00/969696',
         'https://via.placeholder.com/200x300/0044ff/969696'
+      ]
+    },
+
+    images2 () {
+      return [
+        {
+          name: 'Imagem vermelha',
+          url: 'https://via.placeholder.com/200x300/ff0000/969696',
+          uuid: 'imagem-vermelha'
+        },
+        {
+          name: 'Imagem verde',
+          url: 'https://via.placeholder.com/200x300/09ff00/969696',
+          uuid: 'imagem-verde'
+        },
+        {
+          name: 'Imagem azul',
+          url: 'https://via.placeholder.com/200x300/0044ff/969696',
+          uuid: 'imagem-azul'
+        }
       ]
     }
   }

--- a/docs/src/examples/QasGallery/ObjectImages.vue
+++ b/docs/src/examples/QasGallery/ObjectImages.vue
@@ -1,0 +1,107 @@
+<template>
+  <div class="container spaced">
+    <div>
+      <qas-gallery v-model="images" use-delete />
+      <pre>{{ images }}</pre>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      model: '',
+      images: [
+        {
+          name: 'Imagem vermelha',
+          url: 'https://via.placeholder.com/200x300/ff0000/969696',
+          uuid: 'imagem-vermelha'
+        },
+        {
+          name: 'Imagem verde',
+          url: 'https://via.placeholder.com/200x300/09ff00/969696',
+          uuid: 'imagem-verde'
+        },
+        {
+          name: 'Imagem azul',
+          url: 'https://via.placeholder.com/200x300/0044ff/969696',
+          uuid: 'imagem-azul'
+        },
+        {
+          name: 'Imagem vermelha 2',
+          url: 'https://via.placeholder.com/200x300/ff0000/969696',
+          uuid: 'imagem-vermelha-2'
+        },
+        {
+          name: 'Imagem vermelha 3',
+          url: 'https://via.placeholder.com/200x300/ff0000/969696',
+          uuid: 'imagem-vermelha-3'
+        },
+        {
+          name: 'Imagem verde 2',
+          url: 'https://via.placeholder.com/200x300/09ff00/969696',
+          uuid: 'imagem-verde-2'
+        },
+        {
+          name: 'Imagem azul 2',
+          url: 'https://via.placeholder.com/200x300/0044ff/969696',
+          uuid: 'imagem-azul-2'
+        },
+        {
+          name: 'Imagem vermelha 4',
+          url: 'https://via.placeholder.com/200x300/ff0000/969696',
+          uuid: 'imagem-vermelha-4'
+        }
+      ]
+    }
+  },
+
+  computed: {
+    images2 () {
+      return [
+        {
+          name: 'Imagem vermelha',
+          url: 'https://via.placeholder.com/200x300/ff0000/969696',
+          uuid: 'imagem-vermelha'
+        },
+        {
+          name: 'Imagem verde',
+          url: 'https://via.placeholder.com/200x300/09ff00/969696',
+          uuid: 'imagem-verde'
+        },
+        {
+          name: 'Imagem azul',
+          url: 'https://via.placeholder.com/200x300/0044ff/969696',
+          uuid: 'imagem-azul'
+        },
+        {
+          name: 'Imagem vermelha 2',
+          url: 'https://via.placeholder.com/200x300/ff0000/969696',
+          uuid: 'imagem-vermelha-2'
+        },
+        {
+          name: 'Imagem vermelha 3',
+          url: 'https://via.placeholder.com/200x300/ff0000/969696',
+          uuid: 'imagem-vermelha-3'
+        },
+        {
+          name: 'Imagem verde 2',
+          url: 'https://via.placeholder.com/200x300/09ff00/969696',
+          uuid: 'imagem-verde-2'
+        },
+        {
+          name: 'Imagem azul 2',
+          url: 'https://via.placeholder.com/200x300/0044ff/969696',
+          uuid: 'imagem-azul-2'
+        },
+        {
+          name: 'Imagem vermelha 4',
+          url: 'https://via.placeholder.com/200x300/ff0000/969696',
+          uuid: 'imagem-vermelha-4'
+        }
+      ]
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QasGallery/ObjectImages.vue
+++ b/docs/src/examples/QasGallery/ObjectImages.vue
@@ -1,8 +1,7 @@
 <template>
   <div class="container spaced">
     <div>
-      <qas-gallery v-model="images" use-delete />
-      <pre>{{ images }}</pre>
+      <qas-gallery v-model="images" custom-id="31362c39-2cb5-4fe2-982a-c270f88d2462" entity="users" model-key="photos" use-destroy />
     </div>
   </div>
 </template>
@@ -11,94 +10,54 @@
 export default {
   data () {
     return {
-      model: '',
       images: [
         {
           name: 'Imagem vermelha',
           url: 'https://via.placeholder.com/200x300/ff0000/969696',
-          uuid: 'imagem-vermelha'
+          uuid: 'imagem-vermelha',
+          destroyable: true
         },
         {
           name: 'Imagem verde',
           url: 'https://via.placeholder.com/200x300/09ff00/969696',
-          uuid: 'imagem-verde'
+          uuid: 'imagem-verde',
+          destroyable: true
         },
         {
           name: 'Imagem azul',
           url: 'https://via.placeholder.com/200x300/0044ff/969696',
-          uuid: 'imagem-azul'
+          uuid: 'imagem-azul',
+          destroyable: false
         },
         {
           name: 'Imagem vermelha 2',
           url: 'https://via.placeholder.com/200x300/ff0000/969696',
-          uuid: 'imagem-vermelha-2'
+          uuid: 'imagem-vermelha-2',
+          destroyable: true
         },
         {
           name: 'Imagem vermelha 3',
           url: 'https://via.placeholder.com/200x300/ff0000/969696',
-          uuid: 'imagem-vermelha-3'
+          uuid: 'imagem-vermelha-3',
+          destroyable: true
         },
         {
           name: 'Imagem verde 2',
           url: 'https://via.placeholder.com/200x300/09ff00/969696',
-          uuid: 'imagem-verde-2'
+          uuid: 'imagem-verde-2',
+          destroyable: true
         },
         {
           name: 'Imagem azul 2',
           url: 'https://via.placeholder.com/200x300/0044ff/969696',
-          uuid: 'imagem-azul-2'
+          uuid: 'imagem-azul-2',
+          destroyable: true
         },
         {
           name: 'Imagem vermelha 4',
           url: 'https://via.placeholder.com/200x300/ff0000/969696',
-          uuid: 'imagem-vermelha-4'
-        }
-      ]
-    }
-  },
-
-  computed: {
-    images2 () {
-      return [
-        {
-          name: 'Imagem vermelha',
-          url: 'https://via.placeholder.com/200x300/ff0000/969696',
-          uuid: 'imagem-vermelha'
-        },
-        {
-          name: 'Imagem verde',
-          url: 'https://via.placeholder.com/200x300/09ff00/969696',
-          uuid: 'imagem-verde'
-        },
-        {
-          name: 'Imagem azul',
-          url: 'https://via.placeholder.com/200x300/0044ff/969696',
-          uuid: 'imagem-azul'
-        },
-        {
-          name: 'Imagem vermelha 2',
-          url: 'https://via.placeholder.com/200x300/ff0000/969696',
-          uuid: 'imagem-vermelha-2'
-        },
-        {
-          name: 'Imagem vermelha 3',
-          url: 'https://via.placeholder.com/200x300/ff0000/969696',
-          uuid: 'imagem-vermelha-3'
-        },
-        {
-          name: 'Imagem verde 2',
-          url: 'https://via.placeholder.com/200x300/09ff00/969696',
-          uuid: 'imagem-verde-2'
-        },
-        {
-          name: 'Imagem azul 2',
-          url: 'https://via.placeholder.com/200x300/0044ff/969696',
-          uuid: 'imagem-azul-2'
-        },
-        {
-          name: 'Imagem vermelha 4',
-          url: 'https://via.placeholder.com/200x300/ff0000/969696',
-          uuid: 'imagem-vermelha-4'
+          uuid: 'imagem-vermelha-4',
+          destroyable: true
         }
       ]
     }

--- a/docs/src/pages/components/gallery.md
+++ b/docs/src/pages/components/gallery.md
@@ -8,8 +8,4 @@ Componente para galeria, mostrando images dentro de um "QasDialog" ao clicar nel
 
 ## Uso
 
-:::tip
-Componente implementa o `QasBox` repassando todas propriedades.
-:::
-
 <doc-example file="QasGallery/Basic" title="Básico" />

--- a/docs/src/pages/components/gallery.md
+++ b/docs/src/pages/components/gallery.md
@@ -9,3 +9,4 @@ Componente para galeria, mostrando images dentro de um "QasDialog" ao clicar nel
 ## Uso
 
 <doc-example file="QasGallery/Basic" title="Básico" />
+<doc-example file="QasGallery/ObjectImages" title="Imagens sendo array de objeto" />

--- a/docs/src/pages/components/gallery.md
+++ b/docs/src/pages/components/gallery.md
@@ -4,6 +4,15 @@ title: QasGallery
 
 Componente para galeria, mostrando images dentro de um "QasDialog" ao clicar nelas.
 
+:::warning
+Este componente depende do `Vuex` ou `Pinia`, utiliza módulos com actions. Por exemplo, para você conseguir remover uma imagem da galeria, você precisa ter:
+- action: update.
+
+Hoje Utilizamos 2 bibliotecas com propósitos diferentes que são compatíveis com o asteroid para lidar com o Vuex, elas são:
+[VuexStoreModule](https://github.com/bildvitta/vuex-store-module), [VuexOffline](https://github.com/bildvitta/vuex-offline) e [StoreModule](https://github.com/bildvitta/store-module).
+:::
+
+
 <doc-api file="gallery/QasGallery" name="QasGallery" />
 
 ## Uso
@@ -11,6 +20,8 @@ Componente para galeria, mostrando images dentro de um "QasDialog" ao clicar nel
 <doc-example file="QasGallery/Basic" title="Básico" />
 
 :::tip
+Quando fazemos uma remoção de imagem de um model, `users` por exemplo, estamos na verdade **editando** ele, então é utilizado a action `update`.
+
 Para conseguir **remover** um item você precisa configurar as seguintes propriedades:
 
 ```

--- a/docs/src/pages/components/gallery.md
+++ b/docs/src/pages/components/gallery.md
@@ -9,4 +9,15 @@ Componente para galeria, mostrando images dentro de um "QasDialog" ao clicar nel
 ## Uso
 
 <doc-example file="QasGallery/Basic" title="Básico" />
-<doc-example file="QasGallery/ObjectImages" title="Imagens sendo array de objeto" />
+
+:::tip
+Para conseguir **remover** um item você precisa configurar as seguintes propriedades:
+
+```
+- custom-id: referente ao model, ex: users/:id, e não ao id da imagem (não obrigatória);
+- entity: referente ao model, ex: "users" (obrigatória);
+- url: referente ao endpoint que a action "update" irá executar (não obrigatória);
+- model-key: referente ao campo que está querendo atualizar, ex: "photos" (obrigatória);
+```
+:::
+<doc-example file="QasGallery/ObjectImages" title="Imagens com nome e opção de remoção" />

--- a/ui/src/components/checkbox-group/QasCheckboxGroup.yml
+++ b/ui/src/components/checkbox-group/QasCheckboxGroup.yml
@@ -21,11 +21,11 @@ props:
     default: []
     type: Array
 
-
 events:
   '@update:model-value -> function(value)':
     desc: Dispara quando o model-value altera, também usado para v-model.
     params:
       value:
         desc: Novo valor do model.
-        type: []
+        default: []
+        type: Array

--- a/ui/src/components/dialog/QasDialog.vue
+++ b/ui/src/components/dialog/QasDialog.vue
@@ -68,6 +68,11 @@ export default {
       type: Object
     },
 
+    width: {
+      default: '',
+      type: String
+    },
+
     maxWidth: {
       default: '',
       type: String
@@ -104,6 +109,10 @@ export default {
       type: Boolean
     },
 
+    useFullMaxWidth: {
+      type: Boolean
+    },
+
     useValidationAllAtOnce: {
       type: Boolean
     }
@@ -133,6 +142,7 @@ export default {
 
     style () {
       return {
+        ...(this.useFullMaxWidth && { width: '100%' }),
         maxWidth: this.maxWidth || (this.$qas.screen.isSmall ? '' : '600px'),
         minWidth: this.minWidth || (this.$qas.screen.isSmall ? '' : '400px')
       }

--- a/ui/src/components/dialog/QasDialog.yml
+++ b/ui/src/components/dialog/QasDialog.yml
@@ -60,6 +60,10 @@ props:
     desc: Define se a tag onde fica a descrição no dialog vai ser um "<q-form />" ou "<div />".
     type: Boolean
 
+  use-full-max-width:
+    desc: propriedade para utilizar `100% do maxWidth`useFullMaxWidth.
+    type: Boolean
+
   use-validation-at-once:
     desc: Valida todos os campos de uma única vez, ao invés de ser um por vez (que é o padrão).
     type: Boolean

--- a/ui/src/components/gallery/QasGallery.vue
+++ b/ui/src/components/gallery/QasGallery.vue
@@ -2,10 +2,18 @@
 <template>
   <div class="qas-gallery">
     <div class="q-col-gutter-md row">
-      <div v-for="(image, index) in initialImages()" :key="index" :class="galleryColumnsClasses" :data-cy="`image-${index}`">
+      <div v-for="(image, index) in getInitialImages()" :key="index" :class="galleryColumnsClasses" :data-cy="`gallery-image-${index}`">
         <div class="q-pa-md rounded-borders shadow-2">
-          <div v-if="image.name" class="ellipsis q-mb-xs qas-gallery__name text-grey-9">
-            {{ image.name }}
+          <div class="flat items-center justify-between no-wrap q-mb-xs row text-grey-9">
+            <div v-if="image.name" class="ellipsis q-mr-xs qas-gallery__name">
+              {{ image.name }}
+            </div>
+
+            <div v-if="useDelete">
+              <qas-btn color="grey-9" dense flat round size="sm" @click="onDestroy(image, index)">
+                <q-icon name="o_delete" size="xs" />
+              </qas-btn>
+            </div>
           </div>
 
           <q-img class="cursor-pointer rounded-borders" height="150px" :src="image.url" @click="toggleCarouselDialog(index)" @error="onError(image.url)" />
@@ -14,7 +22,7 @@
 
       <slot>
         <div v-if="!hideShowMore" class="full-width text-center">
-          <qas-btn color="primary" data-cy="btn-show-more" flat :label="showMoreLabel" @click="showMore" />
+          <qas-btn color="primary" data-cy="gallery-btn-show-more" flat :label="showMoreLabel" @click="showMore" />
         </div>
       </slot>
 
@@ -26,8 +34,8 @@
         </template>
 
         <template #description>
-          <q-carousel v-model="imageIndex" animated :arrows="!$qas.screen.isSmall" control-text-color="primary" data-cy="carousel" :fullscreen="$qas.screen.isSmall" :height="carouselImageHeight" :next-icon="carouselNextIcon" :prev-icon="carouselPreviousIcon" swipeable :thumbnails="showThumbnails">
-            <q-carousel-slide v-for="(image, index) in normalizedImages" :key="index" class="bg-no-repeat bg-size-contain" :data-cy="`carousel-slide-${index}`" :img-src="image.url" :name="index">
+          <q-carousel v-model="imageIndex" animated :arrows="!$qas.screen.isSmall" control-text-color="primary" data-cy="gallery-carousel" :fullscreen="$qas.screen.isSmall" :height="carouselImageHeight" :next-icon="carouselNextIcon" :prev-icon="carouselPreviousIcon" swipeable :thumbnails="showThumbnails">
+            <q-carousel-slide v-for="(image, index) in normalizedImages" :key="index" class="bg-no-repeat bg-size-contain" :data-cy="`gallery-carousel-slide-${index}`" :img-src="image.url" :name="index">
               <div v-if="$qas.screen.isSmall" class="full-width justify-end row">
                 <qas-btn dense flat icon="o_close" @click="toggleCarouselDialog" />
               </div>
@@ -90,8 +98,19 @@ export default {
 
     useLoadAll: {
       type: Boolean
+    },
+
+    useDelete: {
+      type: Boolean
+    },
+
+    modelValue: {
+      type: Array,
+      default: () => []
     }
   },
+
+  emits: ['update:modelValue'],
 
   data () {
     return {
@@ -138,7 +157,7 @@ export default {
     },
 
     clonedImages () {
-      return extend(true, [], this.images)
+      return extend(true, [], this.modelValue)
     }
   },
 
@@ -161,10 +180,16 @@ export default {
       }
     },
 
-    initialImages () {
+    getInitialImages () {
       return this.useLoadAll
         ? this.normalizedImages
         : this.normalizedImages.slice(0, this.displayedImages)
+    },
+
+    onDestroy (image, index) {
+      this.normalizedImages.splice(index, 1)
+
+      this.$emit('update:modelValue', this.normalizedImages)
     }
   }
 }
@@ -173,7 +198,7 @@ export default {
 <style lang="scss">
 .qas-gallery {
   &__name {
-    font-size: 16px;
+    font-size: 14px;
     font-weight: 600;
   }
 }

--- a/ui/src/components/gallery/QasGallery.vue
+++ b/ui/src/components/gallery/QasGallery.vue
@@ -1,15 +1,19 @@
 
 <template>
-  <qas-box class="gallery">
+  <div>
     <div class="q-col-gutter-md row">
       <div v-for="(image, index) in initialImages()" :key="index" :class="galleryColumnsClasses">
-        <q-img class="cursor-pointer rounded-borders" :height="imageHeight" :src="image" @click="toggleCarouselDialog(index)" @error="onError(image)" />
+        <div class="q-pa-md rounded-borders shadow-2">
+          <q-img class="cursor-pointer rounded-borders" :height="imageHeight" :src="image" @click="toggleCarouselDialog(index)" @error="onError(image)" />
+        </div>
       </div>
+
       <slot>
         <div v-if="!hideShowMore" class="full-width text-center">
-          <qas-btn class="text-weight-bolder" color="primary" flat @click="showMore">{{ showMoreLabel }}</qas-btn>
+          <qas-btn color="primary" flat :label="showMoreLabel" @click="showMore" />
         </div>
       </slot>
+
       <qas-dialog v-model="carouselDialog" :cancel="false" class="q-pa-xl" min-width="1100px" :ok="false" :persistent="false">
         <template #header>
           <div class="text-right">
@@ -27,12 +31,20 @@
         </template>
       </qas-dialog>
     </div>
-  </qas-box>
+  </div>
 </template>
 
 <script>
+import QasBtn from '../btn/QasBtn.vue'
+import QasDialog from '../dialog/QasDialog.vue'
+
 export default {
   name: 'QasGallery',
+
+  components: {
+    QasBtn,
+    QasDialog
+  },
 
   props: {
     carouselNextIcon: {
@@ -52,17 +64,17 @@ export default {
 
     initialSize: {
       type: Number,
-      default: 6
+      default: 4,
+      validator: value => {
+        const acceptableValues = [1, 2, 3, 4, 6, 12]
+
+        return acceptableValues.includes(value)
+      }
     },
 
     images: {
       type: Array,
       default: () => []
-    },
-
-    loadSize: {
-      type: Number,
-      default: 6
     },
 
     showMoreLabel: {
@@ -94,9 +106,12 @@ export default {
     },
 
     galleryColumnsClasses () {
-      if (this.isSingleImage) return 'col-12'
+      if (this.isSingleImage) return 'col-3'
 
-      return this.$qas.screen.isSmall ? 'col-6' : 'col-2'
+      const size = 12 / this.initialSize
+      const col = `col-${size}`
+
+      return this.$qas.screen.isSmall ? 'col-12' : col
     },
 
     hideShowMore () {
@@ -132,7 +147,7 @@ export default {
     },
 
     showMore () {
-      this.displayedImages += this.loadSize
+      this.displayedImages += this.displayedImages
     },
 
     onError (error) {

--- a/ui/src/components/gallery/QasGallery.yml
+++ b/ui/src/components/gallery/QasGallery.yml
@@ -3,7 +3,6 @@ type: component
 mixins:
   - '@bildvitta/quasar-ui-asteroid/dist/api/QasBox.json'
 
-
 meta:
   desc: Componente para galeria, mostrando images dentro de um "QasDialog" ao clicar nelas.
 
@@ -29,11 +28,6 @@ props:
 
   initial-size:
     desc: Quantidade de imagens iniciais.
-    default: 6
-    type: Number
-
-  load-size:
-    desc: Quantidade de fotos carregadas por vez.
     default: 6
     type: Number
 

--- a/ui/src/components/gallery/QasGallery.yml
+++ b/ui/src/components/gallery/QasGallery.yml
@@ -7,24 +7,20 @@ meta:
   desc: Componente para galeria, mostrando images dentro de um "QasDialog" ao clicar nelas.
 
 props:
-  carousel-next-icon:
-    desc: Ícone dentro do carousel para passar para próxima imagem.
-    default: o_chevron_right
+  custom-id:
+    desc: Por padrão, o componente vai pegar o "id" que vem como parâmetro na url, caso queira que o id seja diferente da url, use esta prop (utilizado para remover imagem, custom-id referente ao model e não a imagem).
     type: String
+    examples: ['my-custom-id']
 
-  carousel-previous-icon:
-    desc: Ícone dentro do carousel para passar para a imagem anterior.
-    default: o_chevron_left
+  dialog-props:
+    desc: Props para ser repassada para o componente "QasDialog" (utilizado para dialog de remover imagem).
+    default: {}
+    type: Object
+
+  entity:
+    desc: Entidade da store, por exemplo se tiver que trabalhar com modulo de usuários, teremos o model "users" na store, que vai ser nossa "entity" (utilizado para remover imagem).
+    required: true
     type: String
-
-  height:
-    desc: Altura da imagem (fora do dialog).
-    type: String
-
-  images:
-    desc: Imagens a serem exibidas.
-    default: 6
-    type: Number
 
   initial-size:
     desc: Quantidade de imagens iniciais.
@@ -36,6 +32,23 @@ props:
     default: Ver mais
     type: String
 
+  model-value:
+    desc: Model do componente, usado para v-model.
+    default: []
+    type: Array
+    examples: [v-model"value"]
+    model: true
+
+  model-key:
+    desc: Chave identificadora do model, usada para identificar qual campo ela é referente.
+    default: ''
+    type: String
+    examples: [photos]
+
+  url:
+    desc: Envia como parâmetro para a action "update" do modulo correspondente a "entity" (utilizado para remover imagem).
+    type: String
+
   use-load-all:
     desc: Carrega todas imagens de uma única vez.
     type: Boolean
@@ -43,3 +56,69 @@ props:
 slots:
   default:
     desc: Slot para todo conteúdo onde fica o botão "mostrar mais".
+
+  destroy:
+    desc: Slot para o ícone de remover.
+    scope:
+      destroy:
+        desc: Função para remover e atualizar o model.
+        default: undefined
+        type: Function
+
+      index:
+        desc: index atual.
+        default: 0
+        type: Number
+
+      image:
+        desc: imagem atual.
+        default: {}
+        type: Object
+
+  header:
+    desc: Slot para o header.
+    scope:
+      index:
+        desc: index atual.
+        default: 0
+        type: Number
+
+      image:
+        desc: imagem atual.
+        default: {}
+        type: Object
+
+events:
+  '@update:model-value -> function(value)':
+    desc: Dispara quando o model-value altera, também usado para v-model.
+    params:
+      value:
+        desc: Novo valor do model.
+        default: []
+        type: Array
+
+  'delete-success -> function({ data, index })':
+    desc: Dispara quando deleta uma imagem da galeria com sucesso.
+    params:
+      data:
+        desc: Novo valor do v-model.
+        default: []
+        type: Array
+
+      index:
+        desc: Index da imagem deletada.
+        default: []
+        type: Array
+
+  'delete-error -> function({ data, index })':
+    desc: Dispara ocorre uma falha ao deletar uma imagem da galeria.
+    params:
+      data:
+        desc: Valor retornado no erro.
+        default: []
+        type: Array
+
+      index:
+        desc: Index da imagem que seria deletada.
+        default: []
+        type: Array

--- a/ui/src/components/gallery/QasGalleryCarouselDialog.vue
+++ b/ui/src/components/gallery/QasGalleryCarouselDialog.vue
@@ -1,0 +1,83 @@
+<!-- Componente privado, utilizado internamente e não exportado para uso externo da biblioteca -->
+<template>
+  <qas-dialog v-model="model" :cancel="false" class="q-pa-xl" max-width="1100px" :ok="false" :persistent="false" use-full-max-width>
+    <template #header>
+      <div class="text-right">
+        <qas-btn v-close-popup dense flat icon="o_close" rounded @click="close" />
+      </div>
+    </template>
+
+    <template #description>
+      <q-carousel v-model="imageIndexModel" animated :arrows="!$qas.screen.isSmall" control-text-color="primary" data-cy="gallery-carousel" :fullscreen="$qas.screen.isSmall" :height="carouselImageHeight" next-icon="o_chevron_right" prev-icon="o_chevron_left" swipeable :thumbnails="!isSingleImage">
+        <q-carousel-slide v-for="(image, index) in images" :key="index" class="bg-no-repeat bg-size-contain" :data-cy="`gallery-carousel-slide-${index}`" :img-src="image.url" :name="index">
+          <div v-if="$qas.screen.isSmall" class="full-width justify-end row">
+            <qas-btn dense flat icon="o_close" @click="close" />
+          </div>
+        </q-carousel-slide>
+      </q-carousel>
+    </template>
+  </qas-dialog>
+</template>
+
+<script>
+export default {
+  name: 'QasGalleryCarouselDialog',
+
+  props: {
+    images: {
+      type: Array,
+      default: () => []
+    },
+
+    imageIndex: {
+      type: Number,
+      default: 0
+    },
+
+    modelValue: {
+      type: Boolean
+    }
+  },
+
+  emits: [
+    'update:modelValue',
+    'update:imageIndex'
+  ],
+
+  computed: {
+    model: {
+      get () {
+        return this.modelValue
+      },
+
+      set (value) {
+        return this.$emit('update:modelValue', value)
+      }
+    },
+
+    imageIndexModel: {
+      get () {
+        return this.imageIndex
+      },
+
+      set (value) {
+        return this.$emit('update:imageIndex', value)
+      }
+    },
+
+    carouselImageHeight () {
+      return 'calc((500/976) * 100vh)'
+    },
+
+    isSingleImage () {
+      return this.images.length === 1
+    }
+  },
+
+  methods: {
+    close () {
+      this.$emit('update:modelValue', false)
+    }
+  }
+}
+</script>

--- a/ui/src/components/gallery/QasGalleryDeleteDialog.vue
+++ b/ui/src/components/gallery/QasGalleryDeleteDialog.vue
@@ -1,0 +1,64 @@
+<!-- Componente privado, utilizado internamente e não exportado para uso externo da biblioteca -->
+<template>
+  <qas-dialog v-bind="mx_defaultDialogProps" />
+</template>
+
+<script>
+import { getAction } from '@bildvitta/store-adapter'
+
+import QasDialog from '../dialog/QasDialog.vue'
+import { promiseHandler } from '../../helpers'
+import { deleteMixin } from '../../mixins'
+
+export default {
+  name: 'QasGalleryDeleteDialog',
+
+  components: {
+    QasDialog
+  },
+
+  mixins: [deleteMixin],
+
+  props: {
+    payload: {
+      type: Array,
+      default: () => []
+    },
+
+    modelKey: {
+      type: String,
+      default: ''
+    }
+  },
+
+  emits: [
+    'success',
+    'error',
+    'cancel'
+  ],
+
+  methods: {
+    // chamado no mixin
+    async destroy () {
+      const { data, error } = await promiseHandler(
+        getAction.call(this, {
+          entity: this.entity,
+          key: 'update',
+          payload: {
+            id: this.mx_id,
+            url: this.url,
+            payload: { [this.modelKey]: this.payload }
+          }
+        }),
+        {
+          errorMessage: 'Ops! Não foi possível deletar o item.',
+          successMessage: 'Item deletado com sucesso!'
+        }
+      )
+
+      if (data) return this.$emit('success', data)
+      if (error) return this.$emit('error', error)
+    }
+  }
+}
+</script>

--- a/ui/src/mixins/delete.js
+++ b/ui/src/mixins/delete.js
@@ -1,0 +1,49 @@
+export default {
+  props: {
+    customId: {
+      default: '',
+      type: [Number, String]
+    },
+
+    dialogProps: {
+      default: () => ({}),
+      type: Object
+    },
+
+    entity: {
+      default: '',
+      type: String
+    },
+
+    url: {
+      default: '',
+      type: String
+    }
+  },
+
+  computed: {
+    mx_defaultDialogProps () {
+      return {
+        card: {
+          title: 'Confirmar',
+          description: 'Tem certeza que deseja excluir este item?'
+        },
+
+        ok: {
+          label: 'Excluir',
+          onClick: this.destroy
+        },
+
+        cancel: {
+          onClick: () => this.$emit('cancel')
+        },
+
+        ...this.dialogProps
+      }
+    },
+
+    mx_id () {
+      return this.customId || this.$route.params.id
+    }
+  }
+}

--- a/ui/src/mixins/index.js
+++ b/ui/src/mixins/index.js
@@ -4,9 +4,11 @@ import generatorMixin from './generator.js'
 import searchFilterMixin from './search-filter.js'
 import passwordMixin from './password.js'
 import viewMixin from './view.js'
+import deleteMixin from './delete.js'
 
 export {
   contextMixin,
+  deleteMixin,
   formMixin,
   generatorMixin,
   searchFilterMixin,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
## BREAKING CHANGES
- `QasGallery`: propriedade `images` substituída para `modelValue` uma vez que agora é possível excluir itens da galeria.
- `QasGallery`: propriedade `height` removida para padronização.
- `QasGallery`: propriedade `carouselNextIcon` removida para padronização.
- `QasGallery`: propriedade `carouselPreviousIcon` removida para padronização.
- `QasGallery`: propriedade `loadSize` removida, agora o tamanho de carregamento de imagens é relativo ao `initialSize`.

### Adicionado
- `QasDialog`: adicionado nova propriedade `useFullMaxWidth` para utilizar `100% do maxWidth`.
- `QasGallery`: adicionado funcionalidade para deletar imagem a partir da galeria.
- `QasGallery`: adicionado propriedade `customId` usada para deletar a imagem da galeria.
- `QasGallery`: adicionado propriedade `dialogProps` usada para configurar dialog de deleção.
- `QasGallery`: adicionado propriedade `entity` usada para deletar a imagem da galeria.
- `QasGallery`: adicionado propriedade `modelValue` usada para controlar as imagens.
- `QasGallery`: adicionado propriedade `modelKey` usada para deletar a imagem da galeria.
- `QasGallery`: adicionado propriedade `url` usada para deletar a imagem da galeria.
- `QasGallery`: adicionado propriedade `entity` usada para deletar a imagem da galeria.
- `QasGallery`: adicionado evento `@update:modelValue` para atualização do model.
- `QasGallery`: adicionado evento `@delete-success` que é disparado quando acontece uma deleção com sucesso.
- `QasGallery`: adicionado evento `@delete-error` que é a deleção falha.

### Modificado
- `QasGallery`: alterado estilos/comportamento quando é imagem única do componente.
- `QasGallery`: refatoração de código.

### Corrigido
- `QasGallery`: resolvido pequeno problema referente a tamanhos

### Removido
- `QasGallery`: propriedade `images` substituída para `modelValue` uma vez que agora é possível excluir itens da galeria.
- `QasGallery`: propriedade `height` removida para padronização.
- `QasGallery`: propriedade `carouselNextIcon` removida para padronização.
- `QasGallery`: propriedade `carouselPreviousIcon` removida para padronização.
- `QasGallery`: propriedade `loadSize` removida, agora o tamanho de carregamento de imagens é relativo ao `initialSize`.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [x] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [x] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
