### PR TITLE
Changes in QasTableGenerator / QasPagination / set-typograpy.scss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,15 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ### Adicionado
 - `QasHeaderActions`: adicionado novo componente para trabalhar com descrição e ações.
+- `set-typography.scss`: adicionado novo mixin para setar estilos de tipografia quando não é possível através das classes do quasar.
 
 ### Modificado
 - `QasPageHeader`: mudanças de layout e comportamento, agora caso o breadcrumbs tenha mais de 4 níveis é adicionado uma label "...".
 - `typography.scss`: alterado `font-weight` do `$caption` para `400`.
 - `QasPageHeader`: adicionada nova propriedade `useHomeIcon` que habilita o ícone de início como primeiro nível do breadcrumbs, com default `true` para respeitar novo padrão de design.
 - `QasActionsMenu`: alterado valor default da propriedade `useLabelOnSmallScreen` para `false`.
+- `QasTableGenerator`: modificado cores e fontes.
+- `QasPagination`: modificado cor das paginas para `grey-8` e cor dos ícones de setas para `grey-9`.
 
 ## [3.5.0-beta.11] - 02-01-2023
 ### Modificado

--- a/docs/src/assets/menu.js
+++ b/docs/src/assets/menu.js
@@ -397,6 +397,10 @@ module.exports = [
       {
         name: 'set-brand',
         path: '/styles/set-brand'
+      },
+      {
+        name: 'set-typography',
+        path: '/styles/set-typography'
       }
     ]
   },

--- a/docs/src/pages/styles/set-typography.md
+++ b/docs/src/pages/styles/set-typography.md
@@ -1,0 +1,40 @@
+---
+title: set-typography
+---
+
+Inclui os estilos de tipografia do quasar manualmente ao invés de classe, valores disponíveis:
+
+- $h1
+- $h2
+- $h3
+- $h4
+- $h5
+- $h6
+- $subtitle1
+- $subtitle2
+- $body1
+- $body2
+- $overline
+- $caption
+
+:::warning
+Use este mixin somente quando aplicar as classes de tipografia não funcionarem.
+:::
+
+#### Definição
+```scss
+@use 'sass:map';
+
+@mixin set-typography($name, $important: false) {
+  font-size: if($important, map.get($name, 'size') !important, map.get($name, 'size'));
+  font-weight: if($important, map.get($name, 'weight') !important, map.get($name, 'weight'));
+  letter-spacing: if($important, map.get($name, 'letter-spacing') !important, map.get($name, 'letter-spacing'));
+  line-height: if($important, map.get($name, 'line-height') !important, map.get($name, 'line-height'));
+}
+```
+
+#### Uso
+```scss
+@include set-typography($h1); // aplica os estilos da classe "text-h1"
+@include set-typography($h1, true); // aplica os estilos da classe "text-h1" porém adiciona as propriedades com "!important"
+```

--- a/ui/src/components/pagination/QasPagination.vue
+++ b/ui/src/components/pagination/QasPagination.vue
@@ -15,6 +15,7 @@ export default {
         activeDesign: 'flat',
         boundaryNumbers: true,
         color: 'grey-8',
+        class: 'qas-pagination',
         directionLinks: true,
         maxPages: modelValue < 3 ? 3 : 6,
         modelValue,
@@ -25,3 +26,11 @@ export default {
   }
 }
 </script>
+
+<style lang="scss">
+.qas-pagination {
+  .q-icon {
+    color: $grey-9;
+  }
+}
+</style>

--- a/ui/src/components/pagination/QasPagination.vue
+++ b/ui/src/components/pagination/QasPagination.vue
@@ -14,7 +14,7 @@ export default {
         activeColor: 'primary',
         activeDesign: 'flat',
         boundaryNumbers: true,
-        color: 'grey-7',
+        color: 'grey-8',
         directionLinks: true,
         maxPages: modelValue < 3 ? 3 : 6,
         modelValue,

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -1,6 +1,6 @@
 <template>
   <qas-box class="q-px-lg q-py-md">
-    <q-table ref="table" class="bg-transparent qas-table-generator text-grey-8" :class="tableClass" table-class="text-body1" v-bind="attributes">
+    <q-table ref="table" class="bg-white qas-table-generator text-grey-8" :class="tableClass" v-bind="attributes">
       <template v-for="(_, name) in $slots" #[name]="context">
         <slot v-if="hasBodySlot" name="body" :props="context" />
 
@@ -94,8 +94,7 @@ export default {
           field: name,
           label,
           name,
-          headerClasses: 'text-grey-9 text-subtitle1',
-          titleClass: 'text-subtitle1'
+          headerClasses: 'text-grey-9'
         })
       }
 
