### PR TITLE
Add option to QasNestedFields starts empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ## Não publicado
 ## BREAKING CHANGE
 - `QasTableGenerator`: pode haver breaking change de design no espaçamento embaixo do componente uma vez que foi removido a classe `q-mb-xl`.
+- `QasNestedFields`: mudanças de comportamento e estilo do nested, rever implementações.
 
 ### Adicionado
 - `QasPagination`: adicionado novo componente de paginação que é um wrapper do `QPagination`.
@@ -36,7 +37,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasTableGenerator`: removido classe `q-mb-xl` para adaptação de layout, responsabilidade de espaçamento fica com quem implementa.
 - `QasListView`: utilizando `QasPagination` no lugar do `QPagination` e adicionado de informação de quantos itens existem por página.
 - `QasNestedFields`: modificado o valor padrão da propriedade `addInputLabel` para "Adicionar".
-- `QasNestedFields`: modificado o valor padrão da propriedade `useDestroyAlways` para `true`.
+- `QasNestedFields`: modificado o valor padrão da propriedade `useDestroyAlways` para ser um espelho da propriedade `useStartsEmpty` como valor default.
 
 ## [3.5.0-beta.0] - 18-11-2022
 ## BREAKING CHANGE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `plugins`: Adicionado pasta para plugins css.
 - `notify.scss`: Adicionado arquivo de css para o novo padrão de layout dos notifies.
 - `QasListView`: adicionado nova propriedade `use-auto-handle-on-delete` para controlar se o componente vai lidar automaticamente quando acontecer algum delete compatível com a listagem.
+- `QasNestedFields`: adicionada nova propriedade `addFirstInputLabel` para modificar o texto do botão de adicionar o primeiro item.
+- `QasNestedFields`: adicionada nova propriedade `useFirstInputButton` para usar um botão diferente para adicionar o primeiro item.
+- `QasNestedFields`: adicionada nova propriedade `useStartsEmpty` para iniciar o componente sem nenhum item.
 
 ### Modificado
 - [`NotifySuccess`, `NotifyError`]: Mudança de posição que será exibido(era bottom, agora será top).
@@ -32,6 +35,8 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasActionsMenu`: modificado a label padrão do botão para "Opções" e ícone para `o_more_vert`.
 - `QasTableGenerator`: removido classe `q-mb-xl` para adaptação de layout, responsabilidade de espaçamento fica com quem implementa.
 - `QasListView`: utilizando `QasPagination` no lugar do `QPagination` e adicionado de informação de quantos itens existem por página.
+- `QasNestedFields`: modificado o valor padrão da propriedade `addInputLabel` para "Adicionar".
+- `QasNestedFields`: modificado o valor padrão da propriedade `useDestroyAlways` para `true`.
 
 ## [3.5.0-beta.0] - 18-11-2022
 ## BREAKING CHANGE

--- a/docs/src/examples/QasNestedFields/Basic.vue
+++ b/docs/src/examples/QasNestedFields/Basic.vue
@@ -1,10 +1,9 @@
 <template>
   <div class="container spaced">
     <div class="full-width">
-      <div class="q-mt-lg">
-        <qas-label label="Meu campo" />
+      <div class="q-mt-lg text-center">
         <div>
-          <qas-nested-fields v-model="model" class="full-width" :field="nested" :fields-props="fieldsProps" :form-columns="formColumns" row-label="Meu teste" :row-object="rowObject" />
+          <qas-nested-fields v-model="model" class="full-width" :field="nested" :fields-props="fieldsProps" :form-columns="formColumns" :row-object="rowObject" />
         </div>
 
         <div class="q-my-lg">
