### PR TITLE
feat: Edit mode type implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasFormView`: Adicionado computada `formMode` para lidar com o modo padrão do formulário. Essa computada remove a necessidade do usuário passar o mixin `mx_mode` como propriedade para o `QasFormView`, pois internamente o mixin já será repassado como padrão.
+
+### Modificado
+- `form.js`: Modificado mixin `mx_mode` para utilizar o modo de edição padrão por meio da variável de ambiente `EDIT_MODE_TYPE`.
+
 ## [3.5.0-beta.0] - 18-11-2022
 ## BREAKING CHANGE
 - `QasField`: Alterado type `radio` par utilizar o novo componente `QasOptionGroup` e removido prop de erro pois não existe no componente `QOptionGroup`, testar bem para validar.

--- a/ui/src/components/form-view/QasFormView.vue
+++ b/ui/src/components/form-view/QasFormView.vue
@@ -44,7 +44,7 @@ import { NotifyError, NotifySuccess } from '../../plugins'
 import QasBtn from '../btn/QasBtn.vue'
 import QasDialog from '../dialog/QasDialog.vue'
 
-import { viewMixin } from '../../mixins'
+import { viewMixin, formMixin } from '../../mixins'
 
 export default {
   name: 'QasFormView',
@@ -54,7 +54,7 @@ export default {
     QasDialog
   },
 
-  mixins: [viewMixin],
+  mixins: [viewMixin, formMixin],
 
   props: {
     cancelButtonLabel: {
@@ -77,7 +77,7 @@ export default {
     },
 
     mode: {
-      default: 'create',
+      default: '',
       type: String
     },
 
@@ -179,7 +179,7 @@ export default {
     },
 
     isCreateMode () {
-      return this.mode === 'create'
+      return this.formMode === 'create'
     },
 
     resolvedRoute () {
@@ -196,6 +196,10 @@ export default {
 
     isCancelButtonDisabled () {
       return this.disable || this.isSubmitting
+    },
+
+    formMode () {
+      return this.mode || this.mx_mode
     }
   },
 
@@ -406,12 +410,12 @@ export default {
         }
 
         this.$qas.logger.group(
-          `QasFormView - submit -> payload do ${this.entity}/${this.mode}`, [payload]
+          `QasFormView - submit -> payload do ${this.entity}/${this.formMode}`, [payload]
         )
 
         const response = await getAction.call(this, {
           entity: this.entity,
-          key: this.mode,
+          key: this.formMode,
           payload
         })
 
@@ -424,7 +428,7 @@ export default {
         this.$emit('submit-success', response, this.modelValue)
 
         this.$qas.logger.group(
-          `QasFormView - submit -> resposta da action ${this.entity}/${this.mode}`, [response]
+          `QasFormView - submit -> resposta da action ${this.entity}/${this.formMode}`, [response]
         )
       } catch (error) {
         const errors = error?.response?.data?.errors
@@ -443,7 +447,7 @@ export default {
         this.$emit('submit-error', error)
 
         this.$qas.logger.group(
-          `QasFormView - submit -> exceção da action ${this.entity}/${this.mode}`,
+          `QasFormView - submit -> exceção da action ${this.entity}/${this.formMode}`,
           [error],
           { error: true }
         )

--- a/ui/src/components/form-view/QasFormView.yml
+++ b/ui/src/components/form-view/QasFormView.yml
@@ -80,8 +80,7 @@ props:
     model: true
 
   mode:
-    desc: Existem 3 modos no QasFormView, para criação (create) (equivalente a um método POST no http), e edição que são 2 diferentes, replace (equivalente a um método PUT no http) e update (equivalente a um método PATCH no http).
-    default: create
+    desc: Existem 3 modos no QasFormView, para criação (create) (equivalente a um método POST no http), e edição que são 2 diferentes, replace (equivalente a um método PUT no http) e update (equivalente a um método PATCH no http). Por padrão, para criação será utilizado o "create" e para edição o "replace". Para mudar o padrão utilizado na edição, utilize a variável de ambiente "EDIT_MODE_TYPE" com o valor "update".
     type: String
     examples: [create, replace, update]
 

--- a/ui/src/mixins/form.js
+++ b/ui/src/mixins/form.js
@@ -1,3 +1,5 @@
+import handleProcess from '../helpers/handle-process'
+
 export default {
   computed: {
     mx_isEditMode () {
@@ -5,7 +7,9 @@ export default {
     },
 
     mx_mode () {
-      return this.$route.name.endsWith('Edit') ? 'replace' : 'create'
+      const editModeType = handleProcess(() => process.env.EDIT_MODE_TYPE, 'replace')
+
+      return this.$route?.name?.endsWith('Edit') ? editModeType : 'create'
     }
   }
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- (Remova este texto de descrição.) -->

- Adicionada a possibilidade de utilizar outro modo de edição padrão por meio de uma váriavel de ambiente chamada `EDIT_MODE_TYPE`. 
- Agora não é mais necessário passar o `mode` ao utilizar o `QasFormView`, pois por padrão ele já utiliza o mixin `mx_mode` internamente.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [x] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