@@ -247,14 +246,13 @@ export default {
 
 <style lang="scss">
 .qas-table-generator {
-  .q-table th {
-    font-size: inherit;
-    font-weight: bold;
-  }
-
   .q-table {
+    th {
+      @include set-typography($subtitle1);
+    }
+
     td {
-      font-size: inherit;
+      @include set-typography($body1);
     }
 
     tr {
@@ -265,14 +263,8 @@ export default {
       }
     }
 
-    th:first-child,
-    td:first-child {
-      padding-left: 0;
-    }
-
-    // th,
-    td:last-child {
-      padding-right: 0;
+    thead tr:hover {
+      background-color: white;
     }
   }
 

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -1,6 +1,6 @@
 <template>
   <qas-box class="q-px-lg q-py-md">
-    <q-table ref="table" class="bg-transparent qas-table-generator" :class="tableClass" v-bind="attributes">
+    <q-table ref="table" class="bg-transparent qas-table-generator text-grey-8" :class="tableClass" table-class="text-body1" v-bind="attributes">
       <template v-for="(_, name) in $slots" #[name]="context">
         <slot v-if="hasBodySlot" name="body" :props="context" />
 
@@ -94,7 +94,8 @@ export default {
           field: name,
           label,
           name,
-          headerClasses: 'text-primary'
+          headerClasses: 'text-grey-9 text-subtitle1',
+          titleClass: 'text-subtitle1'
         })
       }
 
@@ -247,7 +248,32 @@ export default {
 <style lang="scss">
 .qas-table-generator {
   .q-table th {
+    font-size: inherit;
     font-weight: bold;
+  }
+
+  .q-table {
+    td {
+      font-size: inherit;
+    }
+
+    tr {
+      transition: background-color var(--qas-generic-transition);
+
+      &:hover {
+        background-color: $grey-2;
+      }
+    }
+
+    th:first-child,
+    td:first-child {
+      padding-left: 0;
+    }
+
+    // th,
+    td:last-child {
+      padding-right: 0;
+    }
   }
 
   &--mobile {

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -251,6 +251,13 @@ export default {
       @include set-typography($subtitle1);
     }
 
+    td,
+    th,
+    thead,
+    tr {
+      border-color: $grey-4;
+    }
+
     td {
       @include set-typography($body1);
     }

--- a/ui/src/css/mixins/index.scss
+++ b/ui/src/css/mixins/index.scss
@@ -1,1 +1,2 @@
 @import './set-brand';
+@import './set-typography';

--- a/ui/src/css/mixins/set-typography.scss
+++ b/ui/src/css/mixins/set-typography.scss
@@ -1,0 +1,8 @@
+@use 'sass:map';
+
+@mixin set-typography($name, $important: false) {
+  font-size: if($important, map.get($name, 'size') !important, map.get($name, 'size'));
+  font-weight: if($important, map.get($name, 'weight') !important, map.get($name, 'weight'));
+  letter-spacing: if($important, map.get($name, 'letter-spacing') !important, map.get($name, 'letter-spacing'));
+  line-height: if($important, map.get($name, 'line-height') !important, map.get($name, 'line-height'));
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Adicionado
- `set-typography.scss`: adicionado novo mixin para setar estilos de tipografia quando não é possível através das classes do quasar.

### Modificado
- `QasTableGenerator`: modificado cores e fontes.
- `QasPagination`: modificado cor das paginas para `grey-8` e cor dos ícones de setas para `grey-9`.

clickup: https://app.clickup.com/t/864dm7gah

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [x] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
