### PR TITLE
Changes in notify and default message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- [`QasFormView`, `view.js`, `QasDelete`]: alterado mensagens padrão do nofity, e removido `exception` dos notifies.
+- `notify.scss`: adicionado tamanho máximo de `560px`.
+
 ## [3.5.0-beta.1] - 16-12-2022
 ## BREAKING CHANGE
 - `QasTableGenerator`: pode haver breaking change de design no espaçamento embaixo do componente uma vez que foi removido a classe `q-mb-xl`.

--- a/ui/src/components/delete/QasDelete.vue
+++ b/ui/src/components/delete/QasDelete.vue
@@ -92,6 +92,13 @@ export default {
 
     id () {
       return this.customId || this.$route.params.id
+    },
+
+    defaultNotifyMessages () {
+      return {
+        error: 'Não conseguimos excluir as informações. Por favor, tente novamente em alguns minutos.',
+        success: 'Informações excluídas com sucesso.'
+      }
     }
   },
 
@@ -119,7 +126,7 @@ export default {
           payload
         })
 
-        NotifySuccess('Item deletado com sucesso!')
+        NotifySuccess(this.defaultNotifyMessages.success)
 
         if (this.useAutoDeleteRoute) {
           // remove todas rotas que possuem o id do item excluído.
@@ -134,7 +141,7 @@ export default {
 
         this.$qas.logger.info('QasDelete - destroy -> item deletado com sucesso!')
       } catch (error) {
-        NotifyError('Ops! Não foi possível deletar o item.')
+        NotifyError(this.defaultNotifyMessages.error)
         this.$emit('error', error)
 
         this.$qas.logger.group(

--- a/ui/src/components/form-view/QasFormView.vue
+++ b/ui/src/components/form-view/QasFormView.vue
@@ -196,6 +196,14 @@ export default {
 
     isCancelButtonDisabled () {
       return this.disable || this.isSubmitting
+    },
+
+    defaultNotifyMessages () {
+      return {
+        validationError: 'Existem campos no formulário que ainda não foram preenchidos. Complete todas as informações para avançar.',
+        error: 'Não conseguimos salvar as informações. Por favor, tente novamente em alguns minutos.',
+        success: 'Informações salvas com sucesso.'
+      }
     }
   },
 
@@ -420,7 +428,7 @@ export default {
         }
 
         this.mx_setErrors()
-        NotifySuccess(response.data.status.text || 'Item salvo com sucesso!')
+        NotifySuccess(response.data.status.text || this.defaultNotifyMessages.success)
         this.$emit('submit-success', response, this.modelValue)
 
         this.$qas.logger.group(
@@ -429,16 +437,15 @@ export default {
       } catch (error) {
         const errors = error?.response?.data?.errors
         const message = error?.response?.data?.status?.text
-        const exceptionResponse = error?.response?.data?.exception
 
-        const exception = errors
-          ? 'Existem erros de validação no formulário.'
-          : exceptionResponse || error.message
+        const defaultMessage = error
+          ? this.defaultNotifyMessages.validationError
+          : this.defaultNotifyMessages.error
 
         this.mx_setErrors(errors)
         this.$emit('update:errors', this.mx_errors)
 
-        NotifyError(message || 'Ops! Erro ao salvar item.', exception)
+        NotifyError(message || defaultMessage)
 
         this.$emit('submit-error', error)
 

--- a/ui/src/css/plugins/notify.scss
+++ b/ui/src/css/plugins/notify.scss
@@ -1,5 +1,6 @@
 .q-notification {
   margin-top: 80px;
+  max-width: 560px;
 
   &__content {
     .q-icon {

--- a/ui/src/mixins/view.js
+++ b/ui/src/mixins/view.js
@@ -81,13 +81,16 @@ export default {
 
     mx_hasHeaderSlot () {
       return !!(this.$slots.header)
+    },
+
+    mx_fetchErrorMessage () {
+      return 'Ops… Não conseguimos acessar as informações. Por favor, tente novamente em alguns minutos.'
     }
   },
 
   methods: {
     mx_fetchError (error) {
       const { response } = error
-      const exception = response?.data?.exception || error.message
 
       const status = response?.status
 
@@ -102,7 +105,7 @@ export default {
         return
       }
 
-      this.$qas.error('Ops! Erro ao obter os dados.', exception)
+      this.$qas.error(this.mx_fetchErrorMessage)
     },
 
     mx_setErrors (errors = {}) {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

- Alterado mesagem padrão do `QasFormView`, `view.js`, `QasDelete`.
- Adicionado tamanho máximo ao notify

clickup: https://app.clickup.com/t/864dj3zdr

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [x] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
