### PR TITLE
Color changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `border.scss`: adicionado nova cor de borda `border-grey`.
+- `index.scss`: adicionado nova var css `--qas-border-grey`.
+
+### Modificado
+- [`QasAlert`, `QasAvatar`, `QasBox`, `QasCard`, `QasTransfer`]: modificado cores referente a `primary-contrast` e `secondary-contrast`.
+- `quasar.variables.scss`: modificado cores.
+
+### Removido
+`QasAvatar`: removido propriedades `color` e `text-color` agora sempre vai ser background primary com cor de texto branca.
+
 ## [3.5.0-beta.6] - 26-12-2022
 ### Modificado
 - `QasFormView`: modificado comportamento da propriedade `disable`, agora só desabilita o botão de salvar (submit), deixando o botão voltar habilitado.

--- a/app-extension/src/templates/css/quasar.variables.scss
+++ b/app-extension/src/templates/css/quasar.variables.scss
@@ -3,21 +3,19 @@
 // NÃO MODIFIQUE ESTE ARQUIVO COM AS CONFIGURAÇÕES DO ASTEROID PRÉ DEFINIDAS!
 @import '~@bildvitta/quasar-ui-asteroid/src/index';
 
-$primary   : #00527A;
-// TODO: No futuro a ideia é não ter uma cor secundária.
-// TODO: Por hora vamos usar a mesma de $primary-contrast.
-$secondary : #B8D3E0A3;
+$primary   : #004198;
+$secondary : #1565C0;
 $tertiary  : #c7ceff;
-$accent    : rgba($primary, 0.1);
-$dark      : #1d1d1d;
+$accent    : rgba(33, 33, 33, 20%);
+$dark      : #424242;
 $positive  : #21ba45;
-$negative  : #c10015;
+$negative  : #D40000;
 $info      : #31ccec;
 $warning   : #f2c037;
 
 // Asteroid
-$primary-contrast: $secondary;
-$secondary-contrast: #3691BF80;
+$primary-contrast: #002E6C;
+$secondary-contrast: #90CAF9;
 
 @include set-brand(primary-contrast, $primary-contrast);
 @include set-brand(secondary-contrast, $secondary-contrast);

--- a/app-extension/src/templates/css/quasar.variables.scss
+++ b/app-extension/src/templates/css/quasar.variables.scss
@@ -9,13 +9,13 @@ $tertiary  : #c7ceff;
 $accent    : rgba(33, 33, 33, 20%);
 $dark      : #424242;
 $positive  : #21ba45;
-$negative  : #D40000;
+$negative  : #d40000;
 $info      : #31ccec;
 $warning   : #f2c037;
 
 // Asteroid
-$primary-contrast: #002E6C;
-$secondary-contrast: #90CAF9;
+$primary-contrast: #002e6c;
+$secondary-contrast: #90caf9;
 
 @include set-brand(primary-contrast, $primary-contrast);
 @include set-brand(secondary-contrast, $secondary-contrast);

