### PR TITLE
v3.5.0-beta.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,7 +26,8 @@
     "QasDateTimeInput",
     "QasNestedFields",
     "QasTreeGenerator",
-    "QasGallery"
+    "QasGallery",
+    "QasFilters"
   ],
   "cSpell.words": [
     "Nunito"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,7 +27,8 @@
     "QasNestedFields",
     "QasTreeGenerator",
     "QasGallery",
-    "QasFilters"
+    "QasFilters",
+    "QasOptionGroup"
   ],
   "cSpell.words": [
     "Nunito"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,22 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
-
 ## BREAKING CHANGE
 - `QasField`: Alterado type `radio` par utilizar o novo componente `QasOptionGroup` e removido prop de erro pois não existe no componente `QOptionGroup`, testar bem para validar.
 - Componentes de radio agora existe padronização, a partir do mobile componente segue comportamento de linha, em telas mobile segue comportamento de bloco, não sendo possível alterar este comportamento, verificar locais que utilizam para não quebrar o estilo.
+- `QasSelect`: removido propriedade `useSearch` pois agora existe o padrão de ter pesquisa pelo fuse sempre que existir pelo menos 10 opções e nunca menos que isto.
 
 ### Adicionado
 - `QasFilters`: adicionado nova propriedade `fieldsProps` para repassar propriedades para os campos do filtro.
-- `QaSelect`: adicionado busca automaticamente quando existem pelo menos 10 opções.
+- `QasSelect`: adicionado busca automaticamente quando existem pelo menos 10 opções.
 - `QasOptionGroup`: adicionado novo componente wrapper do `QOptionGroup` do quasar, para deixar padronizado propriedade `inline` e deixar mais componentizado.
 
 ### Modificado
-- `QasField`: Alterado type `radio` par utilizar o novo componente `QasOptionGroup` e removido prop de erro pois não existe no componente `QOptionGroup`.
+- `QasField`: alterado type `radio` par utilizar o novo componente `QasOptionGroup` e removido prop de erro pois não existe no componente `QOptionGroup`.
+- `QasField`: removido propriedade `useSearch` que era repassado para o `QasSelect` já que ela foi removido do mesmo.
+
+### Removido
+- `QasSelect`: removido propriedade `useSearch` pois agora existe o padrão de ter pesquisa pelo fuse sempre que existir pelo menos 10 opções e nunca menos que isto.
 
 ## [3.4.0-beta.1] - 11-11-2022
 ### Adicionado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+
+## BREAKING CHANGE
+- `QasField`: Alterado type `radio` par utilizar o novo componente `QasOptionGroup` e removido prop de erro pois não existe no componente `QOptionGroup`, testar bem para validar.
+- Componentes de radio agora existe padronização, a partir do mobile componente segue comportamento de linha, em telas mobile segue comportamento de bloco, não sendo possível alterar este comportamento, verificar locais que utilizam para não quebrar o estilo.
+
+### Adicionado
+- `QasFilters`: adicionado nova propriedade `fieldsProps` para repassar propriedades para os campos do filtro.
+- `QaSelect`: adicionado busca quando existe mais de pelo menos 10 opções.
+- `QasOptionGroup`: adicionado novo componente wrapper do `QOptionGroup` do quasar, para deixar padronizado propriedade `inline` e deixar mais componentizado.
+
+### Modificado
+- `QasField`: Alterado type `radio` par utilizar o novo componente `QasOptionGroup` e removido prop de erro pois não existe no componente `QOptionGroup`.
+
 ## [3.4.0-beta.1] - 11-11-2022
 ### Adicionado
 - `QasField`: repassando `useStrengthChecker` no QasField.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ### Adicionado
 - `QasFilters`: adicionado nova propriedade `fieldsProps` para repassar propriedades para os campos do filtro.
-- `QaSelect`: adicionado busca quando existe mais de pelo menos 10 opções.
+- `QaSelect`: adicionado busca automaticamente quando existem pelo menos 10 opções.
 - `QasOptionGroup`: adicionado novo componente wrapper do `QOptionGroup` do quasar, para deixar padronizado propriedade `inline` e deixar mais componentizado.
 
 ### Modificado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ### Modificado
 - `QasField`: alterado type `radio` par utilizar o novo componente `QasOptionGroup` e removido prop de erro pois não existe no componente `QOptionGroup`.
 - `QasField`: removido propriedade `useSearch` que era repassado para o `QasSelect` já que ela foi removido do mesmo.
+- `typography.scss`: alterado tipografia para seguir novo padrão de design.
 
 ### Removido
 - `QasSelect`: removido propriedade `useSearch` pois agora existe o padrão de ter pesquisa pelo fuse sempre que existir pelo menos 10 opções e nunca menos que isto.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## Não publicado
+## [3.4.0-beta.1] - 11-11-2022
 ### Adicionado
 - `QasField`: repassando `useStrengthChecker` no QasField.
 
@@ -506,3 +506,4 @@ Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitt
 [3.3.0]: https://github.com/bildvitta/asteroid/compare/v3.2.0...v3.3.0?expand=1
 [3.3.1-beta.0]: https://github.com/bildvitta/asteroid/compare/v3.3.0...v3.3.1-beta.0?expand=1
 [3.4.0-beta.0]: https://github.com/bildvitta/asteroid/compare/v3.3.1-beta.0...v3.4.0-beta.0?expand=1
+[3.4.0-beta.1]: https://github.com/bildvitta/asteroid/compare/v3.4.0-beta.0...v3.4.0-beta.1?expand=1

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
-  "version": "3.4.0-beta.0",
+  "version": "3.4.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bildvitta/quasar-ui-asteroid": {
-      "version": "3.4.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.4.0-beta.0.tgz",
-      "integrity": "sha512-cBRXYher5Wr80PYbeC9WLwQL467D31OJka1dwL1AfLNaA+fyC5W/nnkAr6tYrvtgv57vjJLeMw9oQ0H4uJQ1lg==",
+      "version": "3.4.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.4.0-beta.1.tgz",
+      "integrity": "sha512-Mk0SSSnagEHYcZ8+yIZAbRynEc9bgCPa6dVGU5BKpHN44j9mZI5KaRc2LwFAGY/ITdK+LEt0U1ve/w31gmyj6Q==",
       "requires": {
         "@bildvitta/store-adapter": "^1.0.0-beta.22",
         "@fawmi/vue-google-maps": "^0.9.4",

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
   "description": "Asteroid",
-  "version": "3.4.0-beta.0",
+  "version": "3.4.0-beta.1",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "src/index.js",
@@ -29,7 +29,7 @@
     "yarn": ">= 1.6.0"
   },
   "dependencies": {
-    "@bildvitta/quasar-ui-asteroid": "3.4.0-beta.0",
+    "@bildvitta/quasar-ui-asteroid": "3.4.0-beta.1",
     "@bildvitta/store-adapter": "^1.0.0-beta.23",
     "humps": "^2.0.1"
   }

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bildvitta/asteroid-docs",
-  "version": "3.4.0-beta.0",
+  "version": "3.4.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -194,21 +194,21 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.19.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.6.tgz",
-      "integrity": "sha512-D2Ue4KHpc6Ys2+AxpIx1BZ8+UegLLLE2p3KJEuJRKmokHOtl49jQ5ny1773KsGLZs8MQvBidAF6yWUJxRqtKtg==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.2.tgz",
+      "integrity": "sha512-w7DbG8DtMrJcFOi4VrLm+8QM4az8Mo+PuLBKLp2zrYRCow8W/f9xiXm5sN53C8HksCyDQwCKha9JiDoIyPjT2g==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.19.6",
-        "@babel/helper-compilation-targets": "^7.19.3",
-        "@babel/helper-module-transforms": "^7.19.6",
-        "@babel/helpers": "^7.19.4",
-        "@babel/parser": "^7.19.6",
+        "@babel/generator": "^7.20.2",
+        "@babel/helper-compilation-targets": "^7.20.0",
+        "@babel/helper-module-transforms": "^7.20.2",
+        "@babel/helpers": "^7.20.1",
+        "@babel/parser": "^7.20.2",
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.6",
-        "@babel/types": "^7.19.4",
+        "@babel/traverse": "^7.20.1",
+        "@babel/types": "^7.20.2",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -244,12 +244,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.1.tgz",
-      "integrity": "sha512-u1dMdBUmA7Z0rBB97xh8pIhviK7oItYOkjbsCxTWMknyvbQRBwX7/gn4JXurRdirWMFh+ZtYARqkA6ydogVZpg==",
+      "version": "7.20.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.4.tgz",
+      "integrity": "sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.20.0",
+        "@babel/types": "^7.20.2",
         "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       },
@@ -307,9 +307,9 @@
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.19.0.tgz",
-      "integrity": "sha512-NRz8DwF4jT3UfrmUoZjd0Uph9HQnP30t7Ash+weACcyNkiYTywpIjDBgReJMKgr+n86sn2nPVVmJ28Dm053Kqw==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.20.2.tgz",
+      "integrity": "sha512-k22GoYRAHPYr9I+Gvy2ZQlAe5mGy8BqWst2wRt8cwIufWTxrsVshhIBvYNqC80N0GSFWTsqRVexOtfzlgOEDvA==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
@@ -317,7 +317,7 @@
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-member-expression-to-functions": "^7.18.9",
         "@babel/helper-optimise-call-expression": "^7.18.6",
-        "@babel/helper-replace-supers": "^7.18.9",
+        "@babel/helper-replace-supers": "^7.19.1",
         "@babel/helper-split-export-declaration": "^7.18.6"
       }
     },
@@ -406,19 +406,19 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.19.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.6.tgz",
-      "integrity": "sha512-fCmcfQo/KYr/VXXDIyd3CBGZ6AFhPFy1TfSEJ+PilGVlQT6jcbqtHAM4C1EciRqMza7/TpOUZliuSH+U6HAhJw==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
+      "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
       "dev": true,
       "requires": {
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-module-imports": "^7.18.6",
-        "@babel/helper-simple-access": "^7.19.4",
+        "@babel/helper-simple-access": "^7.20.2",
         "@babel/helper-split-export-declaration": "^7.18.6",
         "@babel/helper-validator-identifier": "^7.19.1",
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.6",
-        "@babel/types": "^7.19.4"
+        "@babel/traverse": "^7.20.1",
+        "@babel/types": "^7.20.2"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -431,9 +431,9 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
-      "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+      "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
       "dev": true
     },
     "@babel/helper-remap-async-to-generator": {
@@ -462,12 +462,12 @@
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.19.4.tgz",
-      "integrity": "sha512-f9Xq6WqBFqaDfbCzn2w85hwklswz5qsKlh7f08w4Y9yhJHpnNC0QemtSkK5YyOY8kPGvyiwdzZksGUhnGdaUIg==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
+      "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.19.4"
+        "@babel/types": "^7.20.2"
       }
     },
     "@babel/helper-skip-transparent-expression-wrappers": {
@@ -554,9 +554,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.1.tgz",
-      "integrity": "sha512-hp0AYxaZJhxULfM1zyp7Wgr+pSUKBcP3M+PHnSzWGdXOzg/kHWIgiUWARvubhUKGOEw3xqY4x+lyZ9ytBVcELw=="
+      "version": "7.20.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.3.tgz",
+      "integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg=="
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
       "version": "7.18.6",
@@ -612,13 +612,13 @@
       }
     },
     "@babel/plugin-proposal-decorators": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.20.0.tgz",
