### PR TITLE
v3.3.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,7 +25,8 @@
     "QasListView",
     "QasDateTimeInput",
     "QasNestedFields",
-    "QasTreeGenerator"
+    "QasTreeGenerator",
+    "QasGallery"
   ],
   "cSpell.words": [
     "Nunito"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,45 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+## BREAKING CHANGES
+- `QasGallery`: propriedade `images` substituída para `modelValue` uma vez que agora é possível excluir itens da galeria.
+- `QasGallery`: propriedade `height` removida para padronização.
+- `QasGallery`: propriedade `carouselNextIcon` removida para padronização.
+- `QasGallery`: propriedade `carouselPreviousIcon` removida para padronização.
+- `QasGallery`: propriedade `loadSize` removida, agora o tamanho de carregamento de imagens é relativo ao `initialSize`.
+
+### Adicionado
+- `QasDialog`: adicionado nova propriedade `useFullMaxWidth` para utilizar `100% do maxWidth`.
+- `QasGallery`: adicionado funcionalidade para deletar imagem a partir da galeria.
+- `QasGallery`: adicionado propriedade `customId` usada para deletar a imagem da galeria.
+- `QasGallery`: adicionado propriedade `dialogProps` usada para configurar dialog de deleção.
+- `QasGallery`: adicionado propriedade `entity` usada para deletar a imagem da galeria.
+- `QasGallery`: adicionado propriedade `modelValue` usada para controlar as imagens.
+- `QasGallery`: adicionado propriedade `modelKey` usada para deletar a imagem da galeria.
+- `QasGallery`: adicionado propriedade `url` usada para deletar a imagem da galeria.
+- `QasGallery`: adicionado propriedade `entity` usada para deletar a imagem da galeria.
+- `QasGallery`: adicionado propriedade `useDestroy` usada para deletar a imagem da galeria.
+- `QasGallery`: adicionado propriedade `useObjectModel` usada para definir model como objeto.
+- `QasGallery`: adicionado evento `@update:modelValue` para atualização do model.
+- `QasGallery`: adicionado evento `@delete-success` que é disparado quando acontece uma deleção com sucesso.
+- `QasGallery`: adicionado evento `@delete-error` que é a deleção falha.
+
+### Modificado
+- `QasGallery`: alterado estilos/comportamento quando é imagem única do componente.
+- `QasGallery`: refatoração de código.
+- `QasGallery`: Adicionado classe `bg-white` para espaço entre a sombra e imagem sempre ficar `branca`.
+
+### Corrigido
+- `QasGallery`: resolvido pequeno problema referente a tamanhos
+
+### Removido
+- `QasGallery`: propriedade `images` substituída para `modelValue` uma vez que agora é possível excluir itens da galeria.
+- `QasGallery`: propriedade `height` removida para padronização.
+- `QasGallery`: propriedade `carouselNextIcon` removida para padronização.
+- `QasGallery`: propriedade `carouselPreviousIcon` removida para padronização.
+- `QasGallery`: propriedade `loadSize` removida, agora o tamanho de carregamento de imagens é relativo ao `initialSize`.
+
 ## [3.3.0-beta.1] - 31-10-2022
 ### Modificado
 - `QasGallery`: Adicionado classe `bg-white` para espaço entre a sombra e imagem sempre ficar `branca`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `QasGallery`: Adicionado classe `bg-white` para espaço entre a sombra e imagem sempre ficar `branca`.
+
 ## [3.3.0-beta.0] - 31-10-2022
 ## BREAKING CHANGES
 - `QasGallery`: propriedade `images` substituída para `modelValue` uma vez que agora é possível excluir itens da galeria.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## Não publicado
+## [3.3.0-beta.1] - 31-10-2022
 ### Modificado
 - `QasGallery`: Adicionado classe `bg-white` para espaço entre a sombra e imagem sempre ficar `branca`.
 
@@ -436,3 +436,4 @@ Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitt
 [3.2.0-beta.3]: https://github.com/bildvitta/asteroid/compare/v3.2.0-beta.2...v3.2.0-beta.3?expand=1
 [3.2.0]: https://github.com/bildvitta/asteroid/compare/v3.1.0...v3.2.0?expand=1
 [3.3.0-beta.0]: https://github.com/bildvitta/asteroid/compare/v3.2.0...v3.3.0-beta.0?expand=1
+[3.3.0-beta.1]: https://github.com/bildvitta/asteroid/compare/v3.3.0-beta.0...v3.3.0-beta.1?expand=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## Não publicado
+## [3.3.0-beta.0] - 31-10-2022
 ## BREAKING CHANGES
 - `QasGallery`: propriedade `images` substituída para `modelValue` uma vez que agora é possível excluir itens da galeria.
 - `QasGallery`: propriedade `height` removida para padronização.
@@ -431,3 +431,4 @@ Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitt
 [3.2.0-beta.2]: https://github.com/bildvitta/asteroid/compare/v3.2.0-beta.1...v3.2.0-beta.2?expand=1
 [3.2.0-beta.3]: https://github.com/bildvitta/asteroid/compare/v3.2.0-beta.2...v3.2.0-beta.3?expand=1
 [3.2.0]: https://github.com/bildvitta/asteroid/compare/v3.1.0...v3.2.0?expand=1
+[3.3.0-beta.0]: https://github.com/bildvitta/asteroid/compare/v3.2.0...v3.3.0-beta.0?expand=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,44 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+## BREAKING CHANGES
+- `QasGallery`: propriedade `images` substituída para `modelValue` uma vez que agora é possível excluir itens da galeria.
+- `QasGallery`: propriedade `height` removida para padronização.
+- `QasGallery`: propriedade `carouselNextIcon` removida para padronização.
+- `QasGallery`: propriedade `carouselPreviousIcon` removida para padronização.
+- `QasGallery`: propriedade `loadSize` removida, agora o tamanho de carregamento de imagens é relativo ao `initialSize`.
+
+### Adicionado
+- `QasDialog`: adicionado nova propriedade `useFullMaxWidth` para utilizar `100% do maxWidth`.
+- `QasGallery`: adicionado funcionalidade para deletar imagem a partir da galeria.
+- `QasGallery`: adicionado propriedade `customId` usada para deletar a imagem da galeria.
+- `QasGallery`: adicionado propriedade `dialogProps` usada para configurar dialog de deleção.
+- `QasGallery`: adicionado propriedade `entity` usada para deletar a imagem da galeria.
+- `QasGallery`: adicionado propriedade `modelValue` usada para controlar as imagens.
+- `QasGallery`: adicionado propriedade `modelKey` usada para deletar a imagem da galeria.
+- `QasGallery`: adicionado propriedade `url` usada para deletar a imagem da galeria.
+- `QasGallery`: adicionado propriedade `entity` usada para deletar a imagem da galeria.
+- `QasGallery`: adicionado propriedade `useDestroy` usada para deletar a imagem da galeria.
+- `QasGallery`: adicionado propriedade `useObjectModel` usada para definir model como objeto.
+- `QasGallery`: adicionado evento `@update:modelValue` para atualização do model.
+- `QasGallery`: adicionado evento `@delete-success` que é disparado quando acontece uma deleção com sucesso.
+- `QasGallery`: adicionado evento `@delete-error` que é a deleção falha.
+
+### Modificado
+- `QasGallery`: alterado estilos/comportamento quando é imagem única do componente.
+- `QasGallery`: refatoração de código.
+
+### Corrigido
+- `QasGallery`: resolvido pequeno problema referente a tamanhos
+
+### Removido
+- `QasGallery`: propriedade `images` substituída para `modelValue` uma vez que agora é possível excluir itens da galeria.
+- `QasGallery`: propriedade `height` removida para padronização.
+- `QasGallery`: propriedade `carouselNextIcon` removida para padronização.
+- `QasGallery`: propriedade `carouselPreviousIcon` removida para padronização.
+- `QasGallery`: propriedade `loadSize` removida, agora o tamanho de carregamento de imagens é relativo ao `initialSize`.
+
 ## [3.2.0] - 21-10-2022
 ## BREAKING CHANGES
 - `QasAppMenu`: removido logo do modular no menu.

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
-  "version": "3.3.0-beta.0",
+  "version": "3.3.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bildvitta/quasar-ui-asteroid": {
-      "version": "3.3.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.3.0-beta.0.tgz",
-      "integrity": "sha512-hDBylL0moFbSEz1Du4crzT4uJihGqYis0+h1e2MGxaiC0dCiuedkP92slksP6kIEOrMIs9Af+RnH8oRd/9XeIQ==",
+      "version": "3.3.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.3.0-beta.1.tgz",
+      "integrity": "sha512-g/QtR/M24LReExOPFD1c34q8A5nyA2oConvVguIkflnsge4hlCAMWpoKcEupLDY3XisfJt1QlW8JtoL05KaOZw==",
       "requires": {
         "@bildvitta/store-adapter": "^1.0.0-beta.22",
         "@fawmi/vue-google-maps": "^0.9.4",

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
-  "version": "3.2.0",
+  "version": "3.3.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bildvitta/quasar-ui-asteroid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.2.0.tgz",
-      "integrity": "sha512-A6AX4u1yO/cvRzxH0Awly6aIhu8XsFfpTL3aiHdcyekbnlhoCAbS+5Q+deeSsO0ZWLc+92fI5ZDAX8lFnPpXrw==",
+      "version": "3.3.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.3.0-beta.0.tgz",
+      "integrity": "sha512-hDBylL0moFbSEz1Du4crzT4uJihGqYis0+h1e2MGxaiC0dCiuedkP92slksP6kIEOrMIs9Af+RnH8oRd/9XeIQ==",
       "requires": {
         "@bildvitta/store-adapter": "^1.0.0-beta.22",
         "@fawmi/vue-google-maps": "^0.9.4",
@@ -616,9 +616,9 @@
       }
     },
     "signature_pad": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-4.0.10.tgz",
-      "integrity": "sha512-PcIm/C55wLgEA36udwW5iaGI9cN9GkRLVHO8Ao4QElcJtYwwhIfYwZt2ui/IAzskD1aZi1Sy2yP3JkVZCv773g=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-4.1.0.tgz",
+      "integrity": "sha512-kPG0UJlLbdn7L2rVJf5Nv9WsapzHn4AwysBUS1O+cTN9lrM0HrpoVshqWgd4Ryww34H1xyDvuor6o8kjXRAQfg=="
     },
     "sortablejs": {
       "version": "1.15.0",

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
   "description": "Asteroid",
-  "version": "3.2.0",
+  "version": "3.3.0-beta.0",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "src/index.js",
@@ -29,7 +29,7 @@
     "yarn": ">= 1.6.0"
   },
   "dependencies": {
-    "@bildvitta/quasar-ui-asteroid": "3.2.0",
+    "@bildvitta/quasar-ui-asteroid": "3.3.0-beta.0",
     "@bildvitta/store-adapter": "^1.0.0-beta.23",
     "humps": "^2.0.1"
   }

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
   "description": "Asteroid",
-  "version": "3.3.0-beta.0",
+  "version": "3.3.0-beta.1",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "src/index.js",
@@ -29,7 +29,7 @@
     "yarn": ">= 1.6.0"
   },
   "dependencies": {
-    "@bildvitta/quasar-ui-asteroid": "3.3.0-beta.0",
+    "@bildvitta/quasar-ui-asteroid": "3.3.0-beta.1",
     "@bildvitta/store-adapter": "^1.0.0-beta.23",
     "humps": "^2.0.1"
   }

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bildvitta/asteroid-docs",
-  "version": "3.2.0",
+  "version": "3.3.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bildvitta/asteroid-docs",
-  "version": "3.3.0-beta.0",
+  "version": "3.3.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid-docs",
   "description": "Asteroid",