--- a/docs/src/components/DocToken.vue
+++ b/docs/src/components/DocToken.vue
@@ -28,7 +28,7 @@ export default {
 @use 'sass:color';
 
 .doc-token {
-  background-color: $primary-contrast;
+  background-color: $grey-4;
   border-radius: $generic-border-radius;
   display: inline-block;
   letter-spacing: -0.03em;

--- a/docs/src/css/quasar.variables.scss
+++ b/docs/src/css/quasar.variables.scss
@@ -15,7 +15,6 @@ $warning   : #f2c037;
 $primary-contrast: #002E6C;
 $secondary-contrast: #90CAF9;
 
-
 // Custom
 $brand-primary: $primary;
 

--- a/docs/src/css/quasar.variables.scss
+++ b/docs/src/css/quasar.variables.scss
@@ -1,21 +1,20 @@
 @use 'sass:color';
 @import '../../../ui/src/index';
 
-$primary   : #00527A;
-// TODO: No futuro a ideia é não ter uma cor secundária.
-// TODO: Por hora vamos usar a mesma de $primary-contrast.
-$secondary : #B8D3E0A3;
+$primary   : #004198;
+$secondary : #1565C0;
 $tertiary  : #c7ceff;
-$accent    : rgba($primary, 0.1);
-$dark      : #1d1d1d;
+$accent    : rgba(33, 33, 33, 20%);
+$dark      : #424242;
 $positive  : #21ba45;
-$negative  : #c10015;
+$negative  : #D40000;
 $info      : #31ccec;
 $warning   : #f2c037;
 
 // Asteroid
-$primary-contrast: $secondary;
-$secondary-contrast: #3691BF80;
+$primary-contrast: #002E6C;
+$secondary-contrast: #90CAF9;
+
 
 // Custom
 $brand-primary: $primary;

--- a/docs/src/css/quasar.variables.scss
+++ b/docs/src/css/quasar.variables.scss
@@ -7,13 +7,13 @@ $tertiary  : #c7ceff;
 $accent    : rgba(33, 33, 33, 20%);
 $dark      : #424242;
 $positive  : #21ba45;
-$negative  : #D40000;
+$negative  : #d40000;
 $info      : #31ccec;
 $warning   : #f2c037;
 
 // Asteroid
-$primary-contrast: #002E6C;
-$secondary-contrast: #90CAF9;
+$primary-contrast: #002e6c;
+$secondary-contrast: #90caf9;
 
 // Custom
 $brand-primary: $primary;

--- a/docs/src/pages/start/usage.md
+++ b/docs/src/pages/start/usage.md
@@ -19,21 +19,19 @@ O arquivo gerado deve conter as seguintes informações:
 
 @import '~@bildvitta/quasar-ui-asteroid/src/index';
 
-$primary   : #00527A;
-// TODO: No futuro a ideia é não ter uma cor secundária.
-// TODO: Por hora vamos usar a mesma de $primary-contrast.
-$secondary : #B8D3E0A3;
+$primary   : #004198;
+$secondary : #1565C0;
 $tertiary  : #c7ceff;
-$accent    : #00365280;
-$dark      : #1d1d1d;
-$positive  : #21ba45;
-$negative  : #c10015;
+$accent    : rgba(33, 33, 33, 20%);
+$dark      : #424242;
+$positive  : #212121;
+$negative  : #D40000;
 $info      : #31ccec;
 $warning   : #f2c037;
 
 // Asteroid
-$primary-contrast: $secondary;
-$secondary-contrast: #3691BF80;
+$primary-contrast: #002E6C;
+$secondary-contrast: #90CAF9;
 
 @include set-brand(primary-contrast, $primary-contrast);
 @include set-brand(secondary-contrast, $secondary-contrast);

--- a/docs/src/pages/styles/border.md
+++ b/docs/src/pages/styles/border.md
@@ -20,3 +20,4 @@ Define uma cor para a borda de acordo com as variáveis `$primary` `$secondary`
 |`border-primary-contrast`  | Cria uma Borda com a cor da variável `$primary-contrast`   |`border: 0 solid $primary-contrast`  |
 |`border-secondary`         | Cria uma Borda com a cor da variável `$secondary`          |`border: 0 solid $secondary`         |
 |`border-secondary-contrast`| Cria uma Borda com a cor da variável `$secondary-contrast` |`border: 0 solid $secondary-contrast`|
+|`border-grey`| Cria uma Borda com a cor da variável `$border-grey` |`border: 0 solid $secondary-contrast`|

--- a/docs/src/pages/styles/set-brand.md
+++ b/docs/src/pages/styles/set-brand.md
@@ -21,8 +21,8 @@ Inclui uma nova Brand
   }
 }
 
-$primary-contrast: #eaeaff;
-$secondary-contrast: #bbd3d0;
+$primary-contrast: #002E6C;
+$secondary-contrast: #90CAF9;
 
 @include set-brand(primary-contrast, $primary-contrast);
 @include set-brand(secondary-contrast, $secondary-contrast);

--- a/ui/dev/src/css/quasar.variables.scss
+++ b/ui/dev/src/css/quasar.variables.scss
@@ -29,8 +29,8 @@ $warning: #f2c037;
   }
 }
 
-$primary-contrast: #eaeaff;
-$secondary-contrast: #bbd3d0;
+$primary-contrast: #002E6C;
+$secondary-contrast: #90CAF9;
 
 @include set-brand(primary-contrast, $primary-contrast);
 @include set-brand(secondary-contrast, $secondary-contrast);

--- a/ui/src/components/alert/QasAlert.vue
+++ b/ui/src/components/alert/QasAlert.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="model" class="q-pa-lg qas-alert relative-position rounded-borders" :class="classes">
+  <div v-if="model" class="bg-white q-pa-lg qas-alert relative-position rounded-borders" :class="classes">
     <qas-btn class="absolute-top-right q-mr-md q-mt-sm" :color="color" dense flat icon="o_close" rounded @click="close" />
 
     <div class="q-gutter-md q-mr-lg">
