### PR TITLE
QasFilters Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ## Não publicado
 ### Adicionado
 - `QasSelect`: adicionado documentação do `useSearch`.
+-`ui/src/index.scss`: adicionado nova variável css para transição: `--qas-generic-transition: 300ms`;
+
+### Modificado
+- `QasFilters`: mudanças de design.
+- `QasFilters`: alterado debounce de `500ms` para `800ms`.
+- `QasPageHeader`: alterado espaçamento de `q-mb-lg` para `q-mb-xl` para manter o que era anteriormente.
 
 ## [3.5.0-beta.4] - 22-12-2022
 ### Adicionado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
+## BREAKING CHANGE
+- `QasFilters`: removido slot `filter-button`.
+
 ### Adicionado
 - `QasSelect`: adicionado documentação do `useSearch`.
 -`ui/src/index.scss`: adicionado nova variável css para transição: `--qas-generic-transition: 300ms`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasFilters`: alterado debounce de `500ms` para `800ms`.
 - `QasPageHeader`: alterado espaçamento de `q-mb-lg` para `q-mb-xl` para manter o que era anteriormente.
 
+### Removido
+- `QasFilters`: removido slot `filter-button`.
+
 ## [3.5.0-beta.4] - 22-12-2022
 ### Adicionado
 - `QasSelect`: adicionado propriedade `useSearch` para caso que não queira busca automática do fuse, se não passar essa prop a busca vai depender da quantidade de options.

--- a/docs/src/examples/QasFilters/Basic.vue
+++ b/docs/src/examples/QasFilters/Basic.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container spaced">
-    <qas-filters :entity="entity" :fields-props="fieldsProps" />
+    <qas-filters :entity="entity" :fields-props="fieldsProps" search-placeholder="Gabriel Assen de Vasconcelos Belin Queiroz Gabrielle Ra" />
   </div>
 </template>
 

--- a/docs/src/examples/QasFilters/Basic.vue
+++ b/docs/src/examples/QasFilters/Basic.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container spaced">
-    <qas-filters :entity="entity" :fields-props="fieldsProps" search-placeholder="Gabriel Assen de Vasconcelos Belin Queiroz Gabrielle Ra" />
+    <qas-filters :entity="entity" :fields-props="fieldsProps" search-placeholder="Gabriel Assen de Vasconcelos Belin Queiroz Gabrielle Ra" :use-search-on-type="false" />
   </div>
 </template>
 

--- a/docs/src/examples/QasFilters/Basic.vue
+++ b/docs/src/examples/QasFilters/Basic.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container spaced">
-    <qas-filters :entity="entity" :fields-props="fieldsProps" search-placeholder="Gabriel Assen de Vasconcelos Belin Queiroz Gabrielle Ra" :use-search-on-type="false" />
+    <qas-filters :entity="entity" :fields-props="fieldsProps" search-placeholder="Gabriel Assen de Vasconcelos Belin Queiroz Gabrielle Ra" />
   </div>
 </template>
 

--- a/docs/src/pages/components/filters.md
+++ b/docs/src/pages/components/filters.md
@@ -27,7 +27,7 @@ Este componente serve para lidar com **filtros dinâmicos**, e normalmente utili
 
 Normalmente este componente é utilizando junto ao `QasListView` para filtrar os dados.
 
-<doc-example file="QasFilters/CommonUsage" title="Normalmente utilizado" />
+<!-- <doc-example file="QasFilters/CommonUsage" title="Normalmente utilizado" /> -->
 
-<doc-example file="QasFilters/CustomFilter" title="Usando slot default com funções 'filter' e 'removeFilter'" />
+<!-- <doc-example file="QasFilters/CustomFilter" title="Usando slot default com funções 'filter' e 'removeFilter'" /> -->
 

--- a/docs/src/pages/components/filters.md
+++ b/docs/src/pages/components/filters.md
@@ -27,7 +27,7 @@ Este componente serve para lidar com **filtros dinâmicos**, e normalmente utili
 
 Normalmente este componente é utilizando junto ao `QasListView` para filtrar os dados.
 
-<!-- <doc-example file="QasFilters/CommonUsage" title="Normalmente utilizado" /> -->
+<doc-example file="QasFilters/CommonUsage" title="Normalmente utilizado" />
 
-<!-- <doc-example file="QasFilters/CustomFilter" title="Usando slot default com funções 'filter' e 'removeFilter'" /> -->
+<doc-example file="QasFilters/CustomFilter" title="Usando slot default com funções 'filter' e 'removeFilter'" />
 

--- a/ui/src/components/filters/QasFilters.vue
+++ b/ui/src/components/filters/QasFilters.vue
@@ -351,16 +351,16 @@ export default {
 // TODO rever
 .qas-filters {
   .q-field::before {
-    transition: border-color var(--qas-generic-transition);
-    content: '';
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    pointer-events: none;
     border: 2px solid transparent;
     border-radius: 4px;
+    bottom: 0;
+    content: '';
+    left: 0;
+    pointer-events: none;
+    position: absolute;
+    right: 0;
+    top: 0;
+    transition: border-color var(--qas-generic-transition);
   }
 
   .q-field--focused::before {
@@ -380,8 +380,8 @@ export default {
     }
 
     .q-field__native {
-      padding-top: var(--qas-spacing-sm);
       padding-bottom: var(--qas-spacing-sm);
+      padding-top: var(--qas-spacing-sm);
     }
   }
 }

--- a/ui/src/components/filters/QasFilters.vue
+++ b/ui/src/components/filters/QasFilters.vue
@@ -7,15 +7,14 @@
             <qas-input v-model="search" class="bg-white q-px-sm qas-filters__input rounded-borders-sm shadow-2" data-cy="filters-search-input" :debounce="debounce" dense hide-bottom-space input-class="ellipsis text-grey-8" :outlined="false" :placeholder="searchPlaceholder" type="search">
               <template #prepend>
                 <q-icon v-if="useSearchOnType" color="grey-8" name="o_search" />
-                <qas-btn v-else color="grey-8" flat icon="o_search" padding="0" />
+                <qas-btn v-else color="grey-9" flat icon="o_search" padding="0" @click="filter()" />
               </template>
 
               <template #append>
                 <qas-btn v-if="hasSearch" class="q-mr-sm" color="grey-9" flat icon="o_clear" padding="0" size="sm" @click="clearSearch" />
-                <qas-btn v-if="!debounce" color="grey-9" flat icon="o_search" type="submit" @click="filter()" />
 
                 <qas-btn v-if="useFilterButton" :color="filterButtonColor" data-cy="filters-btn" flat icon="o_tune" padding="0">
-                  <q-menu class="full-width" max-width="270px">
+                  <q-menu anchor="center right" class="full-width" max-width="270px" self="top right">
                     <div v-if="isFetching" class="q-pa-xl text-center">
                       <q-spinner color="grey" size="2em" />
                     </div>
@@ -52,8 +51,9 @@
       </div>
     </div>
 
-    <div v-if="useChip && hasActiveFilters" class="q-mt-md">
-      <q-chip v-for="(filterItem, key) in activeFilters" :key="key" color="primary" :data-cy="`filters-${filterItem.value}-chip`" dense removable size="md" text-color="white" @remove="removeFilter(filterItem)">{{ filterItem.label }} = "{{ getChipValue(filterItem.value) }}"</q-chip>
+    <div v-if="hasChip" class="q-mt-md">
+      <!-- TODO rever com novo estilo -->
+      <q-chip v-for="(filterItem, key) in activeFilters" :key="key" color="white" :data-cy="`filters-${filterItem.value}-chip`" dense icon-remove="o_close" removable size="md" text-color="grey-8" @remove="removeFilter(filterItem)">{{ getChipValue(filterItem.value) }}</q-chip>
     </div>
 
     <slot :context="mx_context" :filter="filter" :filters="activeFilters" :remove-filter="removeFilter" />
@@ -200,6 +200,10 @@ export default {
 
     showSearch () {
       return !!this.$slots.search || this.useSearch
+    },
+
+    hasChip () {
+      return this.useChip && this.hasActiveFilters
     }
   },
 
@@ -363,6 +367,14 @@ export default {
   .q-field--focused::before {
     border-color: var(--q-primary);
     color: var(--q-primary);
+  }
+
+  .q-field--dense .q-field__prepend {
+    padding-right: var(--qas-spacing-xs);
+  }
+
+  .q-field--dense .q-field__append {
+    padding-left: var(--qas-spacing-sm);
   }
 
   &__input {

--- a/ui/src/components/filters/QasFilters.vue
+++ b/ui/src/components/filters/QasFilters.vue
@@ -6,12 +6,13 @@
           <q-form v-if="useSearch" @submit.prevent="filter()">
             <qas-input v-model="search" class="bg-white q-px-sm qas-filters__input rounded-borders-sm shadow-2" data-cy="filters-search-input" :debounce="debounce" dense hide-bottom-space input-class="ellipsis text-grey-8" :outlined="false" :placeholder="searchPlaceholder" type="search">
               <template #prepend>
-                <q-icon color="grey-8" name="o_search" />
+                <q-icon v-if="useSearchOnType" color="grey-8" name="o_search" />
+                <qas-btn v-else color="grey-8" flat icon="o_search" padding="0" />
               </template>
 
               <template #append>
-                <qas-btn v-if="hasSearch" class="q-mr-sm" color="grey-9" flat icon="o_clear" padding="0" size="sm" unelevated @click="clearSearch" />
-                <qas-btn v-if="!debounce" color="grey-9" flat icon="o_search" type="submit" unelevated @click="filter()" />
+                <qas-btn v-if="hasSearch" class="q-mr-sm" color="grey-9" flat icon="o_clear" padding="0" size="sm" @click="clearSearch" />
+                <qas-btn v-if="!debounce" color="grey-9" flat icon="o_search" type="submit" @click="filter()" />
 
                 <qas-btn v-if="useFilterButton" :color="filterButtonColor" data-cy="filters-btn" flat icon="o_tune" padding="0">
                   <q-menu class="full-width" max-width="270px">
@@ -30,11 +31,11 @@
 
                       <div class="q-col-gutter-x-md q-mt-xl row">
                         <div class="col-6">
-                          <qas-btn class="full-width" data-cy="filters-clear-btn" label="Limpar" outline size="12px" unelevated @click="clearFilters" />
+                          <qas-btn class="full-width" data-cy="filters-clear-btn" label="Limpar" outline size="12px" @click="clearFilters" />
                         </div>
 
                         <div class="col-6">
-                          <qas-btn class="full-width" color="primary" data-cy="filters-submit-btn" label="Filtrar" size="12px" type="submit" unelevated />
+                          <qas-btn class="full-width" color="primary" data-cy="filters-submit-btn" label="Filtrar" size="12px" type="submit" />
                         </div>
                       </div>
                     </q-form>

--- a/ui/src/components/filters/QasFilters.vue
+++ b/ui/src/components/filters/QasFilters.vue
@@ -4,7 +4,7 @@
       <div v-if="showSearch" class="col-12 col-md-6">
         <slot :filter="filter" name="search">
           <q-form v-if="useSearch" @submit.prevent="filter()">
-            <qas-input v-model="search" class="q-px-sm qas-filters__input rounded-borders-sm shadow-2" :class="inputClass" data-cy="filters-search-input" :debounce="debounce" dense hide-bottom-space input-class="ellipsis text-grey-8" :outlined="false" :placeholder="searchPlaceholder" type="search" @blur="onFocus(false)" @focus="onFocus(true)">
+            <qas-input v-model="search" class="q-px-sm qas-filters__input rounded-borders-sm shadow-2" data-cy="filters-search-input" :debounce="debounce" dense hide-bottom-space input-class="ellipsis text-grey-8" :outlined="false" :placeholder="searchPlaceholder" type="search">
               <template #prepend>
                 <q-icon color="grey-8" name="o_search" />
               </template>
@@ -161,7 +161,7 @@ export default {
     },
 
     debounce () {
-      return this.useSearchOnType ? '500' : ''
+      return this.useSearchOnType ? '800' : ''
     },
 
     fields () {
@@ -199,10 +199,6 @@ export default {
 
     showSearch () {
       return !!this.$slots.search || this.useSearch
-    },
-
-    inputClass () {
-      return this.isInputFocused && 'qas-filters__input--active'
     }
   },
 
@@ -369,11 +365,6 @@ export default {
   }
 
   &__input {
-    .q-field--focused::before {
-      border-color: var(--q-primary);
-      color: var(--q-primary);
-    }
-
     .q-field__control::before,
     .q-field__control::after {
       display: none;

--- a/ui/src/components/filters/QasFilters.vue
+++ b/ui/src/components/filters/QasFilters.vue
@@ -1,52 +1,53 @@
 <template>
   <section class="q-mb-lg qas-filters">
-    <div v-if="showFilters" class="q-gutter-x-md row">
-      <div v-if="showSearch" class="col-6">
+    <div v-if="showFilters" class="q-col-gutter-x-md row">
+      <div v-if="showSearch" class="col-12 col-md-6">
         <slot :filter="filter" name="search">
           <q-form v-if="useSearch" @submit.prevent="filter()">
-            <qas-input v-model="search" class="qas-filters__input shadow-2" data-cy="filters-search-input" :debounce="debounce" dense hide-bottom-space :outlined="false" :placeholder="searchPlaceholder" type="search">
+            <qas-input v-model="search" class="q-px-sm qas-filters__input rounded-borders-sm shadow-2" :class="inputClass" data-cy="filters-search-input" :debounce="debounce" dense hide-bottom-space input-class="ellipsis text-grey-8" :outlined="false" :placeholder="searchPlaceholder" type="search" @blur="onFocus(false)" @focus="onFocus(true)">
               <template #prepend>
-                <q-icon class="q-ml-sm" name="o_search" />
+                <q-icon color="grey-8" name="o_search" />
               </template>
 
               <template #append>
-                <div class="q-mr-sm">
-                  <qas-btn v-if="hasSearch" color="grey-9" flat icon="o_clear" unelevated @click="clearSearch" />
+                <qas-btn v-if="hasSearch" class="q-mr-sm" color="grey-9" flat icon="o_clear" padding="0" size="sm" unelevated @click="clearSearch" />
+                <qas-btn v-if="!debounce" color="grey-9" flat icon="o_search" type="submit" unelevated @click="filter()" />
 
-                  <qas-btn v-if="!debounce" color="grey-9" flat icon="o_search" type="submit" unelevated @click="filter()" />
+                <qas-btn v-if="useFilterButton" :color="filterButtonColor" data-cy="filters-btn" flat icon="o_tune" padding="0">
+                  <q-menu class="full-width" max-width="270px">
+                    <div v-if="isFetching" class="q-pa-xl text-center">
+                      <q-spinner color="grey" size="2em" />
+                    </div>
 
-                  <qas-btn v-if="useFilterButton" :color="filterButtonColor" data-cy="filters-btn" flat icon="o_filter_list" round size="sm">
-                    <q-menu class="full-width" max-width="270px">
-                      <div v-if="isFetching" class="q-pa-xl text-center">
-                        <q-spinner color="grey" size="2em" />
+                    <div v-else-if="hasFetchError" class="q-pa-xl text-center">
+                      <q-icon color="negative" name="o_warning" size="2em" />
+                    </div>
+
+                    <q-form v-else class="q-gutter-y-md q-pa-md" @submit.prevent="filter()">
+                      <div v-for="(field, index) in fields" :key="index">
+                        <qas-field v-model="filters[field.name]" :data-cy="`filters-${field.name}-field`" :field="field" v-bind="fieldsProps[field.name]" />
                       </div>
 
-                      <div v-else-if="hasFetchError" class="q-pa-xl text-center">
-                        <q-icon color="negative" name="o_warning" size="2em" />
+                      <div class="q-col-gutter-x-md q-mt-xl row">
+                        <div class="col-6">
+                          <qas-btn class="full-width" data-cy="filters-clear-btn" label="Limpar" outline size="12px" unelevated @click="clearFilters" />
+                        </div>
+
+                        <div class="col-6">
+                          <qas-btn class="full-width" color="primary" data-cy="filters-submit-btn" label="Filtrar" size="12px" type="submit" unelevated />
+                        </div>
                       </div>
-
-                      <q-form v-else class="q-gutter-y-md q-pa-md" @submit.prevent="filter()">
-                        <div v-for="(field, index) in fields" :key="index">
-                          <qas-field v-model="filters[field.name]" :data-cy="`filters-${field.name}-field`" dense :field="field" v-bind="fieldsProps[field.name]" />
-                        </div>
-
-                        <div class="q-col-gutter-x-md q-mt-lg row">
-                          <div class="col-6">
-                            <qas-btn class="full-width" data-cy="filters-clear-btn" label="Limpar" outline size="12px" unelevated @click="clearFilters" />
-                          </div>
-
-                          <div class="col-6">
-                            <qas-btn class="full-width" color="primary" data-cy="filters-submit-btn" label="Filtrar" size="12px" type="submit" unelevated />
-                          </div>
-                        </div>
-                      </q-form>
-                    </q-menu>
-                  </qas-btn>
-                </div>
+                    </q-form>
+                  </q-menu>
+                </qas-btn>
               </template>
             </qas-input>
           </q-form>
         </slot>
+      </div>
+
+      <div class="col-12 col-md-6">
+        <slot name="right-side" />
       </div>
     </div>
 
@@ -198,6 +199,10 @@ export default {
 
     showSearch () {
       return !!this.$slots.search || this.useSearch
+    },
+
+    inputClass () {
+      return this.isInputFocused && 'qas-filters__input--active'
     }
   },
 
@@ -343,15 +348,40 @@ export default {
 </script>
 
 <style lang="scss">
+// TODO rever
 .qas-filters {
-  &__input {
-    // TODO adicionar no qas-input
+  .q-field::before {
+    transition: border-color var(--qas-generic-transition);
+    content: '';
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    pointer-events: none;
+    border: 2px solid transparent;
     border-radius: 4px;
+  }
 
-    // TODO rever
+  .q-field--focused::before {
+    border-color: var(--q-primary);
+    color: var(--q-primary);
+  }
+
+  &__input {
+    .q-field--focused::before {
+      border-color: var(--q-primary);
+      color: var(--q-primary);
+    }
+
     .q-field__control::before,
     .q-field__control::after {
       display: none;
+    }
+
+    .q-field__native {
+      padding-top: var(--qas-spacing-sm);
+      padding-bottom: var(--qas-spacing-sm);
     }
   }
 }

--- a/ui/src/components/filters/QasFilters.vue
+++ b/ui/src/components/filters/QasFilters.vue
@@ -1,10 +1,10 @@
 <template>
-  <section class="q-mb-lg qas-filters">
+  <section class="q-mb-xl qas-filters">
     <div v-if="showFilters" class="q-col-gutter-x-md row">
       <div v-if="showSearch" class="col-12 col-md-6">
         <slot :filter="filter" name="search">
           <q-form v-if="useSearch" @submit.prevent="filter()">
-            <qas-input v-model="search" class="q-px-sm qas-filters__input rounded-borders-sm shadow-2" data-cy="filters-search-input" :debounce="debounce" dense hide-bottom-space input-class="ellipsis text-grey-8" :outlined="false" :placeholder="searchPlaceholder" type="search">
+            <qas-input v-model="search" class="bg-white q-px-sm qas-filters__input rounded-borders-sm shadow-2" data-cy="filters-search-input" :debounce="debounce" dense hide-bottom-space input-class="ellipsis text-grey-8" :outlined="false" :placeholder="searchPlaceholder" type="search">
               <template #prepend>
                 <q-icon color="grey-8" name="o_search" />
               </template>

--- a/ui/src/components/filters/QasFilters.vue
+++ b/ui/src/components/filters/QasFilters.vue
@@ -1,43 +1,53 @@
 <template>
-  <section class="q-mb-lg">
+  <section class="q-mb-lg qas-filters">
     <div v-if="showFilters" class="q-gutter-x-md row">
-      <div v-if="showSearch" class="col">
+      <div v-if="showSearch" class="col-6">
         <slot :filter="filter" name="search">
           <q-form v-if="useSearch" @submit.prevent="filter()">
-            <qas-input v-model="search" data-cy="filters-search-input" :debounce="debounce" dense hide-bottom-space :outlined="false" :placeholder="searchPlaceholder" type="search">
+            <qas-input v-model="search" class="qas-filters__input shadow-2" data-cy="filters-search-input" :debounce="debounce" dense hide-bottom-space :outlined="false" :placeholder="searchPlaceholder" type="search">
+              <template #prepend>
+                <q-icon class="q-ml-sm" name="o_search" />
+              </template>
+
               <template #append>
-                <qas-btn v-if="hasSearch" color="grey-9" flat icon="o_clear" unelevated @click="clearSearch" />
-                <qas-btn v-if="!debounce" color="grey-9" flat icon="o_search" type="submit" unelevated @click="filter()" />
+                <div class="q-mr-sm">
+                  <qas-btn v-if="hasSearch" color="grey-9" flat icon="o_clear" unelevated @click="clearSearch" />
+
+                  <qas-btn v-if="!debounce" color="grey-9" flat icon="o_search" type="submit" unelevated @click="filter()" />
+
+                  <qas-btn v-if="useFilterButton" :color="filterButtonColor" data-cy="filters-btn" flat icon="o_filter_list" round size="sm">
+                    <q-menu class="full-width" max-width="270px">
+                      <div v-if="isFetching" class="q-pa-xl text-center">
+                        <q-spinner color="grey" size="2em" />
+                      </div>
+
+                      <div v-else-if="hasFetchError" class="q-pa-xl text-center">
+                        <q-icon color="negative" name="o_warning" size="2em" />
+                      </div>
+
+                      <q-form v-else class="q-gutter-y-md q-pa-md" @submit.prevent="filter()">
+                        <div v-for="(field, index) in fields" :key="index">
+                          <qas-field v-model="filters[field.name]" :data-cy="`filters-${field.name}-field`" dense :field="field" v-bind="fieldsProps[field.name]" />
+                        </div>
+
+                        <div class="q-col-gutter-x-md q-mt-lg row">
+                          <div class="col-6">
+                            <qas-btn class="full-width" data-cy="filters-clear-btn" label="Limpar" outline size="12px" unelevated @click="clearFilters" />
+                          </div>
+
+                          <div class="col-6">
+                            <qas-btn class="full-width" color="primary" data-cy="filters-submit-btn" label="Filtrar" size="12px" type="submit" unelevated />
+                          </div>
+                        </div>
+                      </q-form>
+                    </q-menu>
+                  </qas-btn>
+                </div>
               </template>
             </qas-input>
           </q-form>
         </slot>
       </div>
-
-      <slot v-if="showFilterButton" :filter="filter" name="filter-button">
-        <qas-btn v-if="useFilterButton" :color="filterButtonColor" data-cy="filters-btn" flat icon="o_filter_list" :label="filterButtonLabel">
-          <q-menu class="full-width" max-width="240px">
-            <div v-if="isFetching" class="q-pa-xl text-center">
-              <q-spinner color="grey" size="2em" />
-            </div>
-
-            <div v-else-if="hasFetchError" class="q-pa-xl text-center">
-              <q-icon color="negative" name="o_warning" size="2em" />
-            </div>
-
-            <q-form v-else class="q-gutter-y-md q-pa-md" @submit.prevent="filter()">
-              <div v-for="(field, index) in fields" :key="index">
-                <qas-field v-model="filters[field.name]" :data-cy="`filters-${field.name}-field`" dense :field="field" v-bind="fieldsProps[field.name]" />
-              </div>
-
-              <div class="text-right">
-                <qas-btn class="q-mr-sm" data-cy="filters-clear-btn" flat label="Limpar" :no-caps="false" size="12px" unelevated @click="clearFilters" />
-                <qas-btn color="primary" data-cy="filters-submit-btn" label="Filtrar" :no-caps="false" size="12px" type="submit" unelevated />
-              </div>
-            </q-form>
-          </q-menu>
-        </qas-btn>
-      </slot>
     </div>
 
     <div v-if="useChip && hasActiveFilters" class="q-mt-md">
@@ -161,6 +171,7 @@ export default {
       return this.hasActiveFilters ? 'primary' : 'grey-9'
     },
 
+    // TODO: remover
     filterButtonLabel () {
       return this.$q.screen.gt.xs ? 'Filtrar' : undefined
     },
@@ -330,3 +341,18 @@ export default {
   }
 }
 </script>
+
+<style lang="scss">
+.qas-filters {
+  &__input {
+    // TODO adicionar no qas-input
+    border-radius: 4px;
+
+    // TODO rever
+    .q-field__control::before,
+    .q-field__control::after {
+      display: none;
+    }
+  }
+}
+</style>

--- a/ui/src/components/filters/QasFilters.yml
+++ b/ui/src/components/filters/QasFilters.yml
@@ -56,13 +56,6 @@ slots:
         desc: função usada para fazer o filtro
         type: Function
 
-  filter-button:
-    desc: Slot para seção do botão do menu lateral.
-    scope:
-      filter:
-        desc: função usada para fazer o filtro
-        type: Function
-
   default:
     desc: Slot para acessar o final do componente.
     scope:

--- a/ui/src/components/page-header/QasPageHeader.vue
+++ b/ui/src/components/page-header/QasPageHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-toolbar class="justify-between q-mb-lg q-px-none">
+  <q-toolbar class="justify-between q-mb-xl q-px-none">
     <div class="ellipsis">
       <q-toolbar-title v-if="title" class="text-bold text-h5">
         {{ title }}

--- a/ui/src/index.scss
+++ b/ui/src/index.scss
@@ -11,6 +11,7 @@ $accent: var(--q-accent);
 :root {
   --qas-background-color: #f5f5f5;
   --qas-generic-border-radius: 8px;
+  --qas-generic-transition: 300ms;
 }
 
 $background-color: var(--qas-background-color);


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Adicionado
-`ui/src/index.scss`: adicionado nova variável css para transição: `--qas-generic-transition: 300ms`;

### Modificado
- `QasFilters`: mudanças de design.
- `QasFilters`: alterado debounce de `500ms` para `800ms`.
- `QasPageHeader`: alterado espaçamento de `q-mb-lg` para `q-mb-xl` para manter o que era anteriormente.

clickup: https://app.clickup.com/t/3ehb3m0

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [x] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
