### PR TITLE
Changed debounce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasPageHeader`: adicionada nova propriedade `useHomeIcon` que habilita o ícone de início como primeiro nível do breadcrumbs, com default `true` para respeitar novo padrão de design.
 - `QasActionsMenu`: alterado valor default da propriedade `useLabelOnSmallScreen` para `false`.
 - `QasDateTimeInput`: adicionado validações para datas invalidas.
+- [`QasFilters`, `QasSearchBox`]: alterado debounce de `800ms` para `1200ms`.
 
 ## [3.5.0-beta.11] - 02-01-2023
 ### Modificado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasActionsMenu`: alterado valor default da propriedade `useLabelOnSmallScreen` para `false`.
 - `QasDateTimeInput`: adicionado validações para datas invalidas.
 - [`QasFilters`, `QasSearchBox`]: alterado debounce de `800ms` para `1200ms`.
+- `QasSelect`: alterado debounce de `500ms` (default) para `1200ms` e quando não tem `useLazyLoading` removido o debounce.
 
 ## [3.5.0-beta.11] - 02-01-2023
 ### Modificado

--- a/ui/src/components/filters/QasFilters.vue
+++ b/ui/src/components/filters/QasFilters.vue
@@ -162,7 +162,7 @@ export default {
     },
 
     debounce () {
-      return this.useSearchOnType ? '800' : ''
+      return this.useSearchOnType ? '1200' : ''
     },
 
     fields () {

--- a/ui/src/components/search-box/QasSearchBox.vue
+++ b/ui/src/components/search-box/QasSearchBox.vue
@@ -112,7 +112,7 @@ export default {
       return {
         clearable: true,
         disable: this.isDisabled,
-        debounce: this.useLazyLoading ? 800 : 0,
+        debounce: this.useLazyLoading ? 1200 : 0,
         outlined: true,
         placeholder: this.placeholder,
         hideBottomSpace: true,

--- a/ui/src/components/select/QasSelect.vue
+++ b/ui/src/components/select/QasSelect.vue
@@ -92,7 +92,7 @@ export default {
         ...this.$attrs,
 
         error: this.hasError,
-        inputDebounce: this.useLazyLoading ? 800 : 0,
+        inputDebounce: this.useLazyLoading ? 1200 : 0,
         loading: this.hasLoading,
         options: this.mx_filteredOptions,
         useInput: this.isSearchable,

--- a/ui/src/components/select/QasSelect.vue
+++ b/ui/src/components/select/QasSelect.vue
@@ -91,12 +91,13 @@ export default {
         outlined: true,
         ...this.$attrs,
 
+        error: this.hasError,
+        inputDebounce: this.useLazyLoading ? 800 : 0,
+        loading: this.hasLoading,
         options: this.mx_filteredOptions,
         useInput: this.isSearchable,
-        error: this.hasError,
-        loading: this.hasLoading,
-        ...(this.useLazyLoading && { onVirtualScroll: this.mx_onVirtualScroll }),
-        ...(this.isSearchable && { onFilter: this.onFilter })
+        ...(this.isSearchable && { onFilter: this.onFilter }),
+        ...(this.useLazyLoading && { onVirtualScroll: this.mx_onVirtualScroll })
       }
     },
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Modificado
- [`QasFilters`, `QasSearchBox`]: alterado debounce de `800ms` para `1200ms`.
- `QasSelect`: alterado debounce de `500ms` (default) para `1200ms` e quando não tem `useLazyLoading` removido o debounce.


clickup: https://app.clickup.com/t/864dm7rum

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
