### PR TITLE
v3.4.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasField`: repassando `useStrengthChecker` no QasField.
+
+### Modificado
+- `QasSearchBox`: modificado tempo de `debounce` no lazy loading de `500` para `800`.
+- `QasSearchBox`: removido `disable` do campo de busca enquanto ocorria uma request.
+
+### Corrigido
+- `QasAppBar`: corrigido badge que mostra se o ambiente é de `Develop`.
+- `QasPasswordInput`: corrigido problema de slots que não mostrada `QasPasswordStrengthChecker` quando renderizado pelo `QasField` e também não respeitava a prop `hideBottomSpace` quando usado diretamente.
+
 ## [3.4.0-beta.0] - 10-11-2022
 ### Adicionado
 - `copyToClipboard`: adicionado novo helper copyToClipboard para ser utilizado no componente `QasCopy` e fora do asteroid.

--- a/docs/src/examples/QasPasswordInput/Basic.vue
+++ b/docs/src/examples/QasPasswordInput/Basic.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="container q-py-lg">
     <qas-password-input v-model="password" />
-
     Senha: {{ password }}
   </div>
 </template>

--- a/ui/src/components/app-bar/QasAppBar.vue
+++ b/ui/src/components/app-bar/QasAppBar.vue
@@ -105,8 +105,7 @@ export default {
     developmentBadgeLabel () {
       const hosts = {
         localhost: 'Local',
-        develop: 'Develop',
-        release: 'Release'
+        '.dev.': 'Develop'
       }
 
       if (process.env.DEV) {

--- a/ui/src/components/field/QasField.vue
+++ b/ui/src/components/field/QasField.vue
@@ -76,8 +76,9 @@ export default {
         mask,
         maxFiles,
         useIso,
+        useLazyLoading,
         useSearch,
-        useLazyLoading
+        useStrengthChecker
       } = this.formattedField
 
       // Default error attributes for Quasar.
@@ -125,7 +126,7 @@ export default {
         number: { is: 'qas-input', type: 'number', ...input },
         hidden: { is: 'input', name, type },
         email: { is: 'qas-input', type, ...input },
-        password: { is: 'qas-password-input', ...input },
+        password: { is: 'qas-password-input', ...input, useStrengthChecker },
 
         decimal: { ...numericInput, mode: 'decimal' },
         money: { ...numericInput, mode: 'money' },

--- a/ui/src/components/password-input/QasPasswordInput.vue
+++ b/ui/src/components/password-input/QasPasswordInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <qas-input v-model="model" :bottom-slots="false" v-bind="$attrs" :type="type" use-remove-error-on-type>
+  <qas-input v-model="model" :bottom-slots="hasBottomSlots" v-bind="$attrs" :type="type" use-remove-error-on-type>
     <template #append>
       <q-icon class="cursor-pointer" :color="iconColor" :name="icon" @click="toggle" />
     </template>
@@ -8,13 +8,14 @@
       <slot :name="name" v-bind="context || {}" />
     </template>
 
-    <template v-if="useStrengthChecker" #hint>
+    <template v-if="hasStrengthChecker" #hint>
       <qas-password-strength-checker v-bind="strengthCheckerProps" :password="model" />
     </template>
   </qas-input>
 </template>
 
 <script>
+import QasInput from '../input/QasInput.vue'
 import passwordMixin from '../../mixins/password.js'
 import QasPasswordStrengthChecker from '../password-strength-checker/QasPasswordStrengthChecker.vue'
 
@@ -22,6 +23,7 @@ export default {
   name: 'QasPasswordInput',
 
   components: {
+    QasInput,
     QasPasswordStrengthChecker
   },
 
@@ -76,6 +78,14 @@ export default {
 
     type () {
       return this.toggleType ? 'password' : 'text'
+    },
+
+    hasBottomSlots () {
+      return !!this.model.length
+    },
+
+    hasStrengthChecker () {
+      return this.useStrengthChecker && this.hasBottomSlots
     }
   },
 

--- a/ui/src/components/search-box/QasSearchBox.vue
+++ b/ui/src/components/search-box/QasSearchBox.vue
@@ -112,7 +112,7 @@ export default {
       return {
         clearable: true,
         disable: this.isDisabled,
-        debounce: this.useLazyLoading ? 500 : 0,
+        debounce: this.useLazyLoading ? 800 : 0,
         outlined: true,
         placeholder: this.placeholder,
         hideBottomSpace: true,
@@ -161,7 +161,7 @@ export default {
     },
 
     isDisabled () {
-      return (!this.useLazyLoading && !this.list.length) || this.mx_isFetching || this.hasNoOptionsOnFirstFetch
+      return (!this.useLazyLoading && !this.list.length) || this.hasNoOptionsOnFirstFetch
     },
 
     showEmptyResult () {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Adicionado
- `QasField`: repassando `useStrengthChecker` no QasField.

### Modificado
- `QasSearchBox`: modificado tempo de `debounce` no lazy loading de `500` para `800`.
- `QasSearchBox`: removido `disable` do campo de busca enquanto ocorria uma request.

### Corrigido
- `QasAppBar`: corrigido badge que mostra se o ambiente é de `Develop`.
- `QasPasswordInput`: corrigido problema de slots que não mostrada `QasPasswordStrengthChecker` quando renderizado pelo `QasField` e também não respeitava a prop `hideBottomSpace` quando usado diretamente.


<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