@@ -58,10 +58,7 @@ export default {
 
   computed: {
     classes () {
-      return {
-        [`text-${this.color}`]: true,
-        [`bg-${this.color}-contrast`]: ['primary', 'secondary'].includes(this.color)
-      }
+      return `text-${this.color}`
     }
   },
 

--- a/ui/src/components/avatar/QasAvatar.vue
+++ b/ui/src/components/avatar/QasAvatar.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-avatar class="text-bold" :class="avatarClass" v-bind="attributes">
+  <q-avatar class="text-bold" :class="avatarClasses" v-bind="attributes">
     <q-img v-if="hasImage" :alt="title" :ratio="1" spinner-color="primary" spinner-size="16px" :src="image" @error="onImageLoadedError" />
     <template v-else-if="hasTitle">{{ firstLetter }}</template>
     <q-icon v-else :name="icon" />
@@ -13,11 +13,6 @@ export default {
   inheritAttrs: false,
 
   props: {
-    color: {
-      default: '',
-      type: String
-    },
-
     dark: {
       type: Boolean
     },
@@ -29,11 +24,6 @@ export default {
 
     image: {
       default: '',
-      type: String
-    },
-
-    textColor: {
-      default: 'primary',
       type: String
     },
 
@@ -50,22 +40,12 @@ export default {
   },
 
   computed: {
-    avatarClass () {
+    avatarClasses () {
       if (this.hasImage) {
         return null
       }
 
-      const contrastColor = this.color ? this.color : this.contrastColor
-
-      return [
-        this.dark
-          ? `bg-${this.textColor} text-${contrastColor}`
-          : `bg-${contrastColor} text-${this.textColor}`
-      ]
-    },
-
-    contrastColor () {
-      return `${this.textColor}-contrast`
+      return 'bg-primary text-white'
     },
 
     firstLetter () {

--- a/ui/src/components/box/QasBox.vue
+++ b/ui/src/components/box/QasBox.vue
@@ -21,7 +21,7 @@ export default {
   computed: {
     boxClass () {
       return {
-        'border-primary-contrast': this.outlined,
+        'border-grey': this.outlined,
         'shadow-2': !this.unelevated
       }
     }

--- a/ui/src/components/card/QasCard.vue
+++ b/ui/src/components/card/QasCard.vue
@@ -23,7 +23,7 @@
         </div>
       </q-card-section>
 
-      <div v-if="hasActionsSlot" class="border-primary-contrast border-top overflow-hidden row">
+      <div v-if="hasActionsSlot" class="border-grey border-top overflow-hidden row">
         <slot name="actions" />
       </div>
     </q-card>

--- a/ui/src/components/transfer/QasTransfer.vue
+++ b/ui/src/components/transfer/QasTransfer.vue
@@ -177,7 +177,7 @@ export default {
       return this[isFirst
         ? 'firstQueue'
         : 'secondQueue'
-      ].some(item => item[this.valueKey] === object[this.valueKey]) && 'bg-secondary'
+      ].some(item => item[this.valueKey] === object[this.valueKey]) && 'bg-grey-4'
     },
 
     getItemLabel (item) {

--- a/ui/src/css/utils/border.scss
+++ b/ui/src/css/utils/border.scss
@@ -17,6 +17,7 @@
 @include set-border-color(primary-contrast, $primary-contrast);
 @include set-border-color(secondary, $secondary);
 @include set-border-color(secondary-contrast, $secondary-contrast);
+@include set-border-color('grey', $border-grey);
 
 // Direction
 .border-top {

--- a/ui/src/index.scss
+++ b/ui/src/index.scss
@@ -10,12 +10,14 @@ $accent: var(--q-accent);
 // Asteroid variables
 :root {
   --qas-background-color: #fbfbfb;
+  --qas-border-grey: #{$grey-4};
   --qas-generic-border-radius: 8px;
   --qas-generic-transition: 300ms;
 }
 
 $background-color: var(--qas-background-color);
 $generic-border-radius: var(--qas-generic-border-radius);
+$border-grey: var(--qas-border-grey);
 
 // variables
 @import './css/variables/index';


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Adicionado
- `border.scss`: adicionado nova cor de borda `border-grey`.
- `index.scss`: adicionado nova var css `--qas-border-grey`.

### Modificado
- [`QasAlert`, `QasAvatar`, `QasBox`, `QasCard`, `QasTransfer`]: modificado cores referente a `primary-contrast` e `secondary-contrast`.
- `quasar.variables.scss`: modificado cores.

### Removido
`QasAvatar`: removido propriedades `color` e `text-color` agora sempre vai ser background primary com cor de texto branca.

clickup: https://app.clickup.com/t/864dkdhkq

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [x] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