-      "integrity": "sha512-vnuRRS20ygSxclEYikHzVrP9nZDFXaSzvJxGLQNAiBX041TmhS4hOUHWNIpq/q4muENuEP9XPJFXTNFejhemkg==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.20.2.tgz",
+      "integrity": "sha512-nkBH96IBmgKnbHQ5gXFrcmez+Z9S2EIDKDQGp005ROqBigc88Tky4rzCnlP/lnlj245dCEQl4/YyV0V1kYh5dw==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.19.0",
-        "@babel/helper-plugin-utils": "^7.19.0",
+        "@babel/helper-create-class-features-plugin": "^7.20.2",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/helper-replace-supers": "^7.19.1",
         "@babel/helper-split-export-declaration": "^7.18.6",
         "@babel/plugin-syntax-decorators": "^7.19.0"
@@ -696,16 +696,16 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.19.4.tgz",
-      "integrity": "sha512-wHmj6LDxVDnL+3WhXteUBaoM1aVILZODAUjg11kHqG4cOlfgMQGxw6aCgvrXrmaJR3Bn14oZhImyCPZzRpC93Q==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.2.tgz",
+      "integrity": "sha512-Ks6uej9WFK+fvIMesSqbAto5dD8Dz4VuuFvGJFKgIGSkJuRGcrwGECPA1fDgQK3/DbExBJpEkTeYeB8geIFCSQ==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.19.4",
-        "@babel/helper-compilation-targets": "^7.19.3",
-        "@babel/helper-plugin-utils": "^7.19.0",
+        "@babel/compat-data": "^7.20.1",
+        "@babel/helper-compilation-targets": "^7.20.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.18.8"
+        "@babel/plugin-transform-parameters": "^7.20.1"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
@@ -972,27 +972,27 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.20.0.tgz",
-      "integrity": "sha512-sXOohbpHZSk7GjxK9b3dKB7CfqUD5DwOH+DggKzOQ7TXYP+RCSbRykfjQmn/zq+rBjycVRtLf9pYhAaEJA786w==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.20.2.tgz",
+      "integrity": "sha512-y5V15+04ry69OV2wULmwhEA6jwSWXO1TwAtIwiPXcvHcoOQUqpyMVd2bDsQJMW8AurjulIyUV8kDqtjSwHy1uQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.19.0"
+        "@babel/helper-plugin-utils": "^7.20.2"
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.19.0.tgz",
-      "integrity": "sha512-YfeEE9kCjqTS9IitkgfJuxjcEtLUHMqa8yUJ6zdz8vR7hKuo6mOy2C05P0F1tdMmDCeuyidKnlrw/iTppHcr2A==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.20.2.tgz",
+      "integrity": "sha512-9rbPp0lCVVoagvtEyQKSo5L8oo0nQS/iif+lwlAz29MccX2642vWDlSZK+2T2buxbopotId2ld7zZAzRfz9j1g==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-compilation-targets": "^7.19.0",
+        "@babel/helper-compilation-targets": "^7.20.0",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-optimise-call-expression": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.19.0",
-        "@babel/helper-replace-supers": "^7.18.9",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-replace-supers": "^7.19.1",
         "@babel/helper-split-export-declaration": "^7.18.6",
         "globals": "^11.1.0"
       }
