### PR TITLE
QasActionsMenu new styles and behaviors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,7 +28,8 @@
     "QasTreeGenerator",
     "QasGallery",
     "QasFilters",
-    "QasOptionGroup"
+    "QasOptionGroup",
+    "QasActionsMenu"
   ],
   "cSpell.words": [
     "Nunito"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `QasActionsMenu`: modificado o estilo padrão do componente e comportamento quando há uma ação ou mais ações.
+- `QasActionsMenu`: modificado a label padrão do botão para "Opções" e ícone para `o_more_vert`.
+
 ## [3.5.0-beta.0] - 18-11-2022
 ## BREAKING CHANGE
 - `QasField`: Alterado type `radio` par utilizar o novo componente `QasOptionGroup` e removido prop de erro pois não existe no componente `QOptionGroup`, testar bem para validar.

--- a/docs/src/examples/QasActionsMenu/Basic.vue
+++ b/docs/src/examples/QasActionsMenu/Basic.vue
@@ -13,6 +13,11 @@ export default {
           icon: 'o_visibility',
           label: 'Visualizar',
           handler: () => alert('handler ativado')
+        },
+        edit: {
+          icon: 'o_create',
+          label: 'Editar',
+          handler: () => alert('handler ativado')
         }
       }
     }

--- a/docs/src/examples/QasActionsMenu/CustomSlot.vue
+++ b/docs/src/examples/QasActionsMenu/CustomSlot.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container q-py-lg">
-    <qas-actions-menu label="configurações" :list="list">
+    <qas-actions-menu label="Configurações" :list="list">
       <template #visibility="{ item }">
         <div class="q-pa-md">
           item: <qas-debugger :inspect="[item]" />

