### PR TITLE
Removed back button from QasPageHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `QasPageHeader`: removido botão de voltar ao lado do título da página, decisão de design.
+
 ## [3.5.0-beta.1] - 16-12-2022
 ## BREAKING CHANGE
 - `QasTableGenerator`: pode haver breaking change de design no espaçamento embaixo do componente uma vez que foi removido a classe `q-mb-xl`.

--- a/ui/src/components/delete/QasDelete.vue
+++ b/ui/src/components/delete/QasDelete.vue
@@ -105,8 +105,6 @@ export default {
       this.$emit('update:deleting', true)
 
       try {
-        const { destroyRoutes, history } = useHistory()
-
         const payload = { id: this.id, url: this.url }
 
         this.$qas.logger.group(
@@ -122,6 +120,8 @@ export default {
         NotifySuccess('Item deletado com sucesso!')
 
         if (this.useAutoDeleteRoute) {
+          const { destroyRoutes, history } = useHistory()
+
           // remove todas rotas que possuem o id do item excluído.
           const routesToBeDeleted = this.getRoutesToBeDeletedById(history.list)
           destroyRoutes(routesToBeDeleted)

--- a/ui/src/components/page-header/QasPageHeader.vue
+++ b/ui/src/components/page-header/QasPageHeader.vue
@@ -2,7 +2,6 @@
   <q-toolbar class="justify-between q-mb-lg q-px-none">
     <div class="ellipsis">
       <q-toolbar-title v-if="title" class="text-bold text-h5">
-        <q-icon v-if="hasPreviousRoute" class="cursor-pointer vertical-baseline" name="o_arrow_back" size="18px" @click="back" />
         {{ title }}
       </q-toolbar-title>
 
@@ -19,7 +18,7 @@ import { castArray } from 'lodash-es'
 import { useHistory } from '../../composables'
 import { createMetaMixin } from 'quasar'
 
-const { hasPreviousRoute, history, getPreviousRoute } = useHistory()
+const { history } = useHistory()
 
 export default {
   name: 'QasPageHeader',
@@ -55,10 +54,6 @@ export default {
   },
 
   computed: {
-    hasPreviousRoute () {
-      return hasPreviousRoute.value
-    },
-
     transformedBreadcrumbs () {
       const list = [...castArray(this.breadcrumbs || this.title)]
       this.root && list.unshift(this.root)
@@ -85,10 +80,6 @@ export default {
   },
 
   methods: {
-    back () {
-      this.$router.push(getPreviousRoute(this.$route))
-    },
-
     getBreadcrumbsClass (index) {
       const lastIndex = this.transformedBreadcrumbs.length - 1
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

Removido botão de voltar do QasPageHeader:

clickup: https://app.clickup.com/t/35k1dp6

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