@@ -1007,12 +1007,12 @@
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.20.0.tgz",
-      "integrity": "sha512-1dIhvZfkDVx/zn2S1aFwlruspTt4189j7fEkH0Y0VyuDM6bQt7bD6kLcz3l4IlLG+e5OReaBz9ROAbttRtUHqA==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.20.2.tgz",
+      "integrity": "sha512-mENM+ZHrvEgxLTBXUiQ621rRXZes3KWUv6NdQlrnr1TkWVw+hUjQBZuP2X32qKlrlG2BzgR95gkuCRSkJl8vIw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.19.0"
+        "@babel/helper-plugin-utils": "^7.20.2"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
@@ -1155,12 +1155,12 @@
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.20.1.tgz",
-      "integrity": "sha512-nDvKLrAvl+kf6BOy1UJ3MGwzzfTMgppxwiD2Jb4LO3xjYyZq30oQzDNJbCQpMdG9+j2IXHoiMrw5Cm/L6ZoxXQ==",
+      "version": "7.20.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.20.3.tgz",
+      "integrity": "sha512-oZg/Fpx0YDrj13KsLyO8I/CX3Zdw7z0O9qOd95SqcoIzuqy/WTGWvePeHAnZCN54SfdyjHcb1S30gc8zlzlHcA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.19.0"
+        "@babel/helper-plugin-utils": "^7.20.2"
       }
     },
     "@babel/plugin-transform-property-literals": {
@@ -1279,18 +1279,18 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.19.4.tgz",
-      "integrity": "sha512-5QVOTXUdqTCjQuh2GGtdd7YEhoRXBMVGROAtsBeLGIbIz3obCBIfRMT1I3ZKkMgNzwkyCkftDXSSkHxnfVf4qg==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.20.2.tgz",
+      "integrity": "sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.19.4",
-        "@babel/helper-compilation-targets": "^7.19.3",
-        "@babel/helper-plugin-utils": "^7.19.0",
+        "@babel/compat-data": "^7.20.1",
+        "@babel/helper-compilation-targets": "^7.20.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/helper-validator-option": "^7.18.6",
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.18.6",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.18.9",
-        "@babel/plugin-proposal-async-generator-functions": "^7.19.1",
+        "@babel/plugin-proposal-async-generator-functions": "^7.20.1",
         "@babel/plugin-proposal-class-properties": "^7.18.6",
         "@babel/plugin-proposal-class-static-block": "^7.18.6",
         "@babel/plugin-proposal-dynamic-import": "^7.18.6",
@@ -1299,7 +1299,7 @@
         "@babel/plugin-proposal-logical-assignment-operators": "^7.18.9",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
         "@babel/plugin-proposal-numeric-separator": "^7.18.6",
-        "@babel/plugin-proposal-object-rest-spread": "^7.19.4",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.2",
         "@babel/plugin-proposal-optional-catch-binding": "^7.18.6",
         "@babel/plugin-proposal-optional-chaining": "^7.18.9",
         "@babel/plugin-proposal-private-methods": "^7.18.6",
@@ -1310,7 +1310,7 @@
         "@babel/plugin-syntax-class-static-block": "^7.14.5",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-        "@babel/plugin-syntax-import-assertions": "^7.18.6",
+        "@babel/plugin-syntax-import-assertions": "^7.20.0",
         "@babel/plugin-syntax-json-strings": "^7.8.3",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
@@ -1323,10 +1323,10 @@
         "@babel/plugin-transform-arrow-functions": "^7.18.6",
         "@babel/plugin-transform-async-to-generator": "^7.18.6",
         "@babel/plugin-transform-block-scoped-functions": "^7.18.6",
-        "@babel/plugin-transform-block-scoping": "^7.19.4",
-        "@babel/plugin-transform-classes": "^7.19.0",
+        "@babel/plugin-transform-block-scoping": "^7.20.2",
+        "@babel/plugin-transform-classes": "^7.20.2",
         "@babel/plugin-transform-computed-properties": "^7.18.9",
-        "@babel/plugin-transform-destructuring": "^7.19.4",
+        "@babel/plugin-transform-destructuring": "^7.20.2",
         "@babel/plugin-transform-dotall-regex": "^7.18.6",
         "@babel/plugin-transform-duplicate-keys": "^7.18.9",
         "@babel/plugin-transform-exponentiation-operator": "^7.18.6",
@@ -1334,14 +1334,14 @@
         "@babel/plugin-transform-function-name": "^7.18.9",
         "@babel/plugin-transform-literals": "^7.18.9",
         "@babel/plugin-transform-member-expression-literals": "^7.18.6",
-        "@babel/plugin-transform-modules-amd": "^7.18.6",
-        "@babel/plugin-transform-modules-commonjs": "^7.18.6",
-        "@babel/plugin-transform-modules-systemjs": "^7.19.0",
+        "@babel/plugin-transform-modules-amd": "^7.19.6",
+        "@babel/plugin-transform-modules-commonjs": "^7.19.6",
+        "@babel/plugin-transform-modules-systemjs": "^7.19.6",
         "@babel/plugin-transform-modules-umd": "^7.18.6",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.19.1",
         "@babel/plugin-transform-new-target": "^7.18.6",
         "@babel/plugin-transform-object-super": "^7.18.6",
-        "@babel/plugin-transform-parameters": "^7.18.8",
+        "@babel/plugin-transform-parameters": "^7.20.1",
         "@babel/plugin-transform-property-literals": "^7.18.6",
         "@babel/plugin-transform-regenerator": "^7.18.6",
         "@babel/plugin-transform-reserved-words": "^7.18.6",
@@ -1353,7 +1353,7 @@
         "@babel/plugin-transform-unicode-escapes": "^7.18.10",
         "@babel/plugin-transform-unicode-regex": "^7.18.6",
         "@babel/preset-modules": "^0.1.5",
-        "@babel/types": "^7.19.4",
+        "@babel/types": "^7.20.2",
         "babel-plugin-polyfill-corejs2": "^0.3.3",
         "babel-plugin-polyfill-corejs3": "^0.6.0",
         "babel-plugin-polyfill-regenerator": "^0.4.1",
@@ -1420,9 +1420,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
-      "integrity": "sha512-Jlgt3H0TajCW164wkTOTzHkZb075tMQMULzrLUoUeKmO7eFL96GgDxf7/Axhc5CAuKE3KFyVW1p6ysKsi2oXAg==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
+      "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
       "dev": true,
       "requires": {
         "@babel/helper-string-parser": "^7.19.4",
@@ -1470,9 +1470,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.19.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.4.tgz",
-          "integrity": "sha512-qpVT7gtuOLjWeDTKLkJ6sryqLliBaFpAtGeqw5cs5giLldvh+Ch0plqnUMKoVAUS6ZEueQQiZV+p5pxtPitEsA=="
+          "version": "7.20.1",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.1.tgz",
+          "integrity": "sha512-hp0AYxaZJhxULfM1zyp7Wgr+pSUKBcP3M+PHnSzWGdXOzg/kHWIgiUWARvubhUKGOEw3xqY4x+lyZ9ytBVcELw=="
         },
         "@bildvitta/store-adapter": {
           "version": "1.0.0-beta.23",
@@ -1492,9 +1492,9 @@
           }
         },
         "@googlemaps/markerclusterer": {
-          "version": "2.0.11",
-          "resolved": "https://registry.npmjs.org/@googlemaps/markerclusterer/-/markerclusterer-2.0.11.tgz",
-          "integrity": "sha512-/Rhqqq12vGwg+EuzaQtzjqrF5CFiGlJpPlC+bjVH/WYbZ4gPGARuEzWqRhY8m1u2cZDHF0yZrJKPOuYzc+2PcA==",
+          "version": "2.0.13",
+          "resolved": "https://registry.npmjs.org/@googlemaps/markerclusterer/-/markerclusterer-2.0.13.tgz",
+          "integrity": "sha512-302GjQ9gsHOK/ef6hif+rJDv+AB3THst02iDCbXH2PS9GFwb/5yuytaLpuzJiqGNG+k2zvTAWTsGY/fQN5DZ7w==",
           "requires": {
             "fast-deep-equal": "^3.1.3",
             "supercluster": "^7.1.3"
@@ -1544,16 +1544,16 @@
           }
         },
         "@microsoft/api-extractor": {
-          "version": "7.33.2",
-          "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.33.2.tgz",
-          "integrity": "sha512-OTCOtpQgvvRnxyCAHCPEDXVyJXrj54sGNCltOQaaT1wkTUPmRYo/I8yrCGXiBPUIHOpV3lUnaDJkzQF9dtbNWA==",
+          "version": "7.33.5",
+          "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.33.5.tgz",
+          "integrity": "sha512-ENoWpTWarKNuodpRFDQr3jyBigHuv98KuJ8H5qXc1LZ1aP5Mk77lCo88HbPisTmSnGevJJHTScfd/DPznOb4CQ==",
           "requires": {
-            "@microsoft/api-extractor-model": "7.25.1",
-            "@microsoft/tsdoc": "0.14.1",
+            "@microsoft/api-extractor-model": "7.25.2",
+            "@microsoft/tsdoc": "0.14.2",
             "@microsoft/tsdoc-config": "~0.16.1",
             "@rushstack/node-core-library": "3.53.2",
             "@rushstack/rig-package": "0.3.17",
-            "@rushstack/ts-command-line": "4.12.5",
+            "@rushstack/ts-command-line": "4.13.0",
             "colors": "~1.2.1",
             "lodash": "~4.17.15",
             "resolve": "~1.17.0",
@@ -1563,19 +1563,19 @@
           }
         },
         "@microsoft/api-extractor-model": {
-          "version": "7.25.1",
-          "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.25.1.tgz",
-          "integrity": "sha512-AaZ0ohCGLRjWiZviM+0p/DaxgMhbawS183LW2+CSqyEBh6wZks7NjoyhzhibAYapS4omnrmv96+0V/2wBvnIZQ==",
+          "version": "7.25.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.25.2.tgz",
+          "integrity": "sha512-+h1uCrLQXFAKMUdghhdDcnniDB+6UA/lS9ArlB4QZQ34UbLuXNy2oQ6fafFK8cKXU4mUPTF/yGRjv7JKD5L7eg==",
           "requires": {
-            "@microsoft/tsdoc": "0.14.1",
+            "@microsoft/tsdoc": "0.14.2",
             "@microsoft/tsdoc-config": "~0.16.1",
             "@rushstack/node-core-library": "3.53.2"
           }
         },
         "@microsoft/tsdoc": {
-          "version": "0.14.1",
-          "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.1.tgz",
-          "integrity": "sha512-6Wci+Tp3CgPt/B9B0a3J4s3yMgLNSku6w5TV6mN+61C71UqsRBv2FUibBf3tPGlNxebgPHMEUzKpb1ggE8KCKw=="
+          "version": "0.14.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz",
+          "integrity": "sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug=="
         },
         "@microsoft/tsdoc-config": {
           "version": "0.16.2",
@@ -1588,11 +1588,6 @@
             "resolve": "~1.19.0"
           },
           "dependencies": {
-            "@microsoft/tsdoc": {
-              "version": "0.14.2",
-              "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz",
-              "integrity": "sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug=="
-            },
             "resolve": {
               "version": "1.19.0",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
@@ -1701,9 +1696,9 @@
           }
         },
         "@rushstack/ts-command-line": {
-          "version": "4.12.5",
-          "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.12.5.tgz",
-          "integrity": "sha512-PCKrOu4RXKXPHcswHEQ9MYDW7Z7iQ+vbkvPtqHC46zFxD67ZCBXkm9P8QNOtED0cQzXh5nCtFnSOMuaOQf0GaQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.13.0.tgz",
+          "integrity": "sha512-crLT31kl+qilz0eBRjqqYO06CqwbElc0EvzS6jI69B9Ikt1SkkSzIZ2iDP7zt/rd1ZYipKIS9hf9CQR9swDIKg==",
           "requires": {
             "@types/argparse": "1.0.38",
             "argparse": "~1.0.9",
@@ -1822,9 +1817,9 @@
           "integrity": "sha512-W9mfWLHmJhkfAmV+7gDjcHeAWALQtgGT3JErxULl0oz6R6+3ug91I7IErs93eCFhPCZPHBs4QJS7YWEV7A3sxw=="
         },
         "acorn": {
-          "version": "8.8.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
+          "version": "8.8.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+          "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA=="
         },
         "ajv": {
           "version": "6.12.6",
@@ -1868,12 +1863,12 @@
           "integrity": "sha512-bYnD2oD9UMZBTxSWcvXH1MTcp0w+CUBfXe4HI1QJLGzJu+O27Ny5gqzRcFuDsZB9jrZ5SJjqAG0PieJsaUdTcg=="
         },
         "autoprefixer": {
-          "version": "10.4.12",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.12.tgz",
-          "integrity": "sha512-WrCGV9/b97Pa+jtwf5UGaRjgQIg7OK3D06GnoYoZNcG1Xb8Gt3EfuKjlhh9i/VtT16g6PYjZ69jdJ2g8FxSC4Q==",
+          "version": "10.4.13",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
+          "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
           "requires": {
             "browserslist": "^4.21.4",
-            "caniuse-lite": "^1.0.30001407",
+            "caniuse-lite": "^1.0.30001426",
             "fraction.js": "^4.2.0",
             "normalize-range": "^0.1.2",
             "picocolors": "^1.0.0",
@@ -1931,9 +1926,9 @@
           "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
         },
         "caniuse-lite": {
-          "version": "1.0.30001419",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001419.tgz",
-          "integrity": "sha512-aFO1r+g6R7TW+PNQxKzjITwLOyDhVRLjW0LcwS/HCZGUUKTGNp9+IwLC4xyDSZBygVL/mxaFR3HIV6wEKQuSzw=="
+          "version": "1.0.30001429",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001429.tgz",
+          "integrity": "sha512-511ThLu1hF+5RRRt0zYCf2U2yRr9GPF6m5y90SBCWsvSoYoW7yAGlv/elyPaNfvGCkp6kj/KFZWU0BMA69Prsg=="
         },
         "chalk": {
           "version": "2.4.2",
@@ -1993,9 +1988,9 @@
           "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
         },
         "core-js": {
-          "version": "3.25.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.5.tgz",
-          "integrity": "sha512-nbm6eZSjm+ZuBQxCUPQKQCoUEfFOXjUZ8dTTyikyKaWrTYmAVbykQfwsKE5dBK88u3QCkCrzsx/PPlKfhsvgpw=="
+          "version": "3.26.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.0.tgz",
+          "integrity": "sha512-+DkDrhoR4Y0PxDz6rurahuB+I45OsEUv8E1maPTB6OuHRohMMcznBq9TMpdpDMm/hUPob/mJJS3PqgbHpMTQgw=="
         },
         "date-fns": {
           "version": "2.29.3",
@@ -2011,9 +2006,9 @@
           }
         },
         "electron-to-chromium": {
-          "version": "1.4.282",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.282.tgz",
-          "integrity": "sha512-Dki0WhHNh/br/Xi1vAkueU5mtIc9XLHcMKB6tNfQKk+kPG0TEUjRh5QEMAUbRp30/rYNMFD1zKKvbVzwq/4wmg=="
+          "version": "1.4.284",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+          "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
         },
         "escalade": {
           "version": "3.1.1",
@@ -2225,9 +2220,9 @@
           }
         },
         "is-core-module": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-          "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+          "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
           "requires": {
             "has": "^1.0.3"
           }
@@ -2500,9 +2495,9 @@
           "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         },
         "quasar": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/quasar/-/quasar-2.10.0.tgz",
-          "integrity": "sha512-PHGcrzPQfFa4tv9a5Z/3D2uat48D4WC9Ad/imzHk/k3G41t0eFMH6glCjAvpCWF2q8dBYIg4nEchiPhlujbKsw=="
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/quasar/-/quasar-2.10.1.tgz",
+          "integrity": "sha512-W0SEbTdfFS4xvO5OyTyuJent+11MpjBJUYLga69ZFigRh7SV6wFpGNfCuxAifM0L83bp4rWrL2KGoIjEoDsjOw=="
         },
         "queue-microtask": {
           "version": "1.2.3",
@@ -2640,9 +2635,9 @@
           }
         },
         "signature_pad": {
-          "version": "4.0.10",
-          "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-4.0.10.tgz",
-          "integrity": "sha512-PcIm/C55wLgEA36udwW5iaGI9cN9GkRLVHO8Ao4QElcJtYwwhIfYwZt2ui/IAzskD1aZi1Sy2yP3JkVZCv773g=="
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-4.1.3.tgz",
+          "integrity": "sha512-R/2Qm7WSoV9lYpSbe3oX+dwdJ6mJqLg1q3XsRPmB+Kgg4uHAbgrt8CPX8sSmBGP191zLjgZCGWfsQy92Aech5A=="
         },
         "sortablejs": {
           "version": "1.15.0",
@@ -2953,16 +2948,16 @@
       "dev": true
     },
     "@microsoft/api-extractor": {
-      "version": "7.33.5",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.33.5.tgz",
-      "integrity": "sha512-ENoWpTWarKNuodpRFDQr3jyBigHuv98KuJ8H5qXc1LZ1aP5Mk77lCo88HbPisTmSnGevJJHTScfd/DPznOb4CQ==",
+      "version": "7.33.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.33.6.tgz",
+      "integrity": "sha512-EYu1qWiMyvP/P+7na76PbE7+eOtvuYIvQa2DhZqkSQSLYP2sKLmZaSMK5Jvpgdr0fK/xLFujK5vLf3vpfcmC8g==",
       "requires": {
         "@microsoft/api-extractor-model": "7.25.2",
         "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
         "@rushstack/node-core-library": "3.53.2",
         "@rushstack/rig-package": "0.3.17",
-        "@rushstack/ts-command-line": "4.13.0",
+        "@rushstack/ts-command-line": "4.13.1",
         "colors": "~1.2.1",
         "lodash": "~4.17.15",
         "resolve": "~1.17.0",
@@ -3457,6 +3452,31 @@
       "requires": {
         "@babel/helper-module-imports": "^7.10.4",
         "@rollup/pluginutils": "^3.1.0"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+          "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "0.0.39",
+            "estree-walker": "^1.0.1",
+            "picomatch": "^2.2.2"
+          }
+        },
+        "@types/estree": {
+          "version": "0.0.39",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+          "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+          "dev": true
+        },
+        "estree-walker": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+          "dev": true
+        }
       }
     },
     "@rollup/plugin-node-resolve": {
@@ -3473,6 +3493,29 @@
         "resolve": "^1.19.0"
       },
       "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+          "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "0.0.39",