--- a/docs/src/pages/components/actions-menu.md
+++ b/docs/src/pages/components/actions-menu.md
@@ -27,15 +27,19 @@ A prop `list` é um objeto de objetos, que contem os seguintes atributos:
 ```
 :::
 
+:::warning
+Quando há mais de uma ação proveniente da propriedade `list`, o componente `QasActionsMenu` renderiza um menu dropdown com todas as ações. Quando houver apenas uma ação será renderizado apenas um botão com a ação proveniente.
+:::
+
 :::danger
 A chave `iconSize` dentro da propriedade `list` foi **removida**, pois sempre os ícones devem ser do tamanho `sm`.
 :::
 
+<doc-example file="QasActionsMenu/Basic" title="Básico" />
+
 :::tip
 A prop `deleteProps` ativa o componente `QasDelete`, quando é passada o `QasActionsMenu` adiciona a opção de deletar o item como padrão, caso não seja passado, o componente `QasDelete` não é adicionado por padrão.
 :::
-
-<doc-example file="QasActionsMenu/Basic" title="Básico" />
 
 :::tip
 Para receber o evento de sucesso ao deletar, dentro da propriedade `deleteProps` adicione a chave `onSuccess`, por exemplo:

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -1,11 +1,11 @@
 <template>
-  <qas-btn class="qas-actions-menu" color="primary" :icon="icon" :label="label" outline padding="md" :use-label-on-small-screen="false">
-    <q-menu class="qas-actions-menu__menu">
-      <q-list class="qas-actions-menu__list" separator>
+  <qas-btn class="qas-actions-menu" flat :icon-right="icon" :label="label" padding="xs" :ripple="false" text-color="dark" :use-label-on-small-screen="false">
+    <q-menu class="q-py-xs qas-actions-menu__menu">
+      <q-list class="qas-actions-menu__list">
         <slot v-for="(item, key) in list" :item="item" :name="key">
-          <q-item :key="key" class="text-primary" clickable v-bind="item.props" @click="onClick(item)">
+          <q-item :key="key" v-bind="item.props" clickable color="dark" @click="onClick(item)">
             <q-item-section>
-              <div class="flex items-center justify-center q-gutter-x-md">
+              <div class="flex items-center q-gutter-x-md">
                 <q-icon :name="item.icon" size="sm" />
                 <div>{{ item.label }}</div>
               </div>
@@ -13,9 +13,9 @@
           </q-item>
         </slot>
 
-        <qas-delete v-if="hasDelete" v-bind="deleteProps" class="text-negative" clickable tag="q-item">
+        <qas-delete v-if="hasDelete" v-bind="deleteProps" clickable tag="q-item">
           <q-item-section>
-            <div class="flex items-center justify-center q-gutter-x-sm">
+            <div class="flex items-center q-gutter-x-sm">
               <q-icon :name="deleteIcon" size="sm" />
               <div>{{ deleteLabel }}</div>
             </div>
@@ -38,12 +38,12 @@ export default {
 
   props: {
     icon: {
-      default: 'o_settings',
+      default: 'o_more_vert',
       type: String
     },
 
     label: {
-      default: 'Configurações',
+      default: 'Opções',
       type: String
     },
 
@@ -87,9 +87,22 @@ export default {
 
 <style lang="scss">
 .qas-actions-menu {
+  transition: color 300ms;
+
+  &:hover {
+    color: var(--q-primary) !important;
+  }
+
+  .q-focus-helper {
+    display: none;
+  }
+
   &__list {
-    width: 265px;
     z-index: 1;
+
+    .q-item {
+      font-weight: 600;
+    }
   }
 }
 </style>

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -1,32 +1,24 @@
 <template>
-  <qas-btn class="qas-actions-menu" flat :icon-right="icon" :label="label" padding="xs" :ripple="false" text-color="dark" :use-label-on-small-screen="false">
-    <q-menu class="q-py-xs qas-actions-menu__menu">
-      <q-list class="qas-actions-menu__list">
-        <slot v-for="(item, key) in actions" :item="item" :name="key">
-          <component :is="getComponent(key)" v-bind="item.props" :key="key" clickable @click="onClick(item)">
-            <q-item-section>
-              <div class="flex items-center q-gutter-x-md">
-                <q-icon :name="item.icon" size="sm" />
-                <div>{{ item.label }}</div>
-              </div>
-            </q-item-section>
-          </component>
-        </slot>
-      </q-list>
-    </q-menu>
-  </qas-btn>
+  <div v-if="hasActions" class="qas-actions-menu">
+    <qas-btn v-if="hasMoreThanOneAction" class="qas-actions-menu__button" flat :icon-right="icon" :label="label" padding="xs" :ripple="false" text-color="dark">
+      <q-menu class="q-py-xs qas-actions-menu__menu">
+        <pv-actions-menu-list :list="actions" />
+      </q-menu>
+    </qas-btn>
+    <pv-actions-menu-list v-else :list="actions" />
+  </div>
 </template>
 
 <script>
 import QasBtn from '../btn/QasBtn.vue'
-import QasDelete from '../delete/QasDelete.vue'
+import PvActionsMenuList from './private/PvActionsMenuList.vue'
 
 export default {
   name: 'QasActionsMenu',
 
   components: {
     QasBtn,
-    QasDelete
+    PvActionsMenuList
   },
 
   props: {
@@ -62,10 +54,6 @@ export default {
   },
 
   computed: {
-    hasDelete () {
-      return !!Object.keys(this.deleteProps).length
-    },
-
     actions () {
       return {
         ...this.list,
@@ -80,21 +68,18 @@ export default {
           }
         })
       }
-    }
-  },
-
-  methods: {
-    getComponent (key) {
-      if (key === 'delete') return 'qas-delete'
-
-      return 'q-item'
     },
 
-    onClick (item) {
-      if (typeof item.handler === 'function') {
-        const { handler, ...filtered } = item
-        item.handler(filtered)
-      }
+    hasActions () {
+      return !!Object.keys(this.actions).length
+    },
+
+    hasDelete () {
+      return !!Object.keys(this.deleteProps).length
+    },
+
+    hasMoreThanOneAction () {
+      return Object.keys(this.actions).length > 1
     }
   }
 }
@@ -102,21 +87,19 @@ export default {
 
 <style lang="scss">
 .qas-actions-menu {
-  transition: color 300ms;
+  &__button {
+    transition: color 300ms;
 
-  &:hover {
-    color: var(--q-primary) !important;
-  }
+    &:hover {
+      color: var(--q-primary) !important;
+    }
 
-  .q-focus-helper {
-    display: none;
-  }
+    .on-right {
+      margin-left: var(--qas-spacing-xs);
+    }
 
-  &__list {
-    z-index: 1;
-
-    .q-item {
-      font-weight: 600;
+    .q-focus-helper {
+      display: none;
     }
   }
 }

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -2,25 +2,16 @@
   <qas-btn class="qas-actions-menu" flat :icon-right="icon" :label="label" padding="xs" :ripple="false" text-color="dark" :use-label-on-small-screen="false">
     <q-menu class="q-py-xs qas-actions-menu__menu">
       <q-list class="qas-actions-menu__list">
-        <slot v-for="(item, key) in list" :item="item" :name="key">
-          <q-item :key="key" v-bind="item.props" clickable color="dark" @click="onClick(item)">
+        <slot v-for="(item, key) in actions" :item="item" :name="key">
+          <component :is="getComponent(key)" v-bind="item.props" :key="key" clickable @click="onClick(item)">
             <q-item-section>
               <div class="flex items-center q-gutter-x-md">
                 <q-icon :name="item.icon" size="sm" />
                 <div>{{ item.label }}</div>
               </div>
             </q-item-section>
-          </q-item>
+          </component>
         </slot>
-
-        <qas-delete v-if="hasDelete" v-bind="deleteProps" clickable tag="q-item">
-          <q-item-section>
-            <div class="flex items-center q-gutter-x-sm">
-              <q-icon :name="deleteIcon" size="sm" />
-              <div>{{ deleteLabel }}</div>
-            </div>
-          </q-item-section>
-        </qas-delete>
       </q-list>
     </q-menu>
   </qas-btn>
@@ -28,12 +19,14 @@
 
 <script>
 import QasBtn from '../btn/QasBtn.vue'
+import QasDelete from '../delete/QasDelete.vue'
 
 export default {
   name: 'QasActionsMenu',
 
   components: {
-    QasBtn
+    QasBtn,
+    QasDelete
   },
 
   props: {
@@ -71,10 +64,32 @@ export default {
   computed: {
     hasDelete () {
       return !!Object.keys(this.deleteProps).length
+    },
+
+    actions () {
+      return {
+        ...this.list,
+        ...(this.hasDelete && {
+          delete: {
+            icon: this.deleteIcon,
+            label: this.deleteLabel,
+            props: {
+              ...this.deleteProps,
+              tag: 'q-item'
+            }
+          }
+        })
+      }
     }
   },
 
   methods: {
+    getComponent (key) {
+      if (key === 'delete') return 'qas-delete'
+
+      return 'q-item'
+    },
+
     onClick (item) {
       if (typeof item.handler === 'function') {
         const { handler, ...filtered } = item

--- a/ui/src/components/actions-menu/QasActionsMenu.yml
+++ b/ui/src/components/actions-menu/QasActionsMenu.yml
@@ -21,13 +21,13 @@ props:
 
   icon:
     desc: Ícone do botão.
-    default: o_settings
+    default: o_more_vert
     type: String
     examples: [start, end, between, around, center]
 
   label:
     desc: Rotulo do botão.
-    default: Configurações
+    default: Opções
     type: String
 
   list:

--- a/ui/src/components/actions-menu/private/PvActionsMenuList.vue
+++ b/ui/src/components/actions-menu/private/PvActionsMenuList.vue
@@ -1,0 +1,66 @@
+<template>
+  <q-list class="actions-menu-list">
+    <slot v-for="(item, key) in list" :item="item" :name="key">
+      <component :is="getComponent(key)" v-bind="item.props" :key="key" clickable :style="itemStyles" @click="onClick(item)">
+        <q-item-section>
+          <div class="flex items-center q-gutter-x-sm">
+            <q-icon :name="item.icon" size="sm" />
+            <div>{{ item.label }}</div>
+          </div>
+        </q-item-section>
+      </component>
+    </slot>
+  </q-list>
+</template>
+
+<script>
+import QasDelete from '../../delete/QasDelete.vue'
+
+export default {
+  name: 'PvActionsMenuList',
+
+  components: {
+    QasDelete
+  },
+
+  props: {
+    list: {
+      default: () => ({}),
+      type: Object
+    }
+  },
+
+  computed: {
+    itemStyles () {
+      return {
+        padding: Object.keys(this.list).length > 1 ? 'var(--qas-spacing-sm) var(--qas-spacing-md)' : 'var(--qas-spacing-xs)'
+      }
+    }
+  },
+
+  methods: {
+    getComponent (key) {
+      if (key === 'delete') return 'qas-delete'
+
+      return 'q-item'
+    },
+
+    onClick (item) {
+      if (typeof item.handler === 'function') {
+        const { handler, ...filtered } = item
+        item.handler(filtered)
+      }
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+.actions-menu-list {
+  z-index: 1;
+
+  .q-item {
+    font-weight: 600;
+  }
+}
+</style>

--- a/ui/src/components/actions-menu/private/PvActionsMenuList.vue
+++ b/ui/src/components/actions-menu/private/PvActionsMenuList.vue
@@ -40,9 +40,7 @@ export default {
 
   methods: {
     getComponent (key) {
-      if (key === 'delete') return 'qas-delete'
-
-      return 'q-item'
+      return key === 'delete' ? 'qas-delete' : 'q-item'
     },
 
     onClick (item) {
@@ -57,8 +55,6 @@ export default {
 
 <style lang="scss">
 .pv-actions-menu-list {
-  z-index: 1;
-
   .q-item {
     font-weight: 600;
   }

--- a/ui/src/components/actions-menu/private/PvActionsMenuList.vue
+++ b/ui/src/components/actions-menu/private/PvActionsMenuList.vue
@@ -1,7 +1,7 @@
 <template>
-  <q-list class="actions-menu-list">
+  <q-list class="pv-actions-menu-list">
     <slot v-for="(item, key) in list" :item="item" :name="key">
-      <component :is="getComponent(key)" v-bind="item.props" :key="key" clickable :style="itemStyles" @click="onClick(item)">
+      <component :is="getComponent(key)" v-bind="item.props" :key="key" :class="itemClasses" clickable @click="onClick(item)">
         <q-item-section>
           <div class="flex items-center q-gutter-x-sm">
             <q-icon :name="item.icon" size="sm" />
@@ -31,9 +31,9 @@ export default {
   },
 
   computed: {
-    itemStyles () {
+    itemClasses () {
       return {
-        padding: Object.keys(this.list).length > 1 ? 'var(--qas-spacing-sm) var(--qas-spacing-md)' : 'var(--qas-spacing-xs)'
+        'q-pa-xs': Object.keys(this.list).length === 1
       }
     }
   },
@@ -56,7 +56,7 @@ export default {
 </script>
 
 <style lang="scss">
-.actions-menu-list {
+.pv-actions-menu-list {
   z-index: 1;
 
   .q-item {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- (Remova este texto de descrição.) -->
Modificação do estilo padrão do componente `QasActionsMenu` e do comportamento quando há uma ou mais ações.

**Mais de uma ação:**
![Screen Shot 2022-12-07 at 21 11 14](https://user-images.githubusercontent.com/19765074/206324629-2f369ae0-6c3d-482a-94b5-f71a593ea2d9.jpg)

**Apenas uma ação:**
![Screen Shot 2022-12-07 at 21 11 29](https://user-images.githubusercontent.com/19765074/206324668-a1d22e6d-6dd5-49e2-b7be-84d2f00d3027.jpg)


<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