@@ -19,7 +18,7 @@
 const nested = {
   name: 'nested',
   type: 'nested',
-  label: 'Meu nested2',
+  label: 'Meu nested',
   children: {
     name: {
       name: 'name',

--- a/docs/src/examples/QasNestedFields/Basic.vue
+++ b/docs/src/examples/QasNestedFields/Basic.vue
@@ -1,9 +1,10 @@
 <template>
   <div class="container spaced">
     <div class="full-width">
-      <div class="q-mt-lg text-center">
+      <div class="q-mt-lg">
+        <qas-label label="Meu campo" />
         <div>
-          <qas-nested-fields v-model="model" class="full-width" :field="nested" :fields-props="fieldsProps" :form-columns="formColumns" :row-object="rowObject" />
+          <qas-nested-fields v-model="model" class="full-width" :field="nested" :fields-props="fieldsProps" :form-columns="formColumns" row-label="Meu teste" :row-object="rowObject" />
         </div>
 
         <div class="q-my-lg">
@@ -18,7 +19,7 @@
 const nested = {
   name: 'nested',
   type: 'nested',
-  label: 'Meu nested',
+  label: 'Meu nested2',
   children: {
     name: {
       name: 'name',

--- a/docs/src/examples/QasNestedFields/StartsEmptyFalse.vue
+++ b/docs/src/examples/QasNestedFields/StartsEmptyFalse.vue
@@ -3,7 +3,7 @@
     <div class="full-width">
       <div class="q-mt-lg text-center">
         <div>
-          <qas-nested-fields v-model="model" class="full-width" :field="nested" :fields-props="fieldsProps" :form-columns="formColumns" :row-object="rowObject" :use-starts-empty="false" />
+          <qas-nested-fields v-model="model" class="full-width" :field="nested" :fields-props="fieldsProps" :form-columns="formColumns" :row-object="rowObject" :use-destroy-always="false" :use-starts-empty="false" />
         </div>
 
         <div class="q-my-lg">

--- a/docs/src/examples/QasNestedFields/StartsEmptyFalse.vue
+++ b/docs/src/examples/QasNestedFields/StartsEmptyFalse.vue
@@ -3,7 +3,7 @@
     <div class="full-width">
       <div class="q-mt-lg text-center">
         <div>
-          <qas-nested-fields v-model="model" class="full-width" :field="nested" :fields-props="fieldsProps" :form-columns="formColumns" :row-object="rowObject" />
+          <qas-nested-fields v-model="model" class="full-width" :field="nested" :fields-props="fieldsProps" :form-columns="formColumns" :row-object="rowObject" :use-starts-empty="false" />
         </div>
 
         <div class="q-my-lg">

--- a/docs/src/pages/components/nested-fields.md
+++ b/docs/src/pages/components/nested-fields.md
@@ -66,6 +66,10 @@ Para saber mais sobre o **API Design Pattern** clice [aqui](https://www.notion.s
 :::
 
 :::warning
+A propriedade `useDestroyAlways` caso não seja repassada ao componente, assume o inicial como o mesmo valor da propriedade `useStartsEmpty`.
+:::
+
+:::warning
 A propriedade `fieldsEvents` não existe mais, para passar eventos para os campos basta passar dentro de `fieldsProps`, já que tudo que é referente a eventos está dentro de `$attrs` no vue 3, por exemplo:
 
 ```js
@@ -83,9 +87,9 @@ Para saber mais clique [aqui](https://v3-migration.vuejs.org/breaking-changes/li
 ## Uso
 
 <doc-example file="QasNestedFields/Basic" title="Básico" />
-<doc-example file="QasNestedFields/StartsEmptyFalse" title="Começando com formulário" />
+<!-- <doc-example file="QasNestedFields/StartsEmptyFalse" title="Começando com formulário" />
 <doc-example file="QasNestedFields/DisabledRows" title="Linhas desabilitadas" />
 <doc-example file="QasNestedFields/InlineActions" title="Propriedade useInlineActions" />
 <doc-example file="QasNestedFields/SlotDynamic" title="Slot field-[nome-da-chave]" />
 <doc-example file="QasNestedFields/SlotFields" title="Slot fields" />
-<doc-example file="QasNestedFields/SlotAddInput" title="Slot add-input" />
+<doc-example file="QasNestedFields/SlotAddInput" title="Slot add-input" /> -->

--- a/docs/src/pages/components/nested-fields.md
+++ b/docs/src/pages/components/nested-fields.md
@@ -83,6 +83,7 @@ Para saber mais clique [aqui](https://v3-migration.vuejs.org/breaking-changes/li
 ## Uso
 
 <doc-example file="QasNestedFields/Basic" title="Básico" />
+<doc-example file="QasNestedFields/StartsEmptyFalse" title="Começando com formulário" />
 <doc-example file="QasNestedFields/DisabledRows" title="Linhas desabilitadas" />
 <doc-example file="QasNestedFields/InlineActions" title="Propriedade useInlineActions" />
 <doc-example file="QasNestedFields/SlotDynamic" title="Slot field-[nome-da-chave]" />

--- a/docs/src/pages/components/nested-fields.md
+++ b/docs/src/pages/components/nested-fields.md
@@ -87,9 +87,9 @@ Para saber mais clique [aqui](https://v3-migration.vuejs.org/breaking-changes/li
 ## Uso
 
 <doc-example file="QasNestedFields/Basic" title="Básico" />
-<!-- <doc-example file="QasNestedFields/StartsEmptyFalse" title="Começando com formulário" />
+<doc-example file="QasNestedFields/StartsEmptyFalse" title="Começando com formulário" />
 <doc-example file="QasNestedFields/DisabledRows" title="Linhas desabilitadas" />
 <doc-example file="QasNestedFields/InlineActions" title="Propriedade useInlineActions" />
 <doc-example file="QasNestedFields/SlotDynamic" title="Slot field-[nome-da-chave]" />
 <doc-example file="QasNestedFields/SlotFields" title="Slot fields" />
-<doc-example file="QasNestedFields/SlotAddInput" title="Slot add-input" /> -->
+<doc-example file="QasNestedFields/SlotAddInput" title="Slot add-input" />

--- a/ui/src/components/nested-fields/QasNestedFields.vue
+++ b/ui/src/components/nested-fields/QasNestedFields.vue
@@ -14,7 +14,7 @@
 
                 <div v-if="hasBlockActions(row)" class="q-gutter-x-sm">
                   <qas-btn v-if="useDuplicate" v-bind="buttonDuplicateProps" @click="add(row)" />
-                  <qas-btn v-if="showDestroyBtn" v-bind="buttonDestroyProps" @click="destroy(index, row)" />
+                  <qas-btn v-if="showDestroyButton" v-bind="buttonDestroyProps" @click="destroy(index, row)" />
                 </div>
               </div>
 
@@ -32,7 +32,7 @@
                     <qas-btn v-if="useDuplicate" color="primary" flat icon="o_content_copy" round @click="add(row)" />
                   </div>
                   <div class="col-auto">
-                    <qas-btn v-if="showDestroyBtn" color="negative" flat icon="o_cancel" round @click="destroy(index, row)" />
+                    <qas-btn v-if="showDestroyButton" color="negative" flat icon="o_cancel" round @click="destroy(index, row)" />
                   </div>
                 </div>
               </div>
@@ -47,7 +47,11 @@
 
       <div v-if="useAdd" class="q-mt-md">
         <slot :add="add" name="add-input">
-          <div v-if="useInlineActions" class="cursor-pointer items-center q-col-gutter-x-md q-mt-md row" @click="add()">
+          <div v-if="showAddFirstInputButton" class="text-left">
+            <qas-btn class="q-px-sm" color="dark" flat @click="add()">{{ addFirstInputLabel }}</qas-btn>
+          </div>
+
+          <div v-else-if="useInlineActions" class="cursor-pointer items-center q-col-gutter-x-md q-mt-md row" @click="add()">
             <div class="col">
               <qas-input class="disabled no-pointer-events" hide-bottom-space :label="addInputLabel" outlined @focus="add()" />
             </div>
@@ -57,8 +61,8 @@
             </div>
           </div>
 
-          <div v-else class="q-mt-lg">
-            <qas-btn class="full-width q-py-md" icon="o_add" outline @click="add()">{{ addInputLabel }}</qas-btn>
+          <div v-else class="text-left">
+            <qas-btn class="q-px-sm" color="dark" flat icon="o_add" @click="add()">{{ addInputLabel }}</qas-btn>
           </div>
         </slot>
       </div>
@@ -90,9 +94,14 @@ export default {
   },
 
   props: {
+    addFirstInputLabel: {
+      type: String,
+      default: 'Clique aqui para adicionar'
+    },
+
     addInputLabel: {
       type: String,
-      default: 'Inserir novo campo'
+      default: 'Adicionar'
     },
 
     buttonDestroyProps: {
@@ -190,10 +199,16 @@ export default {
     },
 
     useDestroyAlways: {
-      type: Boolean
+      type: Boolean,
+      default: true
     },
 
     useDuplicate: {
+      type: Boolean,
+      default: true
+    },
+
+    useFirstInputButton: {
       type: Boolean,
       default: true
     },
@@ -213,6 +228,11 @@ export default {
     useRemoveOnDestroy: {
       type: Boolean,
       default: true
+    },
+
+    useStartsEmpty: {
+      default: true,
+      type: Boolean
     },
 
     modelValue: {
@@ -242,7 +262,7 @@ export default {
       return this.field?.children
     },
 
-    showDestroyBtn () {
+    showDestroyButton () {
       return this.nested.filter(item => !item[this.destroyKey]).length > 1 || this.useDestroyAlways
     },
 
@@ -268,6 +288,10 @@ export default {
         tag: 'div',
         enterActiveClass: 'animated slideInDown'
       }
+    },
+
+    showAddFirstInputButton () {
+      return this.useFirstInputButton && !this.nested.length
     }
   },
 
@@ -282,7 +306,7 @@ export default {
 
     rowObject: {
       handler () {
-        if (!this.nested.length) return this.setDefaultNestedValue()
+        this.setDefaultNestedValue()
       },
       immediate: true
     }
@@ -345,6 +369,7 @@ export default {
     },
 
     setDefaultNestedValue () {
+      if (this.nested.length || this.useStartsEmpty) return
       this.nested.splice(0, 0, { ...this.rowObject })
     },
 

--- a/ui/src/components/nested-fields/QasNestedFields.vue
+++ b/ui/src/components/nested-fields/QasNestedFields.vue
@@ -200,7 +200,7 @@ export default {
 
     useDestroyAlways: {
       type: Boolean,
-      default: true
+      default: undefined
     },
 
     useDuplicate: {
@@ -245,7 +245,8 @@ export default {
 
   data () {
     return {
-      nested: []
+      nested: [],
+      hasDestroyAlways: true
     }
   },
 
@@ -263,7 +264,7 @@ export default {
     },
 
     showDestroyButton () {
-      return this.nested.filter(item => !item[this.destroyKey]).length > 1 || this.useDestroyAlways
+      return this.nested.filter(item => !item[this.destroyKey]).length > 1 || this.hasDestroyAlways
     },
 
     formClasses () {
@@ -307,6 +308,13 @@ export default {
     rowObject: {
       handler () {
         this.setDefaultNestedValue()
+      },
+      immediate: true
+    },
+
+    useDestroyAlways: {
+      handler (value) {
+        this.hasDestroyAlways = value ?? this.useStartsEmpty
       },
       immediate: true
     }

--- a/ui/src/components/nested-fields/QasNestedFields.yml
+++ b/ui/src/components/nested-fields/QasNestedFields.yml
@@ -4,9 +4,14 @@ meta:
   desc: Componente para gerar dinamicamente campos nested.
 
 props:
+  add-first-input-label:
+    desc: Rótulo do input para adicionar o primeiro campo.
+    default: Clique aqui para adicionar
+    type: Boolean
+
   add-input-label:
     desc: Rótulo do input de adicionar novos campos.
-    default: Inserir novo campo
+    default: Adicionar
     type: Boolean
 
   button-destroy-props:
@@ -76,17 +81,17 @@ props:
     model: true
 
   row-label:
-    desc: Rótulo entre cada linha (row).
+    desc: Rótulo entre cada linha.
     type: String
 
   row-object:
-    desc: Objeto contendo valores iniciais do model de cada linha (row).
+    desc: Objeto contendo valores iniciais do model de cada linha.
     default: {}
     type: Object
     examples: ["{ name: '', cities: [] }"]
 
   use-add:
-    desc: Controla quando vai ter seção de "adicionar" novas rows (linhas).
+    desc: Controla quando vai ter seção de "adicionar" novas linhas.
     default: true
     type: Boolean
 
@@ -96,11 +101,17 @@ props:
     type: Boolean
 
   use-destroy-always:
-    desc: Controla o botão de remover em todas linhas (row), incluindo a primeira.
+    desc: Controla o botão de remover em todas linhas, incluindo a primeira.
+    default: true
     type: Boolean
 
   use-duplicate:
     desc: Controla o botão de duplicar linha.
+    default: true
+    type: Boolean
+
+  use-first-input-button:
+    desc: Controla se vai ter um botão diferente para adicionar o primeiro campo.
     default: true
     type: Boolean
 
@@ -109,15 +120,20 @@ props:
     type: Boolean
 
   use-inline-actions:
-    desc: Controla o comportamento referente aos estilos das ações de duplicar/adicionar/remover
+    desc: Controla o comportamento referente aos estilos das ações de duplicar/adicionar/remover.
     type: Boolean
 
   use-single-label:
-    desc: Se o valor for "true", então vai exibir apenas uma label referente a todas linhas (row) e não uma por linha
+    desc: Exibe apenas uma label referente a todas linhas, e não uma por linha.
     type: Boolean
 
   use-remove-on-destroy:
-    desc: Se o valor for "true" o valor do model será removido senão será adicionar uma flag como `destroyed` por exemplo.
+    desc: O valor do model será removido senão será adicionar uma flag como `destroyed` por exemplo.
+    default: true
+    type: Boolean
+
+  use-starts-empty:
+    desc: O componente iniciará sem nenhuma linha.
     default: true
     type: Boolean
 

--- a/ui/src/components/nested-fields/QasNestedFields.yml
+++ b/ui/src/components/nested-fields/QasNestedFields.yml
@@ -7,12 +7,12 @@ props:
   add-first-input-label:
     desc: Rótulo do input para adicionar o primeiro campo.
     default: Clique aqui para adicionar
-    type: Boolean
+    type: String
 
   add-input-label:
     desc: Rótulo do input de adicionar novos campos.
     default: Adicionar
-    type: Boolean
+    type: String
 
   button-destroy-props:
     desc: Props do botão de excluir linha contendo os campos.
@@ -102,7 +102,6 @@ props:
 
   use-destroy-always:
     desc: Controla o botão de remover em todas linhas, incluindo a primeira.
-    default: true
     type: Boolean
 
   use-duplicate:


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

O novo comportamento deve trazer um texto para que o usuário clique e para só então exibir os campos do nested.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