+            "estree-walker": "^1.0.1",
+            "picomatch": "^2.2.2"
+          }
+        },
+        "@types/estree": {
+          "version": "0.0.39",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+          "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+          "dev": true
+        },
+        "estree-walker": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+          "dev": true
+        },
         "resolve": {
           "version": "1.22.1",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -3494,19 +3537,19 @@
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
         "magic-string": "^0.25.7"
-      }
-    },
-    "@rollup/pluginutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "dev": true,
-      "requires": {
-        "@types/estree": "0.0.39",
-        "estree-walker": "^1.0.1",
-        "picomatch": "^2.2.2"
       },
       "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+          "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "0.0.39",
+            "estree-walker": "^1.0.1",
+            "picomatch": "^2.2.2"
+          }
+        },
         "@types/estree": {
           "version": "0.0.39",
           "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -3519,6 +3562,16 @@
           "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
           "dev": true
         }
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+      "requires": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
       }
     },
     "@rushstack/node-core-library": {
@@ -3558,9 +3611,9 @@
       }
     },
     "@rushstack/ts-command-line": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.13.0.tgz",
-      "integrity": "sha512-crLT31kl+qilz0eBRjqqYO06CqwbElc0EvzS6jI69B9Ikt1SkkSzIZ2iDP7zt/rd1ZYipKIS9hf9CQR9swDIKg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.13.1.tgz",
+      "integrity": "sha512-UTQMRyy/jH1IS2U+6pyzyn9xQ2iMcoUKkTcZUzOP/aaMiKlWLwCTDiBVwhw/M1crDx6apF9CwyjuWO9r1SBdJQ==",
       "requires": {
         "@types/argparse": "1.0.38",
         "argparse": "~1.0.9",
@@ -3687,9 +3740,9 @@
       }
     },
     "@types/eslint": {
-      "version": "8.4.9",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.9.tgz",
-      "integrity": "sha512-jFCSo4wJzlHQLCpceUhUnXdrPuCNOjGFMQ8Eg6JXxlz3QaCKOb7eGi2cephQdM4XTYsNej69P9JDJ1zqNIbncQ==",
+      "version": "8.4.10",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
+      "integrity": "sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==",
       "dev": true,
       "requires": {
         "@types/estree": "*",
@@ -3707,10 +3760,9 @@
       }
     },
     "@types/estree": {
-      "version": "0.0.51",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ=="
     },
     "@types/express": {
       "version": "4.17.13",
@@ -3914,36 +3966,36 @@
       }
     },
     "@vue/compiler-core": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.41.tgz",
-      "integrity": "sha512-oA4mH6SA78DT+96/nsi4p9DX97PHcNROxs51lYk7gb9Z4BPKQ3Mh+BLn6CQZBw857Iuhu28BfMSRHAlPvD4vlw==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.45.tgz",
+      "integrity": "sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==",
       "requires": {
         "@babel/parser": "^7.16.4",
-        "@vue/shared": "3.2.41",
+        "@vue/shared": "3.2.45",
         "estree-walker": "^2.0.2",
         "source-map": "^0.6.1"
       }
     },
     "@vue/compiler-dom": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.41.tgz",
-      "integrity": "sha512-xe5TbbIsonjENxJsYRbDJvthzqxLNk+tb3d/c47zgREDa/PCp6/Y4gC/skM4H6PIuX5DAxm7fFJdbjjUH2QTMw==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.45.tgz",
+      "integrity": "sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==",
       "requires": {
-        "@vue/compiler-core": "3.2.41",
-        "@vue/shared": "3.2.41"
+        "@vue/compiler-core": "3.2.45",
+        "@vue/shared": "3.2.45"
       }
     },
     "@vue/compiler-sfc": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.41.tgz",
-      "integrity": "sha512-+1P2m5kxOeaxVmJNXnBskAn3BenbTmbxBxWOtBq3mQTCokIreuMULFantBUclP0+KnzNCMOvcnKinqQZmiOF8w==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.45.tgz",
+      "integrity": "sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==",
       "requires": {
         "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.41",
-        "@vue/compiler-dom": "3.2.41",
-        "@vue/compiler-ssr": "3.2.41",
-        "@vue/reactivity-transform": "3.2.41",
-        "@vue/shared": "3.2.41",
+        "@vue/compiler-core": "3.2.45",
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/compiler-ssr": "3.2.45",
+        "@vue/reactivity-transform": "3.2.45",
+        "@vue/shared": "3.2.45",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7",
         "postcss": "^8.1.10",
@@ -3951,12 +4003,12 @@
       }
     },
     "@vue/compiler-ssr": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.41.tgz",
-      "integrity": "sha512-Y5wPiNIiaMz/sps8+DmhaKfDm1xgj6GrH99z4gq2LQenfVQcYXmHIOBcs5qPwl7jaW3SUQWjkAPKMfQemEQZwQ==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.45.tgz",
+      "integrity": "sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==",
       "requires": {
-        "@vue/compiler-dom": "3.2.41",
-        "@vue/shared": "3.2.41"
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/shared": "3.2.45"
       }
     },
     "@vue/devtools-api": {
@@ -3965,57 +4017,57 @@
       "integrity": "sha512-JD5fcdIuFxU4fQyXUu3w2KpAJHzTVdN+p4iOX2lMWSHMOoQdMAcpFLZzm9Z/2nmsoZ1a96QEhZ26e50xLBsgOQ=="
     },
     "@vue/reactivity": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.41.tgz",
-      "integrity": "sha512-9JvCnlj8uc5xRiQGZ28MKGjuCoPhhTwcoAdv3o31+cfGgonwdPNuvqAXLhlzu4zwqavFEG5tvaoINQEfxz+l6g==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.45.tgz",
+      "integrity": "sha512-PRvhCcQcyEVohW0P8iQ7HDcIOXRjZfAsOds3N99X/Dzewy8TVhTCT4uXpAHfoKjVTJRA0O0K+6QNkDIZAxNi3A==",
       "requires": {
-        "@vue/shared": "3.2.41"
+        "@vue/shared": "3.2.45"
       }
     },
     "@vue/reactivity-transform": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.41.tgz",
-      "integrity": "sha512-mK5+BNMsL4hHi+IR3Ft/ho6Za+L3FA5j8WvreJ7XzHrqkPq8jtF/SMo7tuc9gHjLDwKZX1nP1JQOKo9IEAn54A==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.45.tgz",
+      "integrity": "sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==",
       "requires": {
         "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.41",
-        "@vue/shared": "3.2.41",
+        "@vue/compiler-core": "3.2.45",
+        "@vue/shared": "3.2.45",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7"
       }
     },
     "@vue/runtime-core": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.41.tgz",
-      "integrity": "sha512-0LBBRwqnI0p4FgIkO9q2aJBBTKDSjzhnxrxHYengkAF6dMOjeAIZFDADAlcf2h3GDALWnblbeprYYpItiulSVQ==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.45.tgz",
+      "integrity": "sha512-gzJiTA3f74cgARptqzYswmoQx0fIA+gGYBfokYVhF8YSXjWTUA2SngRzZRku2HbGbjzB6LBYSbKGIaK8IW+s0A==",
       "requires": {
-        "@vue/reactivity": "3.2.41",
-        "@vue/shared": "3.2.41"
+        "@vue/reactivity": "3.2.45",
+        "@vue/shared": "3.2.45"
       }
     },
     "@vue/runtime-dom": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.41.tgz",
-      "integrity": "sha512-U7zYuR1NVIP8BL6jmOqmapRAHovEFp7CSw4pR2FacqewXNGqZaRfHoNLQsqQvVQ8yuZNZtxSZy0FFyC70YXPpA==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.45.tgz",
+      "integrity": "sha512-cy88YpfP5Ue2bDBbj75Cb4bIEZUMM/mAkDMfqDTpUYVgTf/kuQ2VQ8LebuZ8k6EudgH8pYhsGWHlY0lcxlvTwA==",
       "requires": {
-        "@vue/runtime-core": "3.2.41",
-        "@vue/shared": "3.2.41",
+        "@vue/runtime-core": "3.2.45",
+        "@vue/shared": "3.2.45",
         "csstype": "^2.6.8"
       }
     },
     "@vue/server-renderer": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.41.tgz",
-      "integrity": "sha512-7YHLkfJdTlsZTV0ae5sPwl9Gn/EGr2hrlbcS/8naXm2CDpnKUwC68i1wGlrYAfIgYWL7vUZwk2GkYLQH5CvFig==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.45.tgz",
+      "integrity": "sha512-ebiMq7q24WBU1D6uhPK//2OTR1iRIyxjF5iVq/1a5I1SDMDyDu4Ts6fJaMnjrvD3MqnaiFkKQj+LKAgz5WIK3g==",
       "requires": {
-        "@vue/compiler-ssr": "3.2.41",
-        "@vue/shared": "3.2.41"
+        "@vue/compiler-ssr": "3.2.45",
+        "@vue/shared": "3.2.45"
       }
     },
     "@vue/shared": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.41.tgz",
-      "integrity": "sha512-W9mfWLHmJhkfAmV+7gDjcHeAWALQtgGT3JErxULl0oz6R6+3ug91I7IErs93eCFhPCZPHBs4QJS7YWEV7A3sxw=="
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
+      "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg=="
     },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -4218,9 +4270,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -4909,9 +4961,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001429",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001429.tgz",
-      "integrity": "sha512-511ThLu1hF+5RRRt0zYCf2U2yRr9GPF6m5y90SBCWsvSoYoW7yAGlv/elyPaNfvGCkp6kj/KFZWU0BMA69Prsg==",
+      "version": "1.0.30001431",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz",
+      "integrity": "sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==",
       "dev": true
     },
     "chalk": {
@@ -5383,14 +5435,14 @@
       }
     },
     "core-js": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.0.tgz",
-      "integrity": "sha512-+DkDrhoR4Y0PxDz6rurahuB+I45OsEUv8E1maPTB6OuHRohMMcznBq9TMpdpDMm/hUPob/mJJS3PqgbHpMTQgw=="
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.1.tgz",
+      "integrity": "sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA=="
     },
     "core-js-compat": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.26.0.tgz",
-      "integrity": "sha512-piOX9Go+Z4f9ZiBFLnZ5VrOpBl0h7IGCkiFUN11QTe6LjAvOT3ifL/5TdoizMh99hcGy5SoLyWbapIY/PIb/3A==",
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.26.1.tgz",
+      "integrity": "sha512-622/KzTudvXCDLRw70iHW4KKs1aGpcRcowGWyYJr2DEBfRrd6hNJybxSWJFuZYD4ma86xhrwDDHxmDaIq4EA8A==",
       "dev": true,
       "requires": {
         "browserslist": "^4.21.4"
@@ -7393,9 +7445,9 @@
       "dev": true
     },
     "idb": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.0.tgz",
