### PR TITLE
Added required label for $attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasField`: agora o label de required também é modificado caso passe através dos `$attrs`.
+
 ## [3.5.0-beta.5] - 26-12-2022
 ## BREAKING CHANGE
 - `QasFilters`: removido slot `filter-button`.

--- a/ui/src/components/field/QasField.vue
+++ b/ui/src/components/field/QasField.vue
@@ -149,26 +149,36 @@ export default {
         select: { is: 'qas-select', entity, name, multiple, options, useLazyLoading, ...input }
       }
 
-      return { ...(profiles[type] || profiles.default), ...this.$attrs }
+      return {
+        ...(profiles[type] || profiles.default),
+        ...this.$attrs,
+        label: this.formattedLabel
+      }
     },
 
     errorMessage () {
       return Array.isArray(this.error) ? this.error.join(' ') : this.error
     },
 
+    formattedLabel () {
+      const nonRequiredFieldsLabel = ['boolean', 'checkbox', 'radio']
+
+      const label = this.$attrs.label || this.formattedField.label
+      const { required, type } = this.formattedField
+
+      if (required && label && !nonRequiredFieldsLabel.includes(type)) {
+        return `${label}*`
+      }
+
+      return label
+    },
+
     // This computed will change the key name when the server sends different key.
     formattedField () {
       const field = {}
-      const nonRequiredFieldsLabel = ['boolean', 'checkbox', 'radio']
 
       for (const key in this.field) {
         field[attributesProfile[key] || key] = this.field[key]
-      }
-
-      const { label, required, type } = field
-
-      if (required && label && !nonRequiredFieldsLabel.includes(type)) {
-        field.label = `${label}*`
       }
 
       return field


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

### Corrigido
- `QasField`: agora o label de required também é modificado caso passe através dos `$attrs`.

clickup: https://app.clickup.com/t/864djyrxd

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