-  "version": "3.3.0-beta.0",
+  "version": "3.3.0-beta.1",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "productName": "Asteroid Docs",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid-docs",
   "description": "Asteroid",
-  "version": "3.2.0",
+  "version": "3.3.0-beta.0",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "productName": "Asteroid Docs",

--- a/docs/src/examples/QasGallery/Basic.vue
+++ b/docs/src/examples/QasGallery/Basic.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container spaced">
     <div>
-      <qas-gallery :images="images" />
+      <qas-gallery v-model="images" />
     </div>
   </div>
 </template>
@@ -10,13 +10,7 @@
 export default {
   data () {
     return {
-      model: ''
-    }
-  },
-
-  computed: {
-    images () {
-      return [
+      images: [
         'https://via.placeholder.com/200x300/ff0000/969696',
         'https://via.placeholder.com/200x300/09ff00/969696',
         'https://via.placeholder.com/200x300/0044ff/969696',

--- a/docs/src/examples/QasGallery/ObjectImages.vue
+++ b/docs/src/examples/QasGallery/ObjectImages.vue
@@ -1,0 +1,66 @@
+<template>
+  <div class="container spaced">
+    <div>
+      <qas-gallery v-model="images" custom-id="31362c39-2cb5-4fe2-982a-c270f88d2462" entity="users" model-key="photos" use-destroy use-object-model />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      images: [
+        {
+          name: 'Imagem vermelha',
+          url: 'https://via.placeholder.com/200x300/ff0000/969696',
+          uuid: 'imagem-vermelha',
+          destroyable: true
+        },
+        {
+          name: 'Imagem verde',
+          url: 'https://via.placeholder.com/200x300/09ff00/969696',
+          uuid: 'imagem-verde',
+          destroyable: true
+        },
+        {
+          name: 'Imagem azul',
+          url: 'https://via.placeholder.com/200x300/0044ff/969696',
+          uuid: 'imagem-azul',
+          destroyable: false
+        },
+        {
+          name: 'Imagem vermelha 2',
+          url: 'https://via.placeholder.com/200x300/ff0000/969696',
+          uuid: 'imagem-vermelha-2',
+          destroyable: true
+        },
+        {
+          name: 'Imagem vermelha 3',
+          url: 'https://via.placeholder.com/200x300/ff0000/969696',
+          uuid: 'imagem-vermelha-3',
+          destroyable: true
+        },
+        {
+          name: 'Imagem verde 2',
+          url: 'https://via.placeholder.com/200x300/09ff00/969696',
+          uuid: 'imagem-verde-2',
+          destroyable: true
+        },
+        {
+          name: 'Imagem azul 2',
+          url: 'https://via.placeholder.com/200x300/0044ff/969696',
+          uuid: 'imagem-azul-2',
+          destroyable: true
+        },
+        {
+          name: 'Imagem vermelha 4',
+          url: 'https://via.placeholder.com/200x300/ff0000/969696',
+          uuid: 'imagem-vermelha-4',
+          destroyable: true
+        }
+      ]
+    }
+  }
+}
+</script>

--- a/docs/src/pages/components/gallery.md
+++ b/docs/src/pages/components/gallery.md
@@ -4,12 +4,31 @@ title: QasGallery
 
 Componente para galeria, mostrando images dentro de um "QasDialog" ao clicar nelas.
 
+:::warning
+Este componente depende do `Vuex` ou `Pinia`, utiliza módulos com actions. Por exemplo, para você conseguir remover uma imagem da galeria, você precisa ter:
+- action: update.
+
+Hoje Utilizamos 2 bibliotecas com propósitos diferentes que são compatíveis com o asteroid para lidar com o Vuex, elas são:
+[VuexStoreModule](https://github.com/bildvitta/vuex-store-module), [VuexOffline](https://github.com/bildvitta/vuex-offline) e [StoreModule](https://github.com/bildvitta/store-module).
+:::
+
+
 <doc-api file="gallery/QasGallery" name="QasGallery" />
 
 ## Uso
 
-:::tip
-Componente implementa o `QasBox` repassando todas propriedades.
-:::
-
 <doc-example file="QasGallery/Basic" title="Básico" />
+
+:::tip
+Quando fazemos uma remoção de imagem de um model, `users` por exemplo, estamos na verdade **editando** ele, então é utilizado a action `update`.
+
+Para conseguir **remover** um item você precisa configurar as seguintes propriedades:
+
+```
+- custom-id: referente ao model, ex: users/:id, e não ao id da imagem (não obrigatória);
+- entity: referente ao model, ex: "users" (obrigatória);
+- url: referente ao endpoint que a action "update" irá executar (não obrigatória);
+- model-key: referente ao campo que está querendo atualizar, ex: "photos" (obrigatória);
+```
+:::
+<doc-example file="QasGallery/ObjectImages" title="Imagens com nome e opção de remoção" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bildvitta/asteroid",
-  "version": "3.2.0",
+  "version": "3.3.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bildvitta/asteroid",
-  "version": "3.3.0-beta.0",
+  "version": "3.3.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid",
   "description": "Asteroid",
-  "version": "3.2.0",
+  "version": "3.3.0-beta.0",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid",
   "description": "Asteroid",
-  "version": "3.3.0-beta.0",
+  "version": "3.3.0-beta.1",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "scripts": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
-  "version": "3.2.0",
+  "version": "3.3.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
-  "version": "3.3.0-beta.0",
+  "version": "3.3.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
   "description": "Asteroid",
-  "version": "3.2.0",
+  "version": "3.3.0-beta.0",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "dist/asteroid.cjs.min.js",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
   "description": "Asteroid",
-  "version": "3.3.0-beta.0",
+  "version": "3.3.0-beta.1",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "dist/asteroid.cjs.min.js",

--- a/ui/src/components/checkbox-group/QasCheckboxGroup.yml
+++ b/ui/src/components/checkbox-group/QasCheckboxGroup.yml
@@ -21,11 +21,11 @@ props:
     default: []
     type: Array
 
-
 events:
   '@update:model-value -> function(value)':
     desc: Dispara quando o model-value altera, também usado para v-model.
     params:
       value:
         desc: Novo valor do model.
-        type: []
+        default: []
+        type: Array

--- a/ui/src/components/dialog/QasDialog.vue
+++ b/ui/src/components/dialog/QasDialog.vue
@@ -104,6 +104,10 @@ export default {
       type: Boolean
     },
 
+    useFullMaxWidth: {
+      type: Boolean
+    },
+
     useValidationAllAtOnce: {
       type: Boolean
     }
@@ -133,6 +137,7 @@ export default {
 
     style () {
       return {
+        ...(this.useFullMaxWidth && { width: '100%' }),
         maxWidth: this.maxWidth || (this.$qas.screen.isSmall ? '' : '600px'),
         minWidth: this.minWidth || (this.$qas.screen.isSmall ? '' : '400px')
       }

--- a/ui/src/components/dialog/QasDialog.yml
+++ b/ui/src/components/dialog/QasDialog.yml
@@ -60,6 +60,10 @@ props:
     desc: Define se a tag onde fica a descrição no dialog vai ser um "<q-form />" ou "<div />".
     type: Boolean
 
+  use-full-max-width:
+    desc: propriedade para utilizar `100% do maxWidth`.
+    type: Boolean
+
   use-validation-at-once:
     desc: Valida todos os campos de uma única vez, ao invés de ser um por vez (que é o padrão).
     type: Boolean

--- a/ui/src/components/gallery/QasGallery.vue
+++ b/ui/src/components/gallery/QasGallery.vue
@@ -3,7 +3,7 @@
   <div class="qas-gallery">
     <div class="q-col-gutter-md row">
       <div v-for="(image, index) in getInitialImages()" :key="index" :class="galleryColumnsClasses" :data-cy="`gallery-image-${index}`">
-        <div class="q-pa-md rounded-borders shadow-2">
+        <div class="bg-white q-pa-md rounded-borders shadow-2">
           <div class="flat items-center justify-between no-wrap q-mb-xs row text-grey-9">
             <div class="ellipsis q-mr-xs qas-gallery__name">
               <slot v-if="image.name" :image="image" :index="index" name="header">

--- a/ui/src/components/gallery/QasGallery.vue
+++ b/ui/src/components/gallery/QasGallery.vue
@@ -1,38 +1,59 @@
 
 <template>
-  <qas-box class="gallery">
+  <div class="qas-gallery">
     <div class="q-col-gutter-md row">
-      <div v-for="(image, index) in initialImages()" :key="index" :class="galleryColumnsClasses">
-        <q-img class="cursor-pointer rounded-borders" :height="imageHeight" :src="image" @click="toggleCarouselDialog(index)" @error="onError(image)" />
+      <div v-for="(image, index) in getInitialImages()" :key="index" :class="galleryColumnsClasses" :data-cy="`gallery-image-${index}`">
+        <div class="q-pa-md rounded-borders shadow-2">
+          <div class="flat items-center justify-between no-wrap q-mb-xs row text-grey-9">
+            <div class="ellipsis q-mr-xs qas-gallery__name">
+              <slot v-if="image.name" :image="image" :index="index" name="header">
+                {{ image.name }}
+              </slot>
+            </div>
+
+            <div v-if="useDestroy">
+              <slot :destroy="onDestroy" :image="image" :index="index" name="destroy">
+                <qas-btn color="grey-9" dense :disabled="isDestroyDisabled(image)" flat round size="sm" @click="onDestroy(image, index)">
+                  <q-icon name="o_delete" size="xs" />
+                </qas-btn>
+              </slot>
+            </div>
+          </div>
+
+          <q-img class="cursor-pointer rounded-borders" height="150px" :src="image.url" @click="toggleCarouselDialog(index)" @error="onError(image.url)" />
+        </div>
       </div>
+
       <slot>
         <div v-if="!hideShowMore" class="full-width text-center">
-          <qas-btn class="text-weight-bolder" color="primary" flat @click="showMore">{{ showMoreLabel }}</qas-btn>
+          <qas-btn color="primary" data-cy="gallery-btn-show-more" flat :label="showMoreLabel" @click="showMore" />
         </div>
       </slot>
-      <qas-dialog v-model="carouselDialog" :cancel="false" class="q-pa-xl" min-width="1100px" :ok="false" :persistent="false">
-        <template #header>
-          <div class="text-right">
-            <qas-btn v-close-popup dense flat icon="o_close" rounded @click="toggleCarouselDialog" />
-          </div>
-        </template>
-        <template #description>
-          <q-carousel v-model="imageIndex" animated :arrows="!$qas.screen.isSmall" control-text-color="primary" :fullscreen="$qas.screen.isSmall" :height="carouselImageHeight" :next-icon="carouselNextIcon" :prev-icon="carouselPreviousIcon" swipeable :thumbnails="showThumbnails">
-            <q-carousel-slide v-for="(image, index) in clonedImages" :key="index" class="bg-no-repeat bg-size-contain" :img-src="image" :name="index">
-              <div v-if="$qas.screen.isSmall" class="full-width justify-end row">
-                <qas-btn dense flat icon="o_close" @click="toggleCarouselDialog" />
-              </div>
-            </q-carousel-slide>
-          </q-carousel>
-        </template>
-      </qas-dialog>
+
+      <pv-gallery-carousel-dialog v-model="carouselDialog" v-model:imageIndex="imageIndex" :images="normalizedImages" />
+
+      <pv-gallery-delete-dialog v-model="showDeleteDialog" v-bind="deleteGalleryDialogProps" @cancel="resetCurrentModel" @error="onDeleteError" @success="onDeleteSuccess" />
     </div>
-  </qas-box>
+  </div>
 </template>
 
 <script>
+import QasBtn from '../btn/QasBtn.vue'
+import PvGalleryDeleteDialog from './private/PvGalleryDeleteDialog.vue'
+import PvGalleryCarouselDialog from './private/PvGalleryCarouselDialog.vue'
+import { extend } from 'quasar'
+import { deleteMixin } from '../../mixins'
+
 export default {
   name: 'QasGallery',
+
+  components: {
+    PvGalleryCarouselDialog,
+    PvGalleryDeleteDialog,
+    QasBtn
+  },
+
+  mixins: [deleteMixin],
 
   props: {
     carouselNextIcon: {
@@ -45,24 +66,14 @@ export default {
       default: 'o_chevron_left'
     },
 
-    height: {
-      type: String,
-      default: ''
-    },
-
     initialSize: {
       type: Number,
-      default: 6
-    },
+      default: 4,
+      validator: value => {
+        const acceptableValues = [1, 2, 3, 4, 6, 12]
 
-    images: {
-      type: Array,
-      default: () => []
-    },
-
-    loadSize: {
-      type: Number,
-      default: 6
+        return acceptableValues.includes(value)
+      }
     },
 
     showMoreLabel: {
@@ -72,81 +83,162 @@ export default {
 
     useLoadAll: {
       type: Boolean
+    },
+
+    useDestroy: {
+      type: Boolean
+    },
+
+    useObjectModel: {
+      type: Boolean
+    },
+
+    modelValue: {
+      type: Array,
+      default: () => []
+    },
+
+    modelKey: {
+      type: String,
+      default: ''
     }
   },
+
+  emits: [
+    'delete-error',
+    'delete-success',
+    'update:modelValue'
+  ],
 
   data () {
     return {
       carouselDialog: false,
-      clonedImages: [],
-      imageIndex: [],
-      displayedImages: this.initialSize
+      imageIndex: 0,
+      displayedImages: this.initialSize,
+      showDeleteDialog: false,
+      currentModel: [],
+      imageToBeDestroyed: { index: null }
     }
   },
 
   computed: {
-    imageHeight () {
-      if (this.isSingleImage) {
-        return this.height || 'auto'
-      }
-
-      return this.$qas.screen.isSmall ? '90px' : '120px'
-    },
-
     galleryColumnsClasses () {
-      if (this.isSingleImage) return 'col-12'
+      const size = 12 / this.initialSize
+      const col = `col-${size}`
 
-      return this.$qas.screen.isSmall ? 'col-6' : 'col-2'
+      return this.$qas.screen.isSmall ? 'col-12' : col
     },
 
     hideShowMore () {
-      return (this.clonedImages.length <= this.displayedImages) || this.useLoadAll
+      return (this.normalizedImages.length <= this.displayedImages) || this.useLoadAll
     },
 
-    carouselImageHeight () {
-      return 'calc((500/976) * 100vh)'
+    normalizedImages () {
+      if (!this.useObjectModel) {
+        return this.clonedImages.map(url => ({ url }))
+      }
+
+      return this.clonedImages
     },
 
-    showThumbnails () {
-      return !this.isSingleImage
+    clonedImages () {
+      return extend(true, [], this.modelValue)
     },
 
-    isSingleImage () {
-      return this.clonedImages.length === 1
+    deleteGalleryDialogProps () {
+      return {
+        customId: this.customId,
+        dialogProps: this.dialogProps,
+        entity: this.entity,
+        modelKey: this.modelKey,
+        payload: this.currentModel,
+        url: this.url
+      }
     }
   },
 
   watch: {
-    images: {
+    normalizedImages: {
       handler (value) {
-        this.clonedImages = [...value]
+        this.currentModel = extend(true, [], value)
       },
+
       immediate: true
     }
   },
 
   methods: {
-    toggleCarouselDialog (image) {
-      this.imageIndex = image
+    toggleCarouselDialog (index) {
+      this.imageIndex = index
       this.carouselDialog = !this.carouselDialog
     },
 
     showMore () {
-      this.displayedImages += this.loadSize
+      this.displayedImages += this.displayedImages
     },
 
     onError (error) {
-      const index = this.clonedImages.findIndex(image => image === error)
+      const index = this.normalizedImages.findIndex(image => image.url === error)
 
       if (~index) {
-        this.clonedImages.splice(index, 1)
+        this.normalizedImages.splice(index, 1)
         this.$forceUpdate()
       }
     },
 
-    initialImages () {
-      return this.useLoadAll ? this.clonedImages : this.clonedImages.slice(0, this.displayedImages)
+    getInitialImages () {
+      return this.useLoadAll
+        ? this.normalizedImages
+        : this.normalizedImages.slice(0, this.displayedImages)
+    },
+
+    onDestroy (image, index) {
+      if (this.isDestroyDisabled(image)) return
+
+      this.imageToBeDestroyed.index = index
+
+      this.currentModel.splice(this.imageToBeDestroyed.index, 1)
+
+      this.showDeleteDialog = !this.showDeleteDialog
+    },
+
+    isDestroyDisabled (image) {
+      return 'destroyable' in image && !image.destroyable
+    },
+
+    onDeleteSuccess () {
+      this.normalizedImages.splice(this.imageToBeDestroyed.index, 1)
+
+      this.$emit('update:modelValue', this.normalizedImages)
+
+      this.$emit(
+        'delete-success',
+        { data: this.normalizedImages, index: this.imageToBeDestroyed.index }
+      )
+    },
+
+    resetCurrentModel () {
+      this.currentModel = extend(true, [], this.normalizedImages)
+    },
+
+    onDeleteError (error) {
+      this.resetCurrentModel()
+
+      this.$emit(
+        'delete-error',
+        { data: error, index: this.imageToBeDestroyed.index }
+      )
     }
   }
 }
 </script>
+
+<!-- TODO rever tipografia -->
+<style lang="scss">
+.qas-gallery {
+  &__name {
+    font-size: 16px;
+    font-weight: 600;
+  }
+}
+</style>

--- a/ui/src/components/gallery/QasGallery.yml
+++ b/ui/src/components/gallery/QasGallery.yml
@@ -3,37 +3,26 @@ type: component
 mixins:
   - '@bildvitta/quasar-ui-asteroid/dist/api/QasBox.json'
 
-
 meta:
   desc: Componente para galeria, mostrando images dentro de um "QasDialog" ao clicar nelas.
 
 props:
-  carousel-next-icon:
-    desc: Ícone dentro do carousel para passar para próxima imagem.
-    default: o_chevron_right
+  custom-id:
+    desc: Por padrão, o componente vai pegar o "id" que vem como parâmetro na url, caso queira que o id seja diferente da url, use esta prop (utilizado para remover imagem, custom-id referente ao model e não a imagem).
     type: String
+    examples: ['my-custom-id']
 
-  carousel-previous-icon:
-    desc: Ícone dentro do carousel para passar para a imagem anterior.
-    default: o_chevron_left
+  dialog-props:
+    desc: Props para ser repassada para o componente "QasDialog" (utilizado para dialog de remover imagem).
+    default: {}
+    type: Object
+
+  entity:
+    desc: Entidade da store, por exemplo se tiver que trabalhar com modulo de usuários, teremos o model "users" na store, que vai ser nossa "entity" (utilizado para remover imagem).
     type: String
-
-  height:
-    desc: Altura da imagem (fora do dialog).
-    type: String
-
-  images:
-    desc: Imagens a serem exibidas.
-    default: 6
-    type: Number
 
   initial-size:
     desc: Quantidade de imagens iniciais.
-    default: 6
-    type: Number
-
-  load-size:
-    desc: Quantidade de fotos carregadas por vez.
     default: 6
     type: Number
 
@@ -42,10 +31,101 @@ props:
     default: Ver mais
     type: String
 
+  model-value:
+    desc: Model do componente, usado para v-model.
+    default: []
+    type: Array
+    examples: [v-model"value"]
+    model: true
+
+  model-key:
+    desc: Chave identificadora do model, usada para identificar qual campo ela é referente.
+    default: ''
+    type: String
+    examples: [photos]
+
+  url:
+    desc: Envia como parâmetro para a action "update" do modulo correspondente a "entity" (utilizado para remover imagem).
+    type: String
+
+  use-destroy:
+    desc: Usado para habilitar botão de remover imagem da galeroa.
+    type: Boolean
+
   use-load-all:
     desc: Carrega todas imagens de uma única vez.
+    type: Boolean
+
+  use-object-model:
+    desc: Usado para definir o model como objeto.
     type: Boolean
 
 slots:
   default:
     desc: Slot para todo conteúdo onde fica o botão "mostrar mais".
+
+  destroy:
+    desc: Slot para o ícone de remover.
+    scope:
+      destroy:
+        desc: Função para remover e atualizar o model.
+        default: undefined
+        type: Function
+
+      index:
+        desc: index atual.
+        default: 0
+        type: Number
+
+      image:
+        desc: imagem atual.
+        default: {}
+        type: Object
+
+  header:
+    desc: Slot para o header.
+    scope:
+      index:
+        desc: index atual.
+        default: 0
+        type: Number
+
+      image:
+        desc: imagem atual.
+        default: {}
+        type: Object
+
+events:
+  '@update:model-value -> function(value)':
+    desc: Dispara quando o model-value altera, também usado para v-model.
+    params:
+      value:
+        desc: Novo valor do model.
+        default: []
+        type: Array
+
+  'delete-success -> function({ data, index })':
+    desc: Dispara quando deleta uma imagem da galeria com sucesso.
+    params:
+      data:
+        desc: Novo valor do v-model.
+        default: []
+        type: Array
+
+      index:
+        desc: Index da imagem deletada.
+        default: []
+        type: Array
+
+  'delete-error -> function({ data, index })':
+    desc: Dispara ocorre uma falha ao deletar uma imagem da galeria.
+    params:
+      data:
+        desc: Valor retornado no erro.
+        default: []
+        type: Array
+
+      index:
+        desc: Index da imagem que seria deletada.
+        default: []
+        type: Array

--- a/ui/src/components/gallery/private/PvGalleryCarouselDialog.vue
+++ b/ui/src/components/gallery/private/PvGalleryCarouselDialog.vue
@@ -1,0 +1,82 @@
+<template>
+  <qas-dialog v-model="model" :cancel="false" class="q-pa-xl" max-width="1100px" :ok="false" :persistent="false" use-full-max-width>
+    <template #header>
+      <div class="text-right">
+        <qas-btn v-close-popup dense flat icon="o_close" rounded @click="close" />
+      </div>
+    </template>
+
+    <template #description>
+      <q-carousel v-model="imageIndexModel" animated :arrows="!$qas.screen.isSmall" control-text-color="primary" data-cy="gallery-carousel" :fullscreen="$qas.screen.isSmall" :height="carouselImageHeight" next-icon="o_chevron_right" prev-icon="o_chevron_left" swipeable :thumbnails="!isSingleImage">
+        <q-carousel-slide v-for="(image, index) in images" :key="index" class="bg-no-repeat bg-size-contain" :data-cy="`gallery-carousel-slide-${index}`" :img-src="image.url" :name="index">
+          <div v-if="$qas.screen.isSmall" class="full-width justify-end row">
+            <qas-btn dense flat icon="o_close" @click="close" />
+          </div>
+        </q-carousel-slide>
+      </q-carousel>
+    </template>
+  </qas-dialog>
+</template>
+
+<script>
+export default {
+  name: 'PvGalleryCarouselDialog',
+
+  props: {
+    images: {
+      type: Array,
+      default: () => []
+    },
+
+    imageIndex: {
+      type: Number,
+      default: 0
+    },
+
+    modelValue: {
+      type: Boolean
+    }
+  },
+
+  emits: [
+    'update:modelValue',
+    'update:imageIndex'
+  ],
+
+  computed: {
+    model: {
+      get () {
+        return this.modelValue
+      },
+
+      set (value) {
+        return this.$emit('update:modelValue', value)
+      }
+    },
+
+    imageIndexModel: {
+      get () {
+        return this.imageIndex
+      },
+
+      set (value) {
+        return this.$emit('update:imageIndex', value)
+      }
+    },
+
+    carouselImageHeight () {
+      return 'calc((500/976) * 100vh)'
+    },
+
+    isSingleImage () {
+      return this.images.length === 1
+    }
+  },
+
+  methods: {
+    close () {
+      this.$emit('update:modelValue', false)
+    }
+  }
+}
+</script>

--- a/ui/src/components/gallery/private/PvGalleryDeleteDialog.vue
+++ b/ui/src/components/gallery/private/PvGalleryDeleteDialog.vue
@@ -1,0 +1,63 @@
+<template>
+  <qas-dialog v-bind="mx_defaultDialogProps" />
+</template>
+
+<script>
+import { getAction } from '@bildvitta/store-adapter'
+
+import QasDialog from '../../dialog/QasDialog.vue'
+import { promiseHandler } from '../../../helpers'
+import { deleteMixin } from '../../../mixins'
+
+export default {
+  name: 'PvGalleryDeleteDialog',
+
+  components: {
+    QasDialog
+  },
+
+  mixins: [deleteMixin],
+
+  props: {
+    payload: {
+      type: Array,
+      default: () => []
+    },
+
+    modelKey: {
+      type: String,
+      default: ''
+    }
+  },
+
+  emits: [
+    'success',
+    'error',
+    'cancel'
+  ],
+
+  methods: {
+    // chamado no mixin
+    async destroy () {
+      const { data, error } = await promiseHandler(
+        getAction.call(this, {
+          entity: this.entity,
+          key: 'update',
+          payload: {
+            id: this.mx_id,
+            url: this.url,
+            payload: { [this.modelKey]: this.payload }
+          }
+        }),
+        {
+          errorMessage: 'Ops! Não foi possível deletar o item.',
+          successMessage: 'Item deletado com sucesso!'
+        }
+      )
+
+      if (data) return this.$emit('success', data)
+      if (error) return this.$emit('error', error)
+    }
+  }
+}
+</script>

--- a/ui/src/mixins/delete.js
+++ b/ui/src/mixins/delete.js
@@ -1,0 +1,49 @@
+export default {
+  props: {
+    customId: {
+      default: '',
+      type: [Number, String]
+    },
+
+    dialogProps: {
+      default: () => ({}),
+      type: Object
+    },
+
+    entity: {
+      default: '',
+      type: String
+    },
+
+    url: {
+      default: '',
+      type: String
+    }
+  },
+
+  computed: {
+    mx_defaultDialogProps () {
+      return {
+        card: {
+          title: 'Confirmar',
+          description: 'Tem certeza que deseja excluir este item?'
+        },
+
+        ok: {
+          label: 'Excluir',
+          onClick: this.destroy
+        },
+
+        cancel: {
+          onClick: () => this.$emit('cancel')
+        },
+
+        ...this.dialogProps
+      }
+    },
+
+    mx_id () {
+      return this.customId || this.$route.params.id
+    }
+  }
+}

--- a/ui/src/mixins/index.js
+++ b/ui/src/mixins/index.js
@@ -4,9 +4,11 @@ import generatorMixin from './generator.js'
 import searchFilterMixin from './search-filter.js'
 import passwordMixin from './password.js'
 import viewMixin from './view.js'
+import deleteMixin from './delete.js'
 
 export {
   contextMixin,
+  deleteMixin,
   formMixin,
   generatorMixin,
   searchFilterMixin,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## 3.3.0
## BREAKING CHANGES
- `QasGallery`: propriedade `images` substituída para `modelValue` uma vez que agora é possível excluir itens da galeria.
- `QasGallery`: propriedade `height` removida para padronização.
- `QasGallery`: propriedade `carouselNextIcon` removida para padronização.
- `QasGallery`: propriedade `carouselPreviousIcon` removida para padronização.
- `QasGallery`: propriedade `loadSize` removida, agora o tamanho de carregamento de imagens é relativo ao `initialSize`.

### Adicionado
- `QasDialog`: adicionado nova propriedade `useFullMaxWidth` para utilizar `100% do maxWidth`.
- `QasGallery`: adicionado funcionalidade para deletar imagem a partir da galeria.
- `QasGallery`: adicionado propriedade `customId` usada para deletar a imagem da galeria.
- `QasGallery`: adicionado propriedade `dialogProps` usada para configurar dialog de deleção.
- `QasGallery`: adicionado propriedade `entity` usada para deletar a imagem da galeria.
- `QasGallery`: adicionado propriedade `modelValue` usada para controlar as imagens.
- `QasGallery`: adicionado propriedade `modelKey` usada para deletar a imagem da galeria.
- `QasGallery`: adicionado propriedade `url` usada para deletar a imagem da galeria.
- `QasGallery`: adicionado propriedade `entity` usada para deletar a imagem da galeria.
- `QasGallery`: adicionado propriedade `useDestroy` usada para deletar a imagem da galeria.
- `QasGallery`: adicionado propriedade `useObjectModel` usada para definir model como objeto.
- `QasGallery`: adicionado evento `@update:modelValue` para atualização do model.
- `QasGallery`: adicionado evento `@delete-success` que é disparado quando acontece uma deleção com sucesso.
- `QasGallery`: adicionado evento `@delete-error` que é a deleção falha.

### Modificado
- `QasGallery`: alterado estilos/comportamento quando é imagem única do componente.
- `QasGallery`: refatoração de código.
- `QasGallery`: Adicionado classe `bg-white` para espaço entre a sombra e imagem sempre ficar `branca`.

### Corrigido
- `QasGallery`: resolvido pequeno problema referente a tamanhos

### Removido
- `QasGallery`: propriedade `images` substituída para `modelValue` uma vez que agora é possível excluir itens da galeria.
- `QasGallery`: propriedade `height` removida para padronização.
- `QasGallery`: propriedade `carouselNextIcon` removida para padronização.
- `QasGallery`: propriedade `carouselPreviousIcon` removida para padronização.
- `QasGallery`: propriedade `loadSize` removida, agora o tamanho de carregamento de imagens é relativo ao `initialSize`.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [ ] v3-beta.x -> a partir da branch `main-homolog`.
- [x] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [x] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