-      "integrity": "sha512-Wsk07aAxDsntgYJY4h0knZJuTxM73eQ4reRAO+Z1liOh8eMCJ/MoDS8fCui1vGT9mnjtl1sOu3I2i/W1swPYZg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
       "dev": true
     },
     "ieee754": {
@@ -8157,9 +8209,9 @@
       "dev": true
     },
     "loader-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
-      "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
       "requires": {
         "big.js": "^5.2.2",
@@ -8388,9 +8440,9 @@
       }
     },
     "memfs": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.10.tgz",
-      "integrity": "sha512-0bCUP+L79P4am30yP1msPzApwuMQG23TjwlwdHeEV5MxioDR1a0AgB0T9FfggU52eJuDCq8WVwb5ekznFyWiTQ==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.11.tgz",
+      "integrity": "sha512-GvsCITGAyDCxxsJ+X6prJexFQEhOCJaIlUbsAvjzSI5o5O7j2dle3jWvz5Z5aOdpOxW6ol3vI1+0ut+641F1+w==",
       "dev": true,
       "requires": {
         "fs-monkey": "^1.0.3"
@@ -9139,9 +9191,9 @@
       }
     },
     "postcss": {
-      "version": "8.4.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
-      "integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
+      "version": "8.4.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
+      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
       "requires": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -9216,9 +9268,9 @@
       },
       "dependencies": {
         "cosmiconfig": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-          "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+          "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
           "dev": true,
           "requires": {
             "@types/parse-json": "^4.0.0",
@@ -9581,73 +9633,73 @@
       }
     },
     "pouchdb-adapter-http": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-adapter-http/-/pouchdb-adapter-http-7.3.0.tgz",
-      "integrity": "sha512-7nNfpbvL0MEu3RtwKkhi3VTxWDrSfEKyrWspSAhsFsn980okth5SRsEIQw0eJ4yNgJaVd47B/mUYVNphpyMTyQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-adapter-http/-/pouchdb-adapter-http-7.3.1.tgz",
+      "integrity": "sha512-09spFXxAvDsa8Q987FAFrqeKDvt8hiCuDjciLCR/uYEO8qwXg05o5CXEVVsHycpGdna1b0+i6i3ZWH+69lxmbg==",
       "requires": {
         "argsarray": "0.0.1",
-        "pouchdb-binary-utils": "7.3.0",
-        "pouchdb-errors": "7.3.0",
-        "pouchdb-fetch": "7.3.0",
-        "pouchdb-utils": "7.3.0"
+        "pouchdb-binary-utils": "7.3.1",
+        "pouchdb-errors": "7.3.1",
+        "pouchdb-fetch": "7.3.1",
+        "pouchdb-utils": "7.3.1"
       }
     },
     "pouchdb-adapter-idb": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-adapter-idb/-/pouchdb-adapter-idb-7.3.0.tgz",
-      "integrity": "sha512-qMy0lrB+LyOFyFUo7Gfr5VvSM1IXyP2c9N2XwmMSSaTib/OsNnBqLj8AWrgPEnzvEkDgImBkk34e5F6MlUFRyA==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-adapter-idb/-/pouchdb-adapter-idb-7.3.1.tgz",
+      "integrity": "sha512-lTlj64QhCvmxrjNowQRuy9FACSrG8j7YIlBiGfmwjOmcfVnU2GP5LLW3CWnkQxsBZ4SL7eg2icB2vOXKLMiADQ==",
       "requires": {
-        "pouchdb-adapter-utils": "7.3.0",
-        "pouchdb-binary-utils": "7.3.0",
-        "pouchdb-collections": "7.3.0",
-        "pouchdb-errors": "7.3.0",
-        "pouchdb-json": "7.3.0",
-        "pouchdb-merge": "7.3.0",
-        "pouchdb-utils": "7.3.0"
+        "pouchdb-adapter-utils": "7.3.1",
+        "pouchdb-binary-utils": "7.3.1",
+        "pouchdb-collections": "7.3.1",
+        "pouchdb-errors": "7.3.1",
+        "pouchdb-json": "7.3.1",
+        "pouchdb-merge": "7.3.1",
+        "pouchdb-utils": "7.3.1"
       }
     },
     "pouchdb-adapter-leveldb-core": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-adapter-leveldb-core/-/pouchdb-adapter-leveldb-core-7.3.0.tgz",
-      "integrity": "sha512-OyUsEae1JlqR2jSGMohP03gj6VANh9fDR/3nPIa1vYyoQWlwQzOS7knKqDaJm7Nui3JC5q/lWos7/FGZBFuF5Q==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-adapter-leveldb-core/-/pouchdb-adapter-leveldb-core-7.3.1.tgz",
+      "integrity": "sha512-mxShHlqLMPz2gChrgtA9okV1ogFmQrRAoM/O4EN0CrQWPLXqYtpL1f7sI2asIvFe7SmpnvbLx7kkZyFmLTfwjA==",
       "requires": {
         "argsarray": "0.0.1",
         "buffer-from": "1.1.2",
         "double-ended-queue": "2.1.0-0",
         "levelup": "4.4.0",
-        "pouchdb-adapter-utils": "7.3.0",
-        "pouchdb-binary-utils": "7.3.0",
-        "pouchdb-collections": "7.3.0",
-        "pouchdb-errors": "7.3.0",
-        "pouchdb-json": "7.3.0",
-        "pouchdb-md5": "7.3.0",
-        "pouchdb-merge": "7.3.0",
-        "pouchdb-utils": "7.3.0",
-        "sublevel-pouchdb": "7.3.0",
+        "pouchdb-adapter-utils": "7.3.1",
+        "pouchdb-binary-utils": "7.3.1",
+        "pouchdb-collections": "7.3.1",
+        "pouchdb-errors": "7.3.1",
+        "pouchdb-json": "7.3.1",
+        "pouchdb-md5": "7.3.1",
+        "pouchdb-merge": "7.3.1",
+        "pouchdb-utils": "7.3.1",
+        "sublevel-pouchdb": "7.3.1",
         "through2": "3.0.2"
       }
     },
     "pouchdb-adapter-memory": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-adapter-memory/-/pouchdb-adapter-memory-7.3.0.tgz",
-      "integrity": "sha512-nUdYi5KpbUa0uv0L3IJorpiUnIOBPxX9qplCX9i7JE8OtLPeLyKuX3WC+3M1//8Lmmxg3b1wXSNIod6FJy4wAQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-adapter-memory/-/pouchdb-adapter-memory-7.3.1.tgz",
+      "integrity": "sha512-iHdWGJAHONqQv0we3Oi1MYen69ZS8McLW9wUyaAYcWTJnAIIAr2ZM0/TeTDVSHfMUwYqEYk7X8jRtJZEMwLnwg==",
       "requires": {
         "memdown": "1.4.1",
-        "pouchdb-adapter-leveldb-core": "7.3.0",
-        "pouchdb-utils": "7.3.0"
+        "pouchdb-adapter-leveldb-core": "7.3.1",
+        "pouchdb-utils": "7.3.1"
       }
     },
     "pouchdb-adapter-utils": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-adapter-utils/-/pouchdb-adapter-utils-7.3.0.tgz",
-      "integrity": "sha512-mU1+smcagWSpInVx/VQk7VVjjnJlyagKtusUS3OdCMFZY35L6RbXC8eIhoNVDbkBfEv3cIwqQ3t7fdvkaa1odQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-adapter-utils/-/pouchdb-adapter-utils-7.3.1.tgz",
+      "integrity": "sha512-uKLG6dClwTs/sLIJ4WkLAi9wlnDBpOnfyhpeAgOjlOGN/XLz5nKHrA4UJRnURDyc+uv79S9r/Unc4hVpmbSPUw==",
       "requires": {
-        "pouchdb-binary-utils": "7.3.0",
-        "pouchdb-collections": "7.3.0",
-        "pouchdb-errors": "7.3.0",
-        "pouchdb-md5": "7.3.0",
-        "pouchdb-merge": "7.3.0",
-        "pouchdb-utils": "7.3.0"
+        "pouchdb-binary-utils": "7.3.1",
+        "pouchdb-collections": "7.3.1",
+        "pouchdb-errors": "7.3.1",
+        "pouchdb-md5": "7.3.1",
+        "pouchdb-merge": "7.3.1",
+        "pouchdb-utils": "7.3.1"
       }
     },
     "pouchdb-all-dbs": {
@@ -9663,9 +9715,9 @@
       }
     },
     "pouchdb-binary-utils": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-binary-utils/-/pouchdb-binary-utils-7.3.0.tgz",
-      "integrity": "sha512-xvBH/XGHGcou2vkEzszJxkCc7YElfRUrkLUg51Jbdmh1mogLDUO0bU3Tj6TOIIJfRkQrU/HV+dDkMAhsil0amQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-binary-utils/-/pouchdb-binary-utils-7.3.1.tgz",
+      "integrity": "sha512-crZJNfAEOnUoRk977Qtmk4cxEv6sNKllQ6vDDKgQrQLFjMUXma35EHzNyIJr1s76J77Q4sqKQAmxz9Y40yHGtw==",
       "requires": {
         "buffer-from": "1.1.2"
       }
@@ -9819,9 +9871,9 @@
       "integrity": "sha512-/SMY9GGasslknivWlCVwXMRMnQ8myKHs4WryQ5535nq1Wj/ehpqWloMwxEQGvZE1Sda3LOm7/5HwLTcB8Our+w=="
     },
     "pouchdb-collections": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-collections/-/pouchdb-collections-7.3.0.tgz",
-      "integrity": "sha512-Xr54m2+fErShXn+qAT4xwqJ+8NwddNPeTMJT4z4k1sZsrwfHmZsWbsKAyGPMF04eQaaU+7DDRMciu2VzaBUXyg=="
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-collections/-/pouchdb-collections-7.3.1.tgz",
+      "integrity": "sha512-yUyDqR+OJmtwgExOSJegpBJXDLAEC84TWnbAYycyh+DZoA51Yw0+XVQF5Vh8Ii90/Ut2xo88fmrmp0t6kqom8w=="
     },
     "pouchdb-core": {
       "version": "7.2.2",
@@ -9929,17 +9981,17 @@
       }
     },
     "pouchdb-errors": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-errors/-/pouchdb-errors-7.3.0.tgz",
-      "integrity": "sha512-dTBbIC1BbCy6J9W/Csg5xROgb3wJN3HpbgAJHHSEtAkb8oA45KZmU3ZwEpNhf0AfPuQm4XgW1936PvlDlGgJiw==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-errors/-/pouchdb-errors-7.3.1.tgz",
+      "integrity": "sha512-Zktz4gnXEUcZcty8FmyvtYUYsHskoST05m6H5/E2gg/0mCfEXq/XeyyLkZHaZmqD0ZPS9yNmASB1VaFWEKEaDw==",
       "requires": {
         "inherits": "2.0.4"
       }
     },
     "pouchdb-fetch": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-fetch/-/pouchdb-fetch-7.3.0.tgz",
