### PR TITLE
Changes in QasPageHeader / QasActionsMenu / typography.scss / QasHeaderActions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,16 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
+## BREAKING CHANGES:
+- `QasPageHeader`: adicionada nova propriedade `useHomeIcon` que habilita o ícone de início como primeiro nível do breadcrumbs, com default `true` para respeitar novo padrão de design, caso já tenha um nível de "início" declaro no breadcrumbs, remova.
+
+### Adicionado
+- `QasHeaderActions`: adicionado novo componente para trabalhar com descrição e ações.
+
 ### Modificado
-- `QasPageHeader`: mudanças de layout e comportamento, agora caso o breadcrumbs tenha mais de 4 níveis.
+- `QasPageHeader`: mudanças de layout e comportamento, agora caso o breadcrumbs tenha mais de 4 níveis é adicionado uma label "...".
+- `typography.scss`: alterado `font-weight` do `$caption` para `400`.
+- `QasPageHeader`: adicionada nova propriedade `useHomeIcon` que habilita o ícone de início como primeiro nível do breadcrumbs, com default `true` para respeitar novo padrão de design.
 
 ## [3.5.0-beta.11] - 02-01-2023
 ### Modificado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasPageHeader`: mudanças de layout e comportamento, agora caso o breadcrumbs tenha mais de 4 níveis é adicionado uma label "...".
 - `typography.scss`: alterado `font-weight` do `$caption` para `400`.
 - `QasPageHeader`: adicionada nova propriedade `useHomeIcon` que habilita o ícone de início como primeiro nível do breadcrumbs, com default `true` para respeitar novo padrão de design.
+- `QasActionsMenu`: alterado valor default da propriedade `useLabelOnSmallScreen` para `false`.
 
 ## [3.5.0-beta.11] - 02-01-2023
 ### Modificado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ## Não publicado
 ## BREAKING CHANGES:
-- `QasPageHeader`: adicionada nova propriedade `useHomeIcon` que habilita o ícone de início como primeiro nível do breadcrumbs, com default `true` para respeitar novo padrão de design, caso já tenha um nível de "início" declaro no breadcrumbs, remova.
+- `QasPageHeader`: adicionada nova propriedade `useHomeIcon` que habilita o ícone de início como primeiro nível do breadcrumbs, com default `true` para respeitar novo padrão de design, caso já tenha um nível de "início" declarado no breadcrumbs, remova.
 
 ### Adicionado
 - `QasHeaderActions`: adicionado novo componente para trabalhar com descrição e ações.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `QasPageHeader`: mudanças de layout e comportamento, agora caso o breadcrumbs tenha mais de 4 níveis. 
+
 ## [3.5.0-beta.10] - 30-12-2022
 ### Corrigido
 - `QasActionsMenu`: corrigido problema de circular dependency entre as propriedades computadas `actions` e `hasMoreThanOneAction`.

--- a/docs/src/assets/menu.js
+++ b/docs/src/assets/menu.js
@@ -130,6 +130,10 @@ module.exports = [
         path: '/components/grid-generator'
       },
       {
+        name: 'HeaderActions',
+        path: '/components/header-actions'
+      },
+      {
         name: 'Input',
         path: '/components/input'
       },