-      "integrity": "sha512-8/lcg8iMDG+GVs1dHNXA4ktJSEpH71dHU3xesMJ25tNQOqfAaaWrkfz9j71ZYDDkveLYE6UjUzl/sDacu2hSjw==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-fetch/-/pouchdb-fetch-7.3.1.tgz",
+      "integrity": "sha512-205xAtvdHRPQ4fp1h9+RmT9oQabo9gafuPmWsS9aEl3ER54WbY8Vaj1JHZGbU4KtMTYvW7H5088zLS7Nrusuag==",
       "requires": {
         "abort-controller": "3.0.0",
         "fetch-cookie": "0.11.0",
@@ -10084,9 +10136,9 @@
       }
     },
     "pouchdb-json": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-json/-/pouchdb-json-7.3.0.tgz",
-      "integrity": "sha512-D4wyi20ltyiFpuziQeMk3CbXs/Q58VoGTYTJQY8MWBw37OidtHGQAt1Kh5yJ435wJqDzJZyxMA5RxGZxEOBDVg==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-json/-/pouchdb-json-7.3.1.tgz",
+      "integrity": "sha512-AyOKsmc85/GtHjMZyEacqzja8qLVfycS1hh1oskR+Bm5PIITX52Fb8zyi0hEetV6VC0yuGbn0RqiLjJxQePeqQ==",
       "requires": {
         "vuvuzela": "1.0.3"
       }
@@ -10165,18 +10217,18 @@
       }
     },
     "pouchdb-md5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-md5/-/pouchdb-md5-7.3.0.tgz",
-      "integrity": "sha512-wL04QgoKyd/L/TV5gxgcvlEyCJiZoXCOEFJklTzkdza/kBQNJGPH7i0ZhKa7Sb+AvZYoWZHddf1Zgv7rBScHkA==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-md5/-/pouchdb-md5-7.3.1.tgz",
+      "integrity": "sha512-aDV8ui/mprnL3xmt0gT/81DFtTtJiKyn+OxIAbwKPMfz/rDFdPYvF0BmDC9QxMMzGfkV+JJUjU6at0PPs2mRLg==",
       "requires": {
-        "pouchdb-binary-utils": "7.3.0",
+        "pouchdb-binary-utils": "7.3.1",
         "spark-md5": "3.0.2"
       }
     },
     "pouchdb-merge": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-merge/-/pouchdb-merge-7.3.0.tgz",
-      "integrity": "sha512-E7LmchMzwYFm6V8OBxejzARLisanpksOju2LEfuiYnotGfNDeW7MByP0qBH0/zF8BfUyyjA1cl7ByaEpsapkeQ=="
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-merge/-/pouchdb-merge-7.3.1.tgz",
+      "integrity": "sha512-FeK3r35mKimokf2PQ2tUI523QWyZ4lYZ0Yd75FfSch/SPY6wIokz5XBZZ6PHdu5aOJsEKzoLUxr8CpSg9DhcAw=="
     },
     "pouchdb-promise": {
       "version": "6.4.3",
@@ -10332,24 +10384,24 @@
       }
     },
     "pouchdb-utils": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-utils/-/pouchdb-utils-7.3.0.tgz",
-      "integrity": "sha512-HH+5IXXWn/ZgVCSnrlydBMYn6MabT7RS7SNoo9w8qVH9efpZSp3eLchw6yMQNLw8LQefWmbbskiHV9VgJmSVWQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-utils/-/pouchdb-utils-7.3.1.tgz",
+      "integrity": "sha512-R3hHBo1zTdTu/NFs3iqkcaQAPwhIH0gMIdfVKd5lbDYlmP26rCG5pdS+v7NuoSSFLJ4xxnaGV+Gjf4duYsJ8wQ==",
       "requires": {
         "argsarray": "0.0.1",
         "clone-buffer": "1.0.0",
         "immediate": "3.3.0",
         "inherits": "2.0.4",
-        "pouchdb-collections": "7.3.0",
-        "pouchdb-errors": "7.3.0",
-        "pouchdb-md5": "7.3.0",
+        "pouchdb-collections": "7.3.1",
+        "pouchdb-errors": "7.3.1",
+        "pouchdb-md5": "7.3.1",
         "uuid": "8.3.2"
       }
     },
     "preact": {
-      "version": "10.11.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.2.tgz",
-      "integrity": "sha512-skAwGDFmgxhq1DCBHke/9e12ewkhc7WYwjuhHB8HHS8zkdtITXLRmUMTeol2ldxvLwYtwbFeifZ9uDDWuyL4Iw=="
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
+      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg=="
     },
     "pretty-bytes": {
       "version": "5.6.0",
@@ -10441,9 +10493,9 @@
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
     "quasar": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/quasar/-/quasar-2.10.1.tgz",
-      "integrity": "sha512-W0SEbTdfFS4xvO5OyTyuJent+11MpjBJUYLga69ZFigRh7SV6wFpGNfCuxAifM0L83bp4rWrL2KGoIjEoDsjOw=="
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/quasar/-/quasar-2.10.2.tgz",
+      "integrity": "sha512-y6suu0f2hJKrnFPHzx+p2EBVGzDF6xHaqYGkDIsMNkhxsrO9Qi2+dZCjq1J6+48EJiqPEOn8t9X/gT7yLSSnLw=="
     },
     "querystring": {
       "version": "0.2.0",
@@ -10627,9 +10679,9 @@
       }
     },
     "regexpu-core": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.2.1.tgz",
-      "integrity": "sha512-HrnlNtpvqP1Xkb28tMhBUO2EbyUHdQlsnlAhzWcwHy8WJR53UWr7/MAvqrsQKMbV4qdpv03oTMG8iIhfsPFktQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.2.2.tgz",
+      "integrity": "sha512-T0+1Zp2wjF/juXMrMxHxidqGYn8U4R+zleSJhX9tQ1PUsS8a9UtYfbsF9LdiVgNX3kiX8RNaKM42nfSgvFJjmw==",
       "dev": true,
       "requires": {
         "regenerate": "^1.4.2",
@@ -10637,7 +10689,7 @@
         "regjsgen": "^0.7.1",
         "regjsparser": "^0.9.1",
         "unicode-match-property-ecmascript": "^2.0.0",
-        "unicode-match-property-value-ecmascript": "^2.0.0"
+        "unicode-match-property-value-ecmascript": "^2.1.0"
       }
     },
     "register-service-worker": {
@@ -10699,9 +10751,9 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "reselect": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
-      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.7.tgz",
+      "integrity": "sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A==",
       "dev": true
     },
     "resolve": {
@@ -11537,41 +11589,41 @@
       }
     },
     "string.prototype.matchall": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
-      "integrity": "sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz",
+      "integrity": "sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
-        "get-intrinsic": "^1.1.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
-        "regexp.prototype.flags": "^1.4.1",
+        "regexp.prototype.flags": "^1.4.3",
         "side-channel": "^1.0.4"
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
       }
     },
     "string_decoder": {
@@ -11739,9 +11791,9 @@
       }
     },
     "sublevel-pouchdb": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/sublevel-pouchdb/-/sublevel-pouchdb-7.3.0.tgz",
-      "integrity": "sha512-zp7u4jmv2N/s+dXZkWTtL4BjREs3SZ1nGBNNJ8RWX4yqN59oHgKmti4CfVOqfsAW9RMasmTqQAEPxL9hX8+CIA==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/sublevel-pouchdb/-/sublevel-pouchdb-7.3.1.tgz",
+      "integrity": "sha512-n+4fK72F/ORdqPwoGgMGYeOrW2HaPpW9o9k80bT1B3Cim5BSvkKkr9WbWOWynni/GHkbCEdvLVFJL1ktosAdhQ==",
       "requires": {
         "inherits": "2.0.4",
         "level-codec": "9.0.2",
@@ -12125,9 +12177,9 @@
       }
     },
     "unicode-match-property-value-ecmascript": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.0.0.tgz",
-      "integrity": "sha512-7Yhkc0Ye+t4PNYzOGKedDhXbYIBe1XEQYQxOPyhcXNMJ0WCABqqj6ckydd6pWRZTHV4GuCPKdBAUiMc60tsKVw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==",
       "dev": true
     },
     "unicode-property-aliases-ecmascript": {
@@ -12300,11 +12352,12 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "vite-plugin-dts": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-1.6.6.tgz",
-      "integrity": "sha512-XEZQlcAN5Bi1PWL0l/E08cI3VpjTCWY5x7C4/bVyC7lpS+/q9CDBCV8gGsqV97/g34N7gNNRNhqs8r0m6JAmIQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-1.7.1.tgz",
+      "integrity": "sha512-2oGMnAjcrZN7jM1TloiS1b1mCn42s3El04ix2RFhId5P1WfMigF8WAwsqT6a6jk0Yso8t7AeZsBkkxYShR0hBQ==",
       "requires": {
-        "@microsoft/api-extractor": "^7.33.1",
+        "@microsoft/api-extractor": "^7.33.5",
+        "@rollup/pluginutils": "^5.0.2",
         "@rushstack/node-core-library": "^3.53.2",
         "debug": "^4.3.4",
         "fast-glob": "^3.2.12",
@@ -12320,15 +12373,15 @@
       "dev": true
     },
     "vue": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.41.tgz",
-      "integrity": "sha512-uuuvnrDXEeZ9VUPljgHkqB5IaVO8SxhPpqF2eWOukVrBnRBx2THPSGQBnVRt0GrIG1gvCmFXMGbd7FqcT1ixNQ==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.45.tgz",
+      "integrity": "sha512-9Nx/Mg2b2xWlXykmCwiTUCWHbWIj53bnkizBxKai1g61f2Xit700A1ljowpTIM11e3uipOeiPcSqnmBg6gyiaA==",
       "requires": {
-        "@vue/compiler-dom": "3.2.41",
-        "@vue/compiler-sfc": "3.2.41",
-        "@vue/runtime-dom": "3.2.41",
-        "@vue/server-renderer": "3.2.41",
-        "@vue/shared": "3.2.41"
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/compiler-sfc": "3.2.45",
+        "@vue/runtime-dom": "3.2.45",
+        "@vue/server-renderer": "3.2.45",
+        "@vue/shared": "3.2.45"
       }
     },
     "vue-loader": {
@@ -12376,9 +12429,9 @@
           }
         },
         "loader-utils": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+          "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -12421,9 +12474,9 @@
           }
         },
         "loader-utils": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+          "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -12462,9 +12515,9 @@
       }
     },
     "web-vitals": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.0.4.tgz",