--- a/docs/src/examples/QasHeaderActions/HeaderActionsWithActionsMenu.vue
+++ b/docs/src/examples/QasHeaderActions/HeaderActionsWithActionsMenu.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="container spaced">
+    <qas-header-actions v-bind="headerActionsProps" />
+    Lorem ipsum dolor sit amet consectetur adipisicing elit. Accusamus sint labore ipsum autem laboriosam. Ipsum officia magni dolorum libero vero blanditiis? Laudantium aspernatur tenetur accusamus excepturi vel placeat, nemo iure?
+  </div>
+</template>
+
+<script>
+export default {
+  computed: {
+    headerActionsProps () {
+      return {
+        description: 'Algum texto de exemplo para ficar ao lado do botão de adicionar.',
+        actionsMenuProps: {
+          deleteProps: {
+            entity: 'users'
+          },
+          list: {
+            add: {
+              label: 'Novo usuário',
+              icon: 'o_add'
+            }
+          }
+        }
+      }
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QasHeaderActions/HeaderActionsWithActionsMenu.vue
+++ b/docs/src/examples/QasHeaderActions/HeaderActionsWithActionsMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container spaced">
-    <qas-header-actions v-bind="headerActionsProps" />
+    <qas-header-actions class="q-mb-md" v-bind="headerActionsProps" />
     Lorem ipsum dolor sit amet consectetur adipisicing elit. Accusamus sint labore ipsum autem laboriosam. Ipsum officia magni dolorum libero vero blanditiis? Laudantium aspernatur tenetur accusamus excepturi vel placeat, nemo iure?
   </div>
 </template>

--- a/docs/src/examples/QasHeaderActions/HeaderActionsWithActionsMenu.vue
+++ b/docs/src/examples/QasHeaderActions/HeaderActionsWithActionsMenu.vue
@@ -10,7 +10,7 @@ export default {
   computed: {
     headerActionsProps () {
       return {
-        description: 'Algum texto de exemplo para ficar ao lado do botão de adicionar.',
+        text: 'Algum texto de exemplo para ficar ao lado do botão de adicionar.',
         actionsMenuProps: {
           deleteProps: {
             entity: 'users'

--- a/docs/src/examples/QasHeaderActions/HeaderActionsWithActionsMenu.vue
+++ b/docs/src/examples/QasHeaderActions/HeaderActionsWithActionsMenu.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="container spaced">
     <qas-header-actions class="q-mb-md" v-bind="headerActionsProps" />
-    Lorem ipsum dolor sit amet consectetur adipisicing elit. Accusamus sint labore ipsum autem laboriosam. Ipsum officia magni dolorum libero vero blanditiis? Laudantium aspernatur tenetur accusamus excepturi vel placeat, nemo iure?
   </div>
 </template>
 

--- a/docs/src/examples/QasHeaderActions/HeaderActionsWithButton.vue
+++ b/docs/src/examples/QasHeaderActions/HeaderActionsWithButton.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container spaced">
-    <qas-header-actions v-bind="headerActionsProps" />
+    <qas-header-actions class="q-mb-sm" v-bind="headerActionsProps" />
   </div>
 </template>
 
@@ -9,7 +9,7 @@ export default {
   computed: {
     headerActionsProps () {
       return {
-        description: 'Algum texto de exemplo para ficar ao lado do botão de adicionar.',
+        text: 'Algum texto de exemplo para ficar ao lado do botão de adicionar.',
         buttonProps: {
           icon: 'o_add',
           label: 'Novo usuário'

--- a/docs/src/examples/QasHeaderActions/HeaderActionsWithButton.vue
+++ b/docs/src/examples/QasHeaderActions/HeaderActionsWithButton.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="container spaced">
+    <qas-header-actions v-bind="headerActionsProps" />
+  </div>
+</template>
+
+<script>
+export default {
+  computed: {
+    headerActionsProps () {
+      return {
+        description: 'Algum texto de exemplo para ficar ao lado do botão de adicionar.',
+        buttonProps: {
+          icon: 'o_add',
+          label: 'Novo usuário'
+        }
+      }
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QasHeaderActions/HeaderActionsWithSlots.vue
+++ b/docs/src/examples/QasHeaderActions/HeaderActionsWithSlots.vue
@@ -17,7 +17,7 @@ export default {
   computed: {
     headerActionsProps () {
       return {
-        description: 'Algum texto de exemplo para ficar ao lado do botão de adicionar.',
+        text: 'Algum texto de exemplo para ficar ao lado do botão de adicionar.',
         buttonProps: {
           icon: 'o_add',
           label: 'Novo usuário'

--- a/docs/src/examples/QasHeaderActions/HeaderActionsWithSlots.vue
+++ b/docs/src/examples/QasHeaderActions/HeaderActionsWithSlots.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="container spaced">
+    <qas-header-actions>
+      <template #left>
+        Slot da esquerda!
+      </template>
+
+      <template #right>
+        Slot da direita!
+      </template>
+    </qas-header-actions>
+  </div>
+</template>
+
+<script>
+export default {
+  computed: {
+    headerActionsProps () {
+      return {
+        description: 'Algum texto de exemplo para ficar ao lado do botão de adicionar.',
+        buttonProps: {
+          icon: 'o_add',
+          label: 'Novo usuário'
+        }
+      }
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QasPageHeader/Basic.vue
+++ b/docs/src/examples/QasPageHeader/Basic.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container spaced">
     <qas-page-header :breadcrumbs="breadcrumbs" title="Meu título!">
-      <qas-btn hide-mobile-label icon="o_add" label="Alguma ação!" />
+      <!-- <qas-btn icon="o_add" label="Alguma ação!" :use-label-on-small-screen="false" /> -->
     </qas-page-header>
   </div>
 </template>
@@ -31,11 +31,11 @@ export default {
         },
         {
           label: 'Algum caminho',
-          route: { path: '/' }
+          route: { path: '/styles/background' }
         },
         {
           label: 'Page header',
-          route: { path: 'components/page-header' }
+          route: { path: '/components/page-header' }
         }
       ]
     }

--- a/docs/src/examples/QasPageHeader/Basic.vue
+++ b/docs/src/examples/QasPageHeader/Basic.vue
@@ -22,7 +22,20 @@ export default {
           route: { path: '/' }
         },
         {
-          label: 'Users'
+          label: 'Algum caminho',
+          route: { path: '/' }
+        },
+        {
+          label: 'Algum caminho',
+          route: { path: '/' }
+        },
+        {
+          label: 'Algum caminho',
+          route: { path: '/' }
+        },
+        {
+          label: 'Page header',
+          route: { path: 'components/page-header' }
         }
       ]
     }

--- a/docs/src/examples/QasPageHeader/Basic.vue
+++ b/docs/src/examples/QasPageHeader/Basic.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="container spaced">
-    <qas-page-header :breadcrumbs="breadcrumbs" :button-props="addButton" title="Nome do usuário" />
+    <qas-page-header :breadcrumbs="breadcrumbs" :button-props="addButton" title="Nome do usuário">
+      <template #bottom>
+        informações em baixo
+      </template>
+    </qas-page-header>
   </div>
 </template>
 

--- a/docs/src/examples/QasPageHeader/Basic.vue
+++ b/docs/src/examples/QasPageHeader/Basic.vue
@@ -1,8 +1,6 @@
 <template>
   <div class="container spaced">
-    <qas-page-header :breadcrumbs="breadcrumbs" title="Meu título!">
-      <!-- <qas-btn icon="o_add" label="Alguma ação!" :use-label-on-small-screen="false" /> -->
-    </qas-page-header>
+    <qas-page-header :breadcrumbs="breadcrumbs" :button-props="addButton" title="Nome do usuário" />
   </div>
 </template>
 
@@ -14,30 +12,25 @@ export default {
     breadcrumbs () {
       return [
         {
-          label: 'Início',
+          label: 'Lista de usuários',
           route: { path: '/' }
         },
         {
-          label: 'Algum caminho',
+          label: 'Usuário',
           route: { path: '/' }
         },
         {
-          label: 'Algum caminho',
-          route: { path: '/' }
-        },
-        {
-          label: 'Algum caminho',
-          route: { path: '/' }
-        },
-        {
-          label: 'Algum caminho',
-          route: { path: '/styles/background' }
-        },
-        {
-          label: 'Page header',
+          label: 'Nome do usuário',
           route: { path: '/components/page-header' }
         }
       ]
+    },
+
+    addButton () {
+      return {
+        icon: 'o_add',
+        label: 'Novo usuário'
+      }
     }
   }
 }

--- a/docs/src/examples/QasPageHeader/HeaderActionsWithActionsMenu.vue
+++ b/docs/src/examples/QasPageHeader/HeaderActionsWithActionsMenu.vue
@@ -28,7 +28,7 @@ export default {
 
     headerActionsProps () {
       return {
-        description: 'Algum texto de exemplo para ficar ao lado do botão de adicionar.',
+        text: 'Algum texto de exemplo para ficar ao lado do botão de adicionar.',
         actionsMenuProps: {
           deleteProps: {
             entity: 'users'

--- a/docs/src/examples/QasPageHeader/HeaderActionsWithActionsMenu.vue
+++ b/docs/src/examples/QasPageHeader/HeaderActionsWithActionsMenu.vue
@@ -1,0 +1,47 @@
+<template>
+  <div class="container spaced">
+    <qas-page-header :breadcrumbs="breadcrumbs" :header-actions-props="headerActionsProps" title="Nome do usuário" />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'UsersList',
+
+  computed: {
+    breadcrumbs () {
+      return [
+        {
+          label: 'Lista de usuários',
+          route: { path: '/' }
+        },
+        {
+          label: 'Usuário',
+          route: { path: '/' }
+        },
+        {
+          label: 'Nome do usuário',
+          route: { path: '/components/page-header' }
+        }
+      ]
+    },
+
+    headerActionsProps () {
+      return {
+        description: 'Algum texto de exemplo para ficar ao lado do botão de adicionar.',
+        actionsMenuProps: {
+          deleteProps: {
+            entity: 'users'
+          },
+          list: {
+            add: {
+              label: 'Novo usuário',
+              icon: 'o_add'
+            }
+          }
+        }
+      }
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QasPageHeader/HeaderActionsWithButton.vue
+++ b/docs/src/examples/QasPageHeader/HeaderActionsWithButton.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container spaced">
-    <qas-page-header :breadcrumbs="breadcrumbs" title="Nome do usuário" />
+    <qas-page-header :breadcrumbs="breadcrumbs" :header-actions-props="headerActionsProps" title="Nome do usuário" />
   </div>
 </template>
 
@@ -24,6 +24,16 @@ export default {
           route: { path: '/components/page-header' }
         }
       ]
+    },
+
+    headerActionsProps () {
+      return {
+        description: 'Algum texto de exemplo para ficar ao lado do botão de adicionar.',
+        buttonProps: {
+          icon: 'o_add',
+          label: 'Novo usuário'
+        }
+      }
     }
   }
 }

--- a/docs/src/examples/QasPageHeader/WithBottomSlot.vue
+++ b/docs/src/examples/QasPageHeader/WithBottomSlot.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="container spaced">
+    <qas-page-header :breadcrumbs="breadcrumbs" title="Nome do usuário">
+      <template #bottom>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Unde vel voluptatum quasi ab, temporibus recusandae aut natus magni mollitia ad cupiditate sapiente modi commodi, qui eveniet, incidunt deserunt delectus tempora.
+      </template>
+    </qas-page-header>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'UsersList',
+
+  computed: {
+    breadcrumbs () {
+      return [
+        {
+          label: 'Lista de usuários',
+          route: { path: '/' }
+        },
+        {
+          label: 'Usuário',
+          route: { path: '/' }
+        },
+        {
+          label: 'Nome do usuário',
+          route: { path: '/components/page-header' }
+        }
+      ]
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QasPageHeader/WithMoreLevels.vue
+++ b/docs/src/examples/QasPageHeader/WithMoreLevels.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container spaced">
-    <qas-page-header :breadcrumbs="breadcrumbs" :header-actions-props="headerActionsProps" title="Nome do usuário" />
+    <qas-page-header :breadcrumbs="breadcrumbs" title="Nome do usuário" />
   </div>
 </template>
 
@@ -20,20 +20,18 @@ export default {
           route: { path: '/' }
         },
         {
+          label: 'Usuário 2',
+          route: { path: '/' }
+        },
+        {
+          label: 'Usuário 3',
+          route: { path: '/' }
+        },
+        {
           label: 'Nome do usuário',
           route: { path: '/components/page-header' }
         }
       ]
-    },
-
-    headerActionsProps () {
-      return {
-        text: 'Algum texto de exemplo para ficar ao lado do botão de adicionar.',
-        buttonProps: {
-          icon: 'o_add',
-          label: 'Novo usuário'
-        }
-      }
     }
   }
 }

--- a/docs/src/pages/components/header-actions.md
+++ b/docs/src/pages/components/header-actions.md
@@ -1,0 +1,13 @@
+---
+title: QasHeaderActions
+---
+
+Componente para cabeçalho usado com alguma descrição e ação.
+
+<doc-api file="header-actions/QasHeaderActions" name="QasHeaderActions" />
+
+## Uso
+
+<doc-example file="QasHeaderActions/HeaderActionsWithButton" title="Com QasBtn" />
+<doc-example file="QasHeaderActions/HeaderActionsWithActionsMenu" title="Com QasActionsMenu" />
+<doc-example file="QasHeaderActions/HeaderActionsWithSlots" title="Com slot" />

--- a/docs/src/pages/components/page-header.md
+++ b/docs/src/pages/components/page-header.md
@@ -13,3 +13,5 @@ Componente implementa [QToolbar](https://quasar.dev/vue-components/toolbar#intro
 ## Uso
 
 <doc-example file="QasPageHeader/Basic" title="Básico" />
+<doc-example file="QasPageHeader/HeaderActionsWithButton" title="Com QasHeaderActions e QasBtn" />
+<doc-example file="QasPageHeader/HeaderActionsWithActionsMenu" title="Com QasHeaderActions e QasActionsMenu" />

--- a/docs/src/pages/components/page-header.md
+++ b/docs/src/pages/components/page-header.md
@@ -13,6 +13,7 @@ Componente implementa [QToolbar](https://quasar.dev/vue-components/toolbar#intro
 ## Uso
 
 <doc-example file="QasPageHeader/Basic" title="Básico" />
+<doc-example file="QasPageHeader/WithMoreLevels" title="Breadcrumbs com muitos níveis" />
 <doc-example file="QasPageHeader/HeaderActionsWithButton" title="Com QasHeaderActions e QasBtn" />
 <doc-example file="QasPageHeader/HeaderActionsWithActionsMenu" title="Com QasHeaderActions e QasActionsMenu" />
 <doc-example file="QasPageHeader/WithBottomSlot" title="Com slot Bottom" />

--- a/docs/src/pages/components/page-header.md
+++ b/docs/src/pages/components/page-header.md
@@ -15,3 +15,4 @@ Componente implementa [QToolbar](https://quasar.dev/vue-components/toolbar#intro
 <doc-example file="QasPageHeader/Basic" title="Básico" />
 <doc-example file="QasPageHeader/HeaderActionsWithButton" title="Com QasHeaderActions e QasBtn" />
 <doc-example file="QasPageHeader/HeaderActionsWithActionsMenu" title="Com QasHeaderActions e QasActionsMenu" />
+<doc-example file="QasPageHeader/WithBottomSlot" title="Com slot Bottom" />

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -64,7 +64,7 @@ export default {
     },
 
     useLabelOnSmallScreen: {
-      default: true,
+      default: false,
       type: Boolean
     }
   },

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -64,7 +64,6 @@ export default {
     },
 
     useLabelOnSmallScreen: {
-      default: false,
       type: Boolean
     }
   },

--- a/ui/src/components/header-actions/QasHeaderActions.vue
+++ b/ui/src/components/header-actions/QasHeaderActions.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="items-center justify-between no-wrap q-gutter-x-md q-mb-xl row">
+    <div class="text-body1 text-grey-8">
+      <slot name="left">
+        {{ description }}
+      </slot>
+    </div>
+
+    <div>
+      <slot name="right">
+        <qas-actions-menu v-if="hasDefaultActionsMenu" v-bind="actionsMenuProps" />
+
+        <qas-btn v-if="hasDefaultButton" :use-label-on-small-screen="false" v-bind="buttonProps" />
+      </slot>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'QasHeaderActions',
+
+  props: {
+    actionsMenuProps: {
+      type: Object,
+      default: () => ({})
+    },
+
+    buttonProps: {
+      default: () => ({}),
+      type: Object
+    },
+
+    description: {
+      type: String,
+      default: ''
+    }
+  },
+
+  computed: {
+    hasDefaultButton () {
+      return !!Object.keys(this.buttonProps).length
+    },
+
+    hasDefaultActionsMenu () {
+      return !!Object.keys(this.actionsMenuProps).length
+    }
+  }
+}
+</script>

--- a/ui/src/components/header-actions/QasHeaderActions.vue
+++ b/ui/src/components/header-actions/QasHeaderActions.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="items-center justify-between no-wrap q-gutter-x-md q-mb-xl row">
-    <div class="text-body1 text-grey-8">
+  <div class="items-center justify-between no-wrap q-col-gutter-x-md q-mb-xl row text-body1 text-grey-8">
+    <div class="" :class="leftClass">
       <slot name="left">
-        {{ description }}
+        {{ text }}
       </slot>
     </div>
 
-    <div>
+    <div v-if="hasRightSide" class="col-3 col-md-3 col-sm-4 justify-end row">
       <slot name="right">
         <qas-actions-menu v-if="hasDefaultActionsMenu" v-bind="actionsMenuProps" />
 
@@ -31,7 +31,7 @@ export default {
       type: Object
     },
 
-    description: {
+    text: {
       type: String,
       default: ''
     }
@@ -44,6 +44,18 @@ export default {
 
     hasDefaultActionsMenu () {
       return !!Object.keys(this.actionsMenuProps).length
+    },
+
+    hasRightSlot () {
+      return !!this.$slots.right
+    },
+
+    hasRightSide () {
+      return this.hasRightSlot || this.hasDefaultActionsMenu || this.hasDefaultButton
+    },
+
+    leftClass () {
+      return this.hasRightSide ? 'col-9 col-md-9 col-sm-8' : 'col-12'
     }
   }
 }

--- a/ui/src/components/header-actions/QasHeaderActions.vue
+++ b/ui/src/components/header-actions/QasHeaderActions.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="items-center justify-between no-wrap q-col-gutter-x-md q-mb-xl row text-body1 text-grey-8">
-    <div class="" :class="leftClass">
+    <div :class="leftClass">
       <slot name="left">
         {{ text }}
       </slot>

--- a/ui/src/components/header-actions/QasHeaderActions.yml
+++ b/ui/src/components/header-actions/QasHeaderActions.yml
@@ -1,0 +1,26 @@
+type: component
+
+meta:
+  desc: Componente para cabeçalho usado com alguma descrição e ação.
+
+props:
+  actions-menu-props:
+    desc: Propriedades do QasActionsMenu.
+    default: {}
+    type: Object
+
+  button-props:
+    desc: Propriedades do QasBtn.
+    default: {}
+    type: Object
+
+  description:
+    desc: Descrição da seção a esquerda.
+    type: String
+
+slots:
+  left:
+    desc: slot para acessar seção da esquerda (descrição).
+
+  right:
+    desc: slot para acessar seção da direita (ação).

--- a/ui/src/components/header-actions/QasHeaderActions.yml
+++ b/ui/src/components/header-actions/QasHeaderActions.yml
@@ -14,7 +14,7 @@ props:
     default: {}
     type: Object
 
-  description:
+  text:
     desc: Descrição da seção a esquerda.
     type: String
 

--- a/ui/src/components/page-header/QasPageHeader.vue
+++ b/ui/src/components/page-header/QasPageHeader.vue
@@ -1,23 +1,29 @@
 <template>
-  <q-toolbar class="justify-between q-mb-xl q-px-none qas-page-header">
-    <div class="ellipsis">
-      <q-toolbar-title v-if="title" class="text-grey-9 text-h3">
-        {{ title }}
-      </q-toolbar-title>
+  <div>
+    <q-toolbar class="justify-between q-mb-xl q-px-none qas-page-header">
+      <div class="ellipsis">
+        <q-toolbar-title v-if="title" class="text-grey-9 text-h3">
+          {{ title }}
+        </q-toolbar-title>
 
-      <q-breadcrumbs v-if="useBreadcrumbs" class="text-caption" gutter="xs" separator-color="grey-8">
-        <q-breadcrumbs-el v-if="useHomeIcon" class="qas-page-header__breadcrumbs-el text-grey-8" icon="o_home" :to="homeRoute" />
+        <q-breadcrumbs v-if="useBreadcrumbs" class="text-caption" gutter="xs" separator-color="grey-8">
+          <q-breadcrumbs-el v-if="useHomeIcon" class="qas-page-header__breadcrumbs-el text-grey-8" icon="o_home" :to="homeRoute" />
 
-        <q-breadcrumbs-el v-for="(item, index) in normalizedBreadcrumbs" :key="index" class="qas-page-header__breadcrumbs-el" :label="item.label" :to="item.route" />
-      </q-breadcrumbs>
+          <q-breadcrumbs-el v-for="(item, index) in normalizedBreadcrumbs" :key="index" class="qas-page-header__breadcrumbs-el" :label="item.label" :to="item.route" />
+        </q-breadcrumbs>
+      </div>
+
+      <slot>
+        <qas-actions-menu v-if="hasDefaultActionsMenu" v-bind="actionsMenuProps" />
+
+        <qas-btn v-if="hasDefaultButton" :use-label-on-small-screen="false" v-bind="buttonProps" />
+      </slot>
+    </q-toolbar>
+
+    <div>
+      <slot name="bottom" />
     </div>
-
-    <slot>
-      <qas-actions-menu v-if="hasDefaultActionsMenu" v-bind="actionsMenuProps" />
-
-      <qas-btn v-if="hasDefaultButton" :use-label-on-small-screen="false" v-bind="buttonProps" />
-    </slot>
-  </q-toolbar>
+  </div>
 </template>
 
 <script>

--- a/ui/src/components/page-header/QasPageHeader.vue
+++ b/ui/src/components/page-header/QasPageHeader.vue
@@ -1,25 +1,20 @@
 <template>
   <q-toolbar class="justify-between q-mb-xl q-px-none qas-page-header">
     <div class="ellipsis">
-      <q-toolbar-title v-if="title" class="text-bold text-h3">
+      <q-toolbar-title v-if="title" class="text-grey-9 text-h3">
         {{ title }}
       </q-toolbar-title>
 
       <q-breadcrumbs v-if="useBreadcrumbs" class="text-caption" gutter="xs" separator-color="grey-8">
-        <q-breadcrumbs-el v-if="useHomeIcon" class="qas-page-header__breadcrumbs-el" :class="getBreadcrumbsClass(0)" icon="home" to="/" />
+        <q-breadcrumbs-el v-if="useHomeIcon" class="qas-page-header__breadcrumbs-el text-grey-8" icon="home" to="/" />
 
         <q-breadcrumbs-el v-for="(item, index) in normalizedBreadcrumbs" :key="item.label" class="qas-page-header__breadcrumbs-el" :class="getBreadcrumbsClass(index)" :label="item.label" :to="item.route" />
       </q-breadcrumbs>
-
-      <!-- <pre>
-        {{ transformedBreadcrumbs }}
-      </pre>
-
-      <pre>
-        {{ normalizedBreadcrumbs }}
-      </pre> -->
     </div>
-    <slot />
+
+    <slot>
+      <qas-btn v-if="hasDefaultButton" :use-label-on-small-screen="false" v-bind="buttonProps" />
+    </slot>
   </q-toolbar>
 </template>
 
@@ -65,6 +60,11 @@ export default {
     useHomeIcon: {
       default: true,
       type: Boolean
+    },
+
+    buttonProps: {
+      default: () => ({}),
+      type: Object
     }
   },
 
@@ -94,15 +94,28 @@ export default {
     },
 
     normalizedBreadcrumbs () {
+      const breadcrumbsSize = this.transformedBreadcrumbs.length
+
+      if (breadcrumbsSize < 5) return this.transformedBreadcrumbs
+
       const [first, second] = this.transformedBreadcrumbs
       const last = this.transformedBreadcrumbs[this.transformedBreadcrumbs.length - 1]
+
+      const beforeLast = {
+        ...this.transformedBreadcrumbs[this.transformedBreadcrumbs.length - 2],
+        label: '...'
+      }
 
       return [
         first,
         second,
-        { label: '...' },
+        beforeLast,
         last
       ]
+    },
+
+    hasDefaultButton () {
+      return !!Object.keys(this.buttonProps).length
     }
   },
 
@@ -119,6 +132,12 @@ export default {
 <style lang="scss">
 .qas-page-header {
   &__breadcrumbs-el {
+    transition: color var(--qas-generic-transition);
+
+    &.q-breadcrumbs__el:not(.q-router-link--exact-active):hover {
+      color: var(--qas-primary-contrast) !important;
+    }
+
     .q-breadcrumbs__el-icon {
       font-size: 16px;
     }

--- a/ui/src/components/page-header/QasPageHeader.vue
+++ b/ui/src/components/page-header/QasPageHeader.vue
@@ -6,13 +6,15 @@
       </q-toolbar-title>
 
       <q-breadcrumbs v-if="useBreadcrumbs" class="text-caption" gutter="xs" separator-color="grey-8">
-        <q-breadcrumbs-el v-if="useHomeIcon" class="qas-page-header__breadcrumbs-el text-grey-8" icon="home" to="/" />
+        <q-breadcrumbs-el v-if="useHomeIcon" class="qas-page-header__breadcrumbs-el text-grey-8" icon="o_home" :to="homeRoute" />
 
-        <q-breadcrumbs-el v-for="(item, index) in normalizedBreadcrumbs" :key="item.label" class="qas-page-header__breadcrumbs-el" :class="getBreadcrumbsClass(index)" :label="item.label" :to="item.route" />
+        <q-breadcrumbs-el v-for="(item, index) in normalizedBreadcrumbs" :key="index" class="qas-page-header__breadcrumbs-el" :label="item.label" :to="item.route" />
       </q-breadcrumbs>
     </div>
 
     <slot>
+      <qas-actions-menu v-if="hasDefaultActionsMenu" v-bind="actionsMenuProps" />
+
       <qas-btn v-if="hasDefaultButton" :use-label-on-small-screen="false" v-bind="buttonProps" />
     </slot>
   </q-toolbar>
@@ -37,6 +39,11 @@ export default {
   ],
 
   props: {
+    actionsMenuProps: {
+      type: Object,
+      default: () => ({})
+    },
+
     breadcrumbs: {
       default: '',
       type: [Array, String]
@@ -116,14 +123,16 @@ export default {
 
     hasDefaultButton () {
       return !!Object.keys(this.buttonProps).length
-    }
-  },
+    },
 
-  methods: {
-    getBreadcrumbsClass (index) {
-      const lastIndex = this.normalizedBreadcrumbs.length - 1
+    hasDefaultActionsMenu () {
+      return !!Object.keys(this.actionsMenuProps).length
+    },
 
-      return lastIndex === index ? 'text-primary' : 'text-grey-8'
+    homeRoute () {
+      const hasRoot = this.$router.hasRoute('Root')
+
+      return hasRoot ? { name: 'Root' } : '/'
     }
   }
 }
@@ -141,6 +150,15 @@ export default {
     .q-breadcrumbs__el-icon {
       font-size: 16px;
     }
+  }
+
+  // aplica cor "grey-8" a todos os .q-breadcrumbs__el que não uma classe .q-breadcrumbs--last como pai
+  .q-breadcrumbs__el:not(.q-breadcrumbs--last .q-breadcrumbs__el) {
+    color: $grey-8;
+  }
+
+  .q-breadcrumbs--last {
+    color: var(--q-primary);
   }
 }
 </style>

--- a/ui/src/components/page-header/QasPageHeader.vue
+++ b/ui/src/components/page-header/QasPageHeader.vue
@@ -111,10 +111,10 @@ export default {
       if (breadcrumbsSize < 5) return this.transformedBreadcrumbs
 
       const [first, second] = this.transformedBreadcrumbs
-      const last = this.transformedBreadcrumbs[this.transformedBreadcrumbs.length - 1]
+      const last = this.transformedBreadcrumbs.at(-1)
 
       const beforeLast = {
-        ...this.transformedBreadcrumbs[this.transformedBreadcrumbs.length - 2],
+        ...this.transformedBreadcrumbs.at(-2),
         label: '...'
       }
 

--- a/ui/src/components/page-header/QasPageHeader.vue
+++ b/ui/src/components/page-header/QasPageHeader.vue
@@ -1,13 +1,23 @@
 <template>
-  <q-toolbar class="justify-between q-mb-xl q-px-none">
+  <q-toolbar class="justify-between q-mb-xl q-px-none qas-page-header">
     <div class="ellipsis">
-      <q-toolbar-title v-if="title" class="text-bold text-h5">
+      <q-toolbar-title v-if="title" class="text-bold text-h3">
         {{ title }}
       </q-toolbar-title>
 
-      <q-breadcrumbs v-if="useBreadcrumbs" class="text-caption" separator-color="grey-7">
-        <q-breadcrumbs-el v-for="(item, index) in transformedBreadcrumbs" :key="item.label" :class="getBreadcrumbsClass(index)" :label="item.label" :to="item.route" />
+      <q-breadcrumbs v-if="useBreadcrumbs" class="text-caption" gutter="xs" separator-color="grey-8">
+        <q-breadcrumbs-el v-if="useHomeIcon" class="qas-page-header__breadcrumbs-el" :class="getBreadcrumbsClass(0)" icon="home" to="/" />
+
+        <q-breadcrumbs-el v-for="(item, index) in normalizedBreadcrumbs" :key="item.label" class="qas-page-header__breadcrumbs-el" :class="getBreadcrumbsClass(index)" :label="item.label" :to="item.route" />
       </q-breadcrumbs>
+
+      <!-- <pre>
+        {{ transformedBreadcrumbs }}
+      </pre>
+
+      <pre>
+        {{ normalizedBreadcrumbs }}
+      </pre> -->
     </div>
     <slot />
   </q-toolbar>
@@ -50,6 +60,11 @@ export default {
     useBreadcrumbs: {
       default: true,
       type: Boolean
+    },
+
+    useHomeIcon: {
+      default: true,
+      type: Boolean
     }
   },
 
@@ -76,15 +91,37 @@ export default {
 
         return item
       })
+    },
+
+    normalizedBreadcrumbs () {
+      const [first, second] = this.transformedBreadcrumbs
+      const last = this.transformedBreadcrumbs[this.transformedBreadcrumbs.length - 1]
+
+      return [
+        first,
+        second,
+        { label: '...' },
+        last
+      ]
     }
   },
 
   methods: {
     getBreadcrumbsClass (index) {
-      const lastIndex = this.transformedBreadcrumbs.length - 1
+      const lastIndex = this.normalizedBreadcrumbs.length - 1
 
-      return lastIndex === index ? 'text-grey-7' : 'text-primary'
+      return lastIndex === index ? 'text-primary' : 'text-grey-8'
     }
   }
 }
 </script>
+
+<style lang="scss">
+.qas-page-header {
+  &__breadcrumbs-el {
+    .q-breadcrumbs__el-icon {
+      font-size: 16px;
+    }
+  }
+}
+</style>

--- a/ui/src/components/page-header/QasPageHeader.vue
+++ b/ui/src/components/page-header/QasPageHeader.vue
@@ -13,20 +13,20 @@
         </q-breadcrumbs>
       </div>
 
-      <slot>
-        <qas-actions-menu v-if="hasDefaultActionsMenu" v-bind="actionsMenuProps" />
-
-        <qas-btn v-if="hasDefaultButton" :use-label-on-small-screen="false" v-bind="buttonProps" />
-      </slot>
+      <slot />
     </q-toolbar>
 
     <div>
-      <slot name="bottom" />
+      <slot name="bottom">
+        <qas-header-actions v-if="hasHeaderActions" v-bind="headerActionsProps" />
+      </slot>
     </div>
   </div>
 </template>
 
 <script>
+import QasHeaderActions from '../header-actions/QasHeaderActions.vue'
+
 import { castArray } from 'lodash-es'
 import { useHistory } from '../../composables'
 import { createMetaMixin } from 'quasar'
@@ -35,6 +35,10 @@ const { history } = useHistory()
 
 export default {
   name: 'QasPageHeader',
+
+  components: {
+    QasHeaderActions
+  },
 
   mixins: [
     createMetaMixin(function () {
@@ -45,14 +49,14 @@ export default {
   ],
 
   props: {
-    actionsMenuProps: {
-      type: Object,
-      default: () => ({})
-    },
-
     breadcrumbs: {
       default: '',
       type: [Array, String]
+    },
+
+    headerActionsProps: {
+      default: () => ({}),
+      type: Object
     },
 
     root: {
@@ -73,11 +77,6 @@ export default {
     useHomeIcon: {
       default: true,
       type: Boolean
-    },
-
-    buttonProps: {
-      default: () => ({}),
-      type: Object
     }
   },
 
@@ -127,12 +126,8 @@ export default {
       ]
     },
 
-    hasDefaultButton () {
-      return !!Object.keys(this.buttonProps).length
-    },
-
-    hasDefaultActionsMenu () {
-      return !!Object.keys(this.actionsMenuProps).length
+    hasHeaderActions () {
+      return !!Object.keys(this.headerActionsProps).length
     },
 
     homeRoute () {

--- a/ui/src/components/page-header/QasPageHeader.yml
+++ b/ui/src/components/page-header/QasPageHeader.yml
@@ -26,7 +26,13 @@ props:
 
   use-breadcrumbs:
     desc: Habilita ou não o breadcrumbs.
-    type: [Array, String]
+    default: true
+    type: Boolean
+
+  use-home-icon:
+    desc: Habilita o ícone de início como primeiro nível do breadcrumbs.
+    default: true
+    type: Boolean
 
 slots:
   bottom:

--- a/ui/src/components/page-header/QasPageHeader.yml
+++ b/ui/src/components/page-header/QasPageHeader.yml
@@ -15,6 +15,11 @@ props:
     desc: Título do cabeçalho.
     type: String
 
+  header-actions-props:
+    desc: Propriedades do QasHeaderActions.
+    default: {}
+    type: Object
+
   root:
     desc: Rota raiz do breadcrumbs.
     type: [Object, String]
@@ -22,3 +27,10 @@ props:
   use-breadcrumbs:
     desc: Habilita ou não o breadcrumbs.
     type: [Array, String]
+
+slots:
+  bottom:
+    desc: slot para acessar abaixo do titulo e breadcrumbs.
+
+  default:
+    desc: slot para acessar lado direito do titulo e breadcrumbs.

--- a/ui/src/css/variables/typography.scss
+++ b/ui/src/css/variables/typography.scss
@@ -99,7 +99,7 @@ $caption: (
   size: 0.75rem,
   line-height: 1.5rem,
   letter-spacing: 0,
-  weight: 600
+  weight: 400
 );
 
 $headings: (

--- a/ui/src/vue-plugin.js
+++ b/ui/src/vue-plugin.js
@@ -22,6 +22,7 @@ import QasFormGenerator from './components/form-generator/QasFormGenerator.vue'
 import QasFormView from './components/form-view/QasFormView.vue'
 import QasGallery from './components/gallery/QasGallery.vue'
 import QasGridGenerator from './components/grid-generator/QasGridGenerator.vue'
+import QasHeaderActions from './components/header-actions/QasHeaderActions.vue'
 import QasInput from './components/input/QasInput.vue'
 import QasLabel from './components/label/QasLabel.vue'
 import QasLayout from './components/layout/QasLayout.vue'
@@ -95,6 +96,7 @@ function install (app) {
   app.component('QasFormView', QasFormView)
   app.component('QasGallery', QasGallery)
   app.component('QasGridGenerator', QasGridGenerator)
+  app.component('QasHeaderActions', QasHeaderActions)
   app.component('QasInput', QasInput)
   app.component('QasLabel', QasLabel)
   app.component('QasLayout', QasLayout)
@@ -169,6 +171,7 @@ export {
   QasFormView,
   QasGallery,
   QasGridGenerator,
+  QasHeaderActions,
   QasInput,
   QasLabel,
   QasLayout,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
## BREAKING CHANGES:
- `QasPageHeader`: adicionada nova propriedade `useHomeIcon` que habilita o ícone de início como primeiro nível do breadcrumbs, com default `true` para respeitar novo padrão de design, caso já tenha um nível de "início" declaro no breadcrumbs, remova.

### Adicionado
- `QasHeaderActions`: adicionado novo componente para trabalhar com descrição e ações.

### Modificado
- `QasPageHeader`: mudanças de layout e comportamento, agora caso o breadcrumbs tenha mais de 4 níveis é adicionado uma label "...".
- `typography.scss`: alterado `font-weight` do `$caption` para `400`.
- `QasPageHeader`: adicionada nova propriedade `useHomeIcon` que habilita o ícone de início como primeiro nível do breadcrumbs, com default `true` para respeitar novo padrão de design.
- `QasActionsMenu`: alterado valor default da propriedade `useLabelOnSmallScreen` para `false`.

clickup: https://app.clickup.com/t/864dm9yra


<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [x] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