-      "integrity": "sha512-Yau8qf1AJ/dm6MY180Bi0qpCIuWmAfKAnOqmxLecGfIHn0+ND3H4JOhXeY73Pyi9zjSF5J4SNUewHLNUzU7mmA=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.1.0.tgz",
+      "integrity": "sha512-zCeQ+bOjWjJbXv5ZL0r8Py3XP2doCQMZXNKlBGfUjPAVZWokApdeF/kFlK1peuKlCt8sL9TFkKzyXE9/cmNJQA=="
     },
     "webidl-conversions": {
       "version": "3.0.1",
@@ -12472,9 +12525,9 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "webpack": {
-      "version": "5.74.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+      "version": "5.75.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
+      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
@@ -12503,6 +12556,12 @@
         "webpack-sources": "^3.2.3"
       },
       "dependencies": {
+        "@types/estree": {
+          "version": "0.0.51",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+          "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+          "dev": true
+        },
         "acorn": {
           "version": "8.8.1",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
@@ -12914,9 +12973,9 @@
           "dev": true
         },
         "ws": {
-          "version": "8.10.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
-          "integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
           "dev": true
         }
       }
@@ -13387,9 +13446,9 @@
           }
         },
         "loader-utils": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+          "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid-docs",
   "description": "Asteroid",
-  "version": "3.4.0-beta.0",
+  "version": "3.4.0-beta.1",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "productName": "Asteroid Docs",

--- a/docs/src/assets/menu.js
+++ b/docs/src/assets/menu.js
@@ -158,6 +158,10 @@ module.exports = [
         path: '/components/numeric-input'
       },
       {
+        name: 'OptionGroup',
+        path: '/components/option-group'
+      },
+      {
         name: 'PageHeader',
         path: '/components/page-header'
       },

--- a/docs/src/boot/asteroid.js
+++ b/docs/src/boot/asteroid.js
@@ -1,7 +1,9 @@
 import { boot } from 'quasar/wrappers'
 
 import Asteroid from 'asteroid'
+import { InitializeGlobalStores } from '@bildvitta/store-adapter'
 
 export default boot(({ app }) => {
+  app.use(InitializeGlobalStores)
   app.use(Asteroid)
 })

--- a/docs/src/examples/QasFilters/Basic.vue
+++ b/docs/src/examples/QasFilters/Basic.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container spaced">
-    <qas-filters :entity="entity" />
+    <qas-filters :entity="entity" :fields-props="fieldsProps" />
   </div>
 </template>
 
@@ -9,6 +9,14 @@ export default {
   computed: {
     entity () {
       return 'users'
+    },
+
+    fieldsProps () {
+      return {
+        company: {
+          label: 'Alterado label pelo fieldsProps!'
+        }
+      }
     }
   }
 }

--- a/docs/src/examples/QasOptionGroup/Basic.vue
+++ b/docs/src/examples/QasOptionGroup/Basic.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="container spaced">
+    <qas-option-group v-model="model" v-bind="field" />
+
+    <div class="q-mt-lg">
+      model: <pre>{{ model }}</pre>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      model: null
+    }
+  },
+
+  computed: {
+    field () {
+      return {
+        label: 'Campo Radio',
+        options: [
+          {
+            label: 'Opção grande 1',
+            value: '1'
+          },
+          {
+            label: 'Opção grande 2',
+            value: '2'
+          },
+          {
+            label: 'Opção grande 3',
+            value: '3'
+          }
+        ]
+      }
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QasSelect/Searchable.vue
+++ b/docs/src/examples/QasSelect/Searchable.vue
@@ -1,19 +1,7 @@
 <template>
   <div class="container q-py-lg">
-    <div>
-      <qas-select v-model="model" label="Meu select" :options="options" use-search />
-      Model: {{ model }}
-    </div>
-
-    <div class="q-mt-lg">
-      <qas-select v-model="model2" label="Meu select multiple" multiple :options="options" use-search />
-      Model múltiplo: {{ model2 }}
-    </div>
-
-    <div class="q-mt-lg">
-      <qas-select v-model="model3" label="Meu select com busca habilitado automaticamente a partir de 10 options" :options="options2" use-search />
-      Model múltiplo: {{ model3 }}
-    </div>
+    <qas-select v-model="model" label="Meu select com busca habilitado automaticamente a partir de 10 options" :options="options" />
+    Model múltiplo: {{ model }}
   </div>
 </template>
 
@@ -21,9 +9,7 @@
 export default {
   data () {
     return {
-      model: '',
-      model2: [],
-      model3: ''
+      model: ''
     }
   },
 
@@ -61,14 +47,7 @@ export default {
         {
           label: 'Opção 8',
           value: 8
-        }
-      ]
-    },
-
-    options2 () {
-      return [
-        ...this.options,
-
+        },
         {
           label: 'Opção 9',
           value: 9

--- a/docs/src/examples/QasSelect/Searchable.vue
+++ b/docs/src/examples/QasSelect/Searchable.vue
@@ -1,13 +1,18 @@
 <template>
   <div class="container q-py-lg">
     <div>
-      <qas-select v-model="model" label="Meu select!" :options="options" use-search />
+      <qas-select v-model="model" label="Meu select" :options="options" use-search />
       Model: {{ model }}
     </div>
 
     <div class="q-mt-lg">
       <qas-select v-model="model2" label="Meu select multiple" multiple :options="options" use-search />
       Model múltiplo: {{ model2 }}
+    </div>
+
+    <div class="q-mt-lg">
+      <qas-select v-model="model3" label="Meu select com busca habilitado automaticamente a partir de 10 options" :options="options2" use-search />
+      Model múltiplo: {{ model3 }}
     </div>
   </div>
 </template>
@@ -17,7 +22,8 @@ export default {
   data () {
     return {
       model: '',
-      model2: []
+      model2: [],
+      model3: ''
     }
   },
 
@@ -55,6 +61,21 @@ export default {
         {
           label: 'Opção 8',
           value: 8
+        }
+      ]
+    },
+
+    options2 () {
+      return [
+        ...this.options,
+
+        {
+          label: 'Opção 9',
+          value: 9
+        },
+        {
+          label: 'Opção 10',
+          value: 10
         }
       ]
     }

--- a/docs/src/pages/components/option-group.md
+++ b/docs/src/pages/components/option-group.md
@@ -1,0 +1,12 @@
+---
+title: QasOptionGroup
+---
+
+Componente wrapper do [QOptionGroup](https://quasar.dev/vue-components/option-group#introduction). Componente para padronizar propriedade `inline`, a partir do mobile componente segue comportamento de linha, em telas mobile segue comportamento de bloco, não sendo possível alterar este comportamento.
+
+<doc-api file="option-group/QasOptionGroup" name="QasOptionGroup" />
+
+## Uso
+
+<doc-example file="QasOptionGroup/Basic" title="Básico" />
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bildvitta/asteroid",
-  "version": "3.4.0-beta.0",
+  "version": "3.4.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid",
   "description": "Asteroid",
-  "version": "3.4.0-beta.0",
+  "version": "3.4.0-beta.1",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "scripts": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
-  "version": "3.4.0-beta.0",
+  "version": "3.4.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
   "description": "Asteroid",
-  "version": "3.4.0-beta.0",
+  "version": "3.4.0-beta.1",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "dist/asteroid.cjs.min.js",

--- a/ui/src/components/field/QasField.vue
+++ b/ui/src/components/field/QasField.vue
@@ -79,7 +79,6 @@ export default {
         maxFiles,
         useIso,
         useLazyLoading,
-        useSearch,
         useStrengthChecker
       } = this.formattedField
 
@@ -147,7 +146,7 @@ export default {
 
         'signature-uploader': { is: 'qas-signature-uploader', entity, uploadLabel: label, ...error },
 
-        select: { is: 'qas-select', entity, name, multiple, options, useSearch, useLazyLoading, ...input }
+        select: { is: 'qas-select', entity, name, multiple, options, useLazyLoading, ...input }
       }
 
       return { ...(profiles[type] || profiles.default), ...this.$attrs }

--- a/ui/src/components/field/QasField.vue
+++ b/ui/src/components/field/QasField.vue
@@ -11,9 +11,10 @@ import QasCheckboxGroup from '../checkbox-group/QasCheckboxGroup.vue'
 import QasDateTimeInput from '../date-time-input/QasDateTimeInput.vue'
 import QasInput from '../input/QasInput.vue'
 import QasNumericInput from '../numeric-input/QasNumericInput.vue'
+import QasOptionGroup from '../option-group/QasOptionGroup.vue'
 import QasPasswordInput from '../password-input/QasPasswordInput.vue'
-import QasUploader from '../uploader/QasUploader.vue'
 import QasSignatureUploader from '../signature-uploader/QasSignatureUploader.vue'
+import QasUploader from '../uploader/QasUploader.vue'
 
 const attributesProfile = {
   maxLength: 'maxlength',
@@ -29,9 +30,10 @@ export default {
     QasDateTimeInput,
     QasInput,
     QasNumericInput,
+    QasOptionGroup,
     QasPasswordInput,
-    QasUploader,
-    QasSignatureUploader
+    QasSignatureUploader,
+    QasUploader
   },
 
   inheritAttrs: false,
@@ -138,7 +140,7 @@ export default {
 
         boolean: { is: 'q-toggle', label, ...error },
         checkbox: { is: 'qas-checkbox-group', label, options, ...error },
-        radio: { is: 'q-option-group', label, options, type: 'radio', ...error },
+        radio: { is: 'qas-option-group', label, options },
 
         upload: { is: 'qas-uploader', accept, autoUpload: true, entity, label, multiple, readonly, maxFiles, ...error },
         editor: { is: 'q-editor', toolbar, ...error },

--- a/ui/src/components/filters/QasFilters.vue
+++ b/ui/src/components/filters/QasFilters.vue
@@ -27,7 +27,7 @@
 
             <q-form v-else class="q-gutter-y-md q-pa-md" @submit.prevent="filter()">
               <div v-for="(field, index) in fields" :key="index">
-                <qas-field v-model="filters[field.name]" :data-cy="`filters-${field.name}-field`" dense :field="field" />
+                <qas-field v-model="filters[field.name]" :data-cy="`filters-${field.name}-field`" dense :field="field" v-bind="fieldsProps[field.name]" />
               </div>
 
               <div class="text-right">
@@ -76,6 +76,11 @@ export default {
     entity: {
       required: true,
       type: String
+    },
+
+    fieldsProps: {
+      default: () => ({}),
+      type: Object
     },
 
     useFilterButton: {

--- a/ui/src/components/filters/QasFilters.yml
+++ b/ui/src/components/filters/QasFilters.yml
@@ -9,6 +9,12 @@ props:
     required: true
     type: String
 
+  fields-props:
+    desc: Propriedade para repassar propriedades para cada campo individualmente.
+    default: {}
+    type: Object
+    examples: ["{ name: { dense: true, onClick: () => alert('Estou sendo clicado') } }"]
+
   search-placeholder:
     desc: Placeholder do campo de busca.
     default: Pesquisar...

--- a/ui/src/components/option-group/QasOptionGroup.vue
+++ b/ui/src/components/option-group/QasOptionGroup.vue
@@ -1,0 +1,54 @@
+<template>
+  <q-option-group v-model="model" :options="options" v-bind="attributes">
+    <template v-for="(_, name) in $slots" #[name]="context">
+      <slot :name="name" v-bind="context || {}" />
+    </template>
+  </q-option-group>
+</template>
+
+<script>
+export default {
+  name: 'QasOptionGroup',
+
+  inheritAttrs: false,
+
+  props: {
+    options: {
+      default: () => [],
+      type: Array
+    },
+
+    type: {
+      type: String,
+      default: 'radio',
+      validator: value => ['radio', 'checkbox', 'toggle'].includes(value)
+    },
+
+    modelValue: {
+      default: '',
+      type: [String, Number, Array, Boolean]
+    }
+  },
+
+  emits: ['update:modelValue'],
+
+  computed: {
+    attributes () {
+      return {
+        ...this.$attrs,
+        inline: !this.$qas.screen.isSmall
+      }
+    },
+
+    model: {
+      get () {
+        return this.modelValue
+      },
+
+      set (value) {
+        return this.$emit('update:modelValue', value)
+      }
+    }
+  }
+}
+</script>

--- a/ui/src/components/option-group/QasOptionGroup.yml
+++ b/ui/src/components/option-group/QasOptionGroup.yml
@@ -1,0 +1,30 @@
+type: component
+
+meta:
+  desc: Componente para gerar dinamicamente campos nested.
+
+props:
+  options:
+    desc: Opções contendo objetos com chaves "label" e "value".
+    default: []
+    type: Array
+
+  model-value:
+    desc: Model do componente, usado para v-model.
+    default: []
+    type: [String, Number, Array, Boolean]
+    examples: [v-model"value"]
+    model: true
+
+  type:
+    desc: Tipo de componente, podendo ser radio, checkbox ou toggle.
+    default: 'radio'
+    type: String
+
+events:
+  '@update:model-value -> function (value)':
+    desc: Dispara toda vez que o model é atualizado, também utilizado para v-model.
+    params:
+      value:
+        desc: Novo valor do v-model
+        type: String

--- a/ui/src/components/option-group/QasOptionGroup.yml
+++ b/ui/src/components/option-group/QasOptionGroup.yml
@@ -1,7 +1,7 @@
 type: component
 
 meta:
-  desc: Componente para gerar dinamicamente campos nested.
+  desc: Componente wrapper do [QOptionGroup](https://quasar.dev/vue-components/option-group#introduction).
 
 props:
   options:

--- a/ui/src/components/select/QasSelect.vue
+++ b/ui/src/components/select/QasSelect.vue
@@ -68,10 +68,6 @@ export default {
     valueKey: {
       default: '',
       type: String
-    },
-
-    useSearch: {
-      type: Boolean
     }
   },
 
@@ -133,8 +129,9 @@ export default {
       * sem necessidade de passar prop manualmente
       */
       const autoFuseQuantity = 10
+      const hasAutoFuseSearch = this.options.length >= autoFuseQuantity && !this.useLazyLoading
 
-      return this.useSearch || this.options.length >= autoFuseQuantity
+      return hasAutoFuseSearch
     },
 
     model: {

--- a/ui/src/components/select/QasSelect.vue
+++ b/ui/src/components/select/QasSelect.vue
@@ -112,7 +112,7 @@ export default {
     },
 
     isSearchable () {
-      return this.useSearch || this.useLazyLoading
+      return this.hasFuse || this.useLazyLoading
     },
 
     defaultOptions () {
@@ -125,6 +125,16 @@ export default {
 
     hasLoading () {
       return this.mx_isFetching || this.$attrs.loading
+    },
+
+    hasFuse () {
+      /*
+      * quantidade de option que precisa ter para o fuse funcionar automaticamente
+      * sem necessidade de passar prop manualmente
+      */
+      const autoFuseQuantity = 10
+
+      return this.useSearch || this.options.length >= autoFuseQuantity
     },
 
     model: {
@@ -147,7 +157,7 @@ export default {
       handler () {
         if (this.useLazyLoading && this.mx_hasFilteredOptions) return
 
-        if (this.fuse) this.setFuse()
+        if (this.fuse || this.hasFuse) this.setFuse()
 
         this.mx_filteredOptions = this.defaultOptions
       },
@@ -163,7 +173,7 @@ export default {
 
   methods: {
     setFuse () {
-      if (this.useSearch) {
+      if (this.hasFuse) {
         this.fuse = new Fuse(this.defaultOptions, this.defaultFuseOptions)
       }
     },
@@ -173,7 +183,7 @@ export default {
         await this.mx_filterOptionsByStore(value)
       }
 
-      if (!this.useLazyLoading && this.useSearch) {
+      if (!this.useLazyLoading && this.hasFuse) {
         this.filterOptionsByFuse(value)
       }
 

--- a/ui/src/components/select/QasSelect.yml
+++ b/ui/src/components/select/QasSelect.yml
@@ -71,10 +71,6 @@ props:
     type: String
     examples: [value-key="uuid"]
 
-  use-search:
-    desc: Controla se vai ou não ter campo de busca no select.
-    type: Boolean
-
   use-lazy-loading:
     desc: Controla a busca pela store "fetchFieldOptions".
     default: false

--- a/ui/src/css/variables/button.scss
+++ b/ui/src/css/variables/button.scss
@@ -1,3 +1,3 @@
-$button-font-size: 0.875rem;
+$button-font-size: 1rem;
 $button-line-height: 1.5rem;
-$button-font-weight: 500;
+$button-font-weight: 600;

--- a/ui/src/css/variables/typography.scss
+++ b/ui/src/css/variables/typography.scss
@@ -9,48 +9,48 @@
 
 // headings
 $h1: (
-  size: 6rem,
-  line-height: 6rem,
+  size: 3rem,
+  line-height: 1.5rem,
   letter-spacing: 0,
   weight: 800,
   margin: 0
 );
 
 $h2: (
-  size: 3.75rem,
-  line-height: 3.75rem,
+  size: 2rem,
+  line-height: 1.5rem,
   letter-spacing: 0,
   weight: 700,
   margin: 0
 );
 
 $h3: (
-  size: 3rem,
-  line-height: 2.5rem,
-  letter-spacing: 0,
-  weight: 600,
-  margin: 0
-);
-
-$h4: (
-  size: 2.125rem,
-  line-height: 2.5rem,
-  letter-spacing: 0,
-  weight: 800,
-  margin: 0
-);
-
-$h5: (
   size: 1.5rem,
-  line-height: 2rem,
+  line-height: 1.5rem,
   letter-spacing: 0,
   weight: 700,
   margin: 0
 );
 
+$h4: (
+  size: 1.125rem,
+  line-height: 1.5rem,
+  letter-spacing: 0,
+  weight: 600,
+  margin: 0
+);
+
+$h5: (
+  size: 1rem,
+  line-height: 1.5rem,
+  letter-spacing: 0,
+  weight: 600,
+  margin: 0
+);
+
 $h6: (
-  size: 1.25rem,
-  line-height: 2rem,
+  size: 0.875rem,
+  line-height: 1.5rem,
   letter-spacing: 0,
   weight: 600,
   margin: 0
@@ -59,14 +59,14 @@ $h6: (
 // subtitles
 $subtitle1: (
   size: 1rem,
-  line-height: 1.75rem,
+  line-height: 1.5rem,
   letter-spacing: 0,
-  weight: 700
+  weight: 600
 );
 
 $subtitle2: (
   size: 0.875rem,
-  line-height: 1.375rem,
+  line-height: 1.5rem,
   letter-spacing: 0,
   weight: 600
 );
@@ -76,20 +76,20 @@ $body1: (
   size: 1rem,
   line-height: 1.5rem,
   letter-spacing: 0,
-  weight: 500
+  weight: 400
 );
 
 $body2: (
   size: 0.875rem,
-  line-height: 1.25rem,
+  line-height: 1.5rem,
   letter-spacing: 0,
   weight: 400
 );
 
 // overline
 $overline: (
-  size: 0.75rem,
-  line-height: 2rem,
+  size: 0.875rem,
+  line-height: 1.5rem,
   letter-spacing: 0.25rem,
   weight: 600
 );
@@ -97,9 +97,9 @@ $overline: (
 // caption
 $caption: (
   size: 0.75rem,
-  line-height: 1.25rem,
+  line-height: 1.5rem,
   letter-spacing: 0,
-  weight: 700
+  weight: 600
 );
 
 $headings: (

--- a/ui/src/vue-plugin.js
+++ b/ui/src/vue-plugin.js
@@ -29,6 +29,7 @@ import QasListView from './components/list-view/QasListView.vue'
 import QasMap from './components/map/QasMap.vue'
 import QasNestedFields from './components/nested-fields/QasNestedFields.vue'
 import QasNumericInput from './components/numeric-input/QasNumericInput.vue'
+import QasOptionGroup from './components/option-group/QasOptionGroup.vue'
 import QasPageHeader from './components/page-header/QasPageHeader.vue'
 import QasPasswordInput from './components/password-input/QasPasswordInput.vue'
 import QasPasswordStrengthChecker from './components/password-strength-checker/QasPasswordStrengthChecker.vue'
@@ -99,6 +100,7 @@ function install (app) {
   app.component('QasMap', QasMap)
   app.component('QasNestedFields', QasNestedFields)
   app.component('QasNumericInput', QasNumericInput)
+  app.component('QasOptionGroup', QasOptionGroup)
   app.component('QasPageHeader', QasPageHeader)
   app.component('QasPasswordInput', QasPasswordInput)
   app.component('QasPasswordStrengthChecker', QasPasswordStrengthChecker)
@@ -170,6 +172,7 @@ export {
   QasMap,
   QasNestedFields,
   QasNumericInput,
+  QasOptionGroup,
   QasPageHeader,
   QasPasswordInput,
   QasPasswordStrengthChecker,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado

## BREAKING CHANGE
- `QasField`: Alterado type `radio` par utilizar o novo componente `QasOptionGroup` e removido prop de erro pois não existe no componente `QOptionGroup`, testar bem para validar.
- Componentes de radio agora existe padronização, a partir do mobile componente segue comportamento de linha, em telas mobile segue comportamento de bloco, não sendo possível alterar este comportamento, verificar locais que utilizam para não quebrar o estilo.

### Adicionado
- `QasFilters`: adicionado nova propriedade `fieldsProps` para repassar propriedades para os campos do filtro.
- `QaSelect`: adicionado busca automaticamente quando existem pelo menos 10 opções.
- `QasOptionGroup`: adicionado novo componente wrapper do `QOptionGroup` do quasar, para deixar padronizado propriedade `inline` e deixar mais componentizado.

### Modificado
- `QasField`: Alterado type `radio` par utilizar o novo componente `QasOptionGroup` e removido prop de erro pois não existe no componente `QOptionGroup`.


<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [ ] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
