### PR TITLE
Changes in QasDialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,24 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
+### Adicionado
+- `QasActions`: adicionado propriedade `use-full-width` para deixar as colunas 100%, com col-12.
+- `QasActions`: adicionado propriedade `use-equal-width` para deixar as colunas 50% no desktop e 100% no mobile, col-12 col-sm-6.
+`ui/src/css/variables/shadow.scss`: adicionado shadow.scss para modificar através de variável.
+
 ### Modificado
 - `QasNumericInput`: adicionado manualmente prefixo `R$ ` com espaçamento a mais propositalmente.
+- `QasActions`: modificado default da propriedade `gutter` para `lg` porém no mobile ela continua `md`.
+- `QasDialog`: modificado estilos do dialog.
+- [`QasDelete`, `delete.js`, `QasFormView`]: removido titulo do dialog.
+- `QasTreeGenerator`: removido titulo do dialog de excluir ramo.
+- `spacing.scss`: modificado variáveis de gutter para aplicar mudanças do spacing.
+- `QasSignatureUploader`: modificado customização do template `actions` do `qas-dialog` para utilizar o default.
+
+### Removido
+- `ui/src/css/utils/shadow.scss`: removido util shadow.scss para mudar shadow por variável.
+- `QasDialog`: removido propriedade `cardProps` pois não utilizamos mais o `QCard`.
+- `QasDialog`: removido propriedade `useCloseButton` pois agora o controle de mostrar o botão é feito automaticamente.
 
 ## [3.5.0-beta.12] - 06-01-2023
 ## BREAKING CHANGES:

--- a/docs/src/examples/QasDialog/Basic.vue
+++ b/docs/src/examples/QasDialog/Basic.vue
@@ -20,10 +20,16 @@ export default {
         useCloseButton: true,
         card: {
           title: 'Título do Dialog',
-          description: 'Descrição do Dialog'
+          description: 'Cerca elétrica perto do corrimão risco iminente de choque. Código da ordem de serviço: 159488 CRM ID: 1179512'
         },
 
-        ok: { onClick: () => alert('clicado') }
+        ok: false,
+        // ok: true,
+
+        // cancel: true
+        cancel: false
+
+        // ok: { onClick: () => alert('clicado') }
       }
     }
   },

--- a/docs/src/examples/QasDialog/ExWithActions.vue
+++ b/docs/src/examples/QasDialog/ExWithActions.vue
@@ -18,11 +18,10 @@ export default {
     dialogProps () {
       return {
         card: {
-          title: 'Título do dialog',
           description: 'Cerca elétrica perto do corrimão risco iminente de choque. Código da ordem de serviço: 159488 CRM ID: 1179512'
         },
-        cancel: false,
-        ok: false
+
+        ok: { onClick: () => alert('clicado') }
       }
     }
   },

--- a/docs/src/examples/QasDialog/ExWithSingleAction.vue
+++ b/docs/src/examples/QasDialog/ExWithSingleAction.vue
@@ -18,11 +18,11 @@ export default {
     dialogProps () {
       return {
         card: {
-          title: 'Título do dialog',
           description: 'Cerca elétrica perto do corrimão risco iminente de choque. Código da ordem de serviço: 159488 CRM ID: 1179512'
         },
-        cancel: false,
-        ok: false
+
+        ok: { onClick: () => alert('clicado') },
+        cancel: false
       }
     }
   },

--- a/docs/src/pages/components/dialog.md
+++ b/docs/src/pages/components/dialog.md
@@ -9,3 +9,5 @@ Componente de dialog.
 ## Uso
 
 <doc-example file="QasDialog/Basic" title="Básico" />
+<doc-example file="QasDialog/ExWithActions" title="Com ações" />
+<doc-example file="QasDialog/ExWithSingleAction" title="Com uma única ação" />

--- a/ui/src/components/actions/QasActions.vue
+++ b/ui/src/components/actions/QasActions.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="qas-actions" :class="classes">
-    <div v-if="hasSecondarySlot" :class="secondaryClasses">
+    <div v-if="hasSecondarySlot" :class="columnClasses">
       <slot name="secondary" />
     </div>
 
-    <div v-if="hasPrimarySlot" :class="primaryClasses">
+    <div v-if="hasPrimarySlot" :class="columnClasses">
       <slot name="primary" />
     </div>
   </div>
@@ -49,18 +49,8 @@ export default {
       return this.gutter || this.$qas.screen.isSmall ? 'md' : 'lg'
     },
 
-    equalClasses () {
-      return 'col-12 col-sm-6'
-    },
-
-    primaryClasses () {
-      if (this.useEqualWidth) return this.equalClasses
-
-      return this.useFullWidth ? 'col-12' : 'col-12 col-sm-auto'
-    },
-
-    secondaryClasses () {
-      if (this.useEqualWidth) return this.equalClasses
+    columnClasses () {
+      if (this.useEqualWidth) return 'col-12 col-sm-6'
 
       return this.useFullWidth ? 'col-12' : 'col-12 col-sm-auto'
     },

--- a/ui/src/components/actions/QasActions.vue
+++ b/ui/src/components/actions/QasActions.vue
@@ -1,10 +1,10 @@
 <template>
-  <div :class="classes">
-    <div class="col-12 col-sm-auto">
+  <div class="qas-actions" :class="classes">
+    <div v-if="hasSecondarySlot" :class="secondaryClasses">
       <slot name="secondary" />
     </div>
 
-    <div class="col-12 col-sm-auto">
+    <div v-if="hasPrimarySlot" :class="primaryClasses">
       <slot name="primary" />
     </div>
   </div>
@@ -22,9 +22,17 @@ export default {
     },
 
     gutter: {
-      default: 'md',
+      default: 'lg',
       type: String,
       validator: value => ['xs', 'sm', 'md', 'lg', 'xl'].includes(value)
+    },
+
+    useFullWidth: {
+      type: Boolean
+    },
+
+    useEqualWidth: {
+      type: Boolean
     }
   },
 
@@ -32,9 +40,37 @@ export default {
     classes () {
       return [
         `justify-${this.align}`,
-        `q-col-gutter-${this.gutter}`,
+        `q-col-gutter-${this.defaultGutter}`,
         this.$qas.screen.isSmall ? 'column reverse' : 'row'
       ]
+    },
+
+    defaultGutter () {
+      return this.$qas.screen.isSmall ? 'md' : 'lg'
+    },
+
+    equalClasses () {
+      return 'col-12 col-sm-6'
+    },
+
+    primaryClasses () {
+      if (this.useEqualWidth) return this.equalClasses
+
+      return this.useFullWidth ? 'col-12' : 'col-12 col-sm-auto'
+    },
+
+    secondaryClasses () {
+      if (this.useEqualWidth) return this.equalClasses
+
+      return this.useFullWidth ? 'col-12' : 'col-12 col-sm-auto'
+    },
+
+    hasPrimarySlot () {
+      return !!this.$slots.primary
+    },
+
+    hasSecondarySlot () {
+      return !!this.$slots.secondary
     }
   }
 }

--- a/ui/src/components/actions/QasActions.vue
+++ b/ui/src/components/actions/QasActions.vue
@@ -22,9 +22,9 @@ export default {
     },
 
     gutter: {
-      default: 'lg',
+      default: '',
       type: String,
-      validator: value => ['xs', 'sm', 'md', 'lg', 'xl'].includes(value)
+      validator: value => !value || ['xs', 'sm', 'md', 'lg', 'xl'].includes(value)
     },
 
     useFullWidth: {
@@ -46,7 +46,7 @@ export default {
     },
 
     defaultGutter () {
-      return this.$qas.screen.isSmall ? 'md' : 'lg'
+      return this.gutter || this.$qas.screen.isSmall ? 'md' : 'lg'
     },
 
     equalClasses () {

--- a/ui/src/components/actions/QasActions.yml
+++ b/ui/src/components/actions/QasActions.yml
@@ -12,9 +12,19 @@ props:
 
   gutter:
     desc: Espaçamento entre os elementos.
-    default: md
+    default: lg
     type: String
     examples: ['xs', 'sm', 'md', 'lg', 'xl']
+
+  use-full-width:
+    desc: Deixa as colunas 100%, com col-12.
+    default: false
+    type: Boolean
+
+  use-equal-width:
+    desc: Deixa as colunas 50% no desktop e 100% no mobile, col-12 col-sm-6.
+    default: false
+    type: Boolean
 
 slots:
   primary:

--- a/ui/src/components/delete/QasDelete.vue
+++ b/ui/src/components/delete/QasDelete.vue
@@ -77,7 +77,6 @@ export default {
     defaultDialogProps () {
       return {
         card: {
-          title: 'Confirmar',
           description: 'Tem certeza que deseja excluir este item?'
         },
 

--- a/ui/src/components/dialog/QasDialog.vue
+++ b/ui/src/components/dialog/QasDialog.vue
@@ -1,16 +1,49 @@
 <template>
-  <q-dialog ref="dialog" :persistent="persistent" v-bind="dialogProps" @update:model-value="updateModelValue">
-    <q-card v-bind="cardProps" class="q-pa-sm" :style="style">
-      <q-card-section>
+  <q-dialog ref="dialog" class="qas-dialog" :persistent="persistent" v-bind="dialogProps" @update:model-value="updateModelValue">
+    <div class="bg-white q-pa-lg" :style="style">
+      <header class="q-mb-lg">
+        <slot name="header">
+          <div class="items-center justify-between row">
+            <h5 class="text-grey-9 text-h5">{{ card.title }}</h5>
+
+            <qas-btn v-if="isInfoDialog" v-close-popup dense flat icon="sym_r_close" rounded />
+          </div>
+        </slot>
+      </header>
+
+      <section class="text-body1 text-grey-8">
+        <component :is="componentTag" ref="form">
+          <slot name="description">
+            <div v-if="card.description">{{ card.description }}</div>
+          </slot>
+        </component>
+      </section>
+
+      <footer v-if="!isInfoDialog" class="q-mt-xl">
+        <slot name="actions">
+          <qas-actions v-bind="actionsProps" :use-equal-width="hasAllActions" :use-full-width="hasSingleAction">
+            <template v-if="hasOk" #primary>
+              <qas-btn v-close-popup="!useForm" class="full-width" v-bind="defaultOk" @click="submitHandler" />
+            </template>
+
+            <template v-if="hasCancel" #secondary>
+              <qas-btn v-close-popup class="full-width" v-bind="defaultCancel" />
+            </template>
+          </qas-actions>
+        </slot>
+      </footer>
+    </div>
+    <!-- <q-card v-bind="cardProps" class="q-pa-lg text-body1 text-grey-8" :style="style">
+      <q-card-section class="q-pa-none">
         <slot name="header">
           <div class="justify-between row">
-            <div class="text-bold text-h6">{{ card.title }}</div>
+            <h5 class="text-grey-9 text-h5">{{ card.title }}</h5>
             <qas-btn v-if="useCloseButton" v-close-popup dense flat icon="sym_r_close" rounded />
           </div>
         </slot>
       </q-card-section>
 
-      <q-card-section class="q-pt-none">
+      <q-card-section class="q-pa-none">
         <component :is="componentTag" ref="form">
           <slot name="description">
             <div v-if="card.description">{{ card.description }}</div>
@@ -20,7 +53,7 @@
 
       <q-card-section>
         <slot name="actions">
-          <qas-actions v-bind="actionsProps">
+          <qas-actions v-bind="actionsProps" :use-full-width="hasSingleAction">
             <template #primary>
               <qas-btn v-if="ok" v-close-popup="!useForm" class="full-width" v-bind="defaultOk" @click="submitHandler" />
             </template>
@@ -31,7 +64,7 @@
           </qas-actions>
         </slot>
       </q-card-section>
-    </q-card>
+    </q-card> -->
   </q-dialog>
 </template>
 
@@ -59,11 +92,6 @@ export default {
     },
 
     card: {
-      default: () => ({}),
-      type: Object
-    },
-
-    cardProps: {
       default: () => ({}),
       type: Object
     },
@@ -138,8 +166,8 @@ export default {
     style () {
       return {
         ...(this.useFullMaxWidth && { width: '100%' }),
-        maxWidth: this.maxWidth || (this.$qas.screen.isSmall ? '' : '600px'),
-        minWidth: this.minWidth || (this.$qas.screen.isSmall ? '' : '400px')
+        maxWidth: this.maxWidth || '470px',
+        minWidth: this.minWidth || (this.$qas.screen.isSmall ? '' : '366px')
       }
     },
 
@@ -152,6 +180,26 @@ export default {
         ...(!this.usePlugin && { modelValue: this.modelValue }),
         ...this.$attrs
       }
+    },
+
+    hasOk () {
+      return typeof this.ok === 'boolean' ? this.ok : !!Object.keys(this.ok)
+    },
+
+    hasCancel () {
+      return typeof this.cancel === 'boolean' ? this.cancel : !!Object.keys(this.cancel)
+    },
+
+    hasAllActions () {
+      return this.hasOk && this.hasCancel
+    },
+
+    hasSingleAction () {
+      return (this.hasOk && !this.hasCancel) || (!this.hasOk && this.hasCancel)
+    },
+
+    isInfoDialog () {
+      return !this.hasOk && !this.hasCancel
     }
   },
 
@@ -195,3 +243,11 @@ export default {
   }
 }
 </script>
+
+<style lang="scss">
+.qas-dialog {
+  .q-dialog__inner > div {
+    box-shadow: $shadow-2;
+  }
+}
+</style>

--- a/ui/src/components/dialog/QasDialog.vue
+++ b/ui/src/components/dialog/QasDialog.vue
@@ -33,38 +33,6 @@
         </slot>
       </footer>
     </div>
-    <!-- <q-card v-bind="cardProps" class="q-pa-lg text-body1 text-grey-8" :style="style">
-      <q-card-section class="q-pa-none">
-        <slot name="header">
-          <div class="justify-between row">
-            <h5 class="text-grey-9 text-h5">{{ card.title }}</h5>
-            <qas-btn v-if="useCloseButton" v-close-popup dense flat icon="sym_r_close" rounded />
-          </div>
-        </slot>
-      </q-card-section>
-
-      <q-card-section class="q-pa-none">
-        <component :is="componentTag" ref="form">
-          <slot name="description">
-            <div v-if="card.description">{{ card.description }}</div>
-          </slot>
-        </component>
-      </q-card-section>
-
-      <q-card-section>
-        <slot name="actions">
-          <qas-actions v-bind="actionsProps" :use-full-width="hasSingleAction">
-            <template #primary>
-              <qas-btn v-if="ok" v-close-popup="!useForm" class="full-width" v-bind="defaultOk" @click="submitHandler" />
-            </template>
-
-            <template #secondary>
-              <qas-btn v-if="cancel" v-close-popup class="full-width" v-bind="defaultCancel" />
-            </template>
-          </qas-actions>
-        </slot>
-      </q-card-section>
-    </q-card> -->
   </q-dialog>
 </template>
 
@@ -112,8 +80,8 @@ export default {
     },
 
     persistent: {
-      type: Boolean,
-      default: true
+      default: true,
+      type: Boolean
     },
 
     useForm: {
@@ -125,10 +93,6 @@ export default {
     },
 
     usePlugin: {
-      type: Boolean
-    },
-
-    useCloseButton: {
       type: Boolean
     },
 

--- a/ui/src/components/dialog/QasDialog.vue
+++ b/ui/src/components/dialog/QasDialog.vue
@@ -1,12 +1,12 @@
 <template>
   <q-dialog ref="dialog" class="qas-dialog" :persistent="persistent" v-bind="dialogProps" @update:model-value="updateModelValue">
     <div class="bg-white q-pa-lg" :style="style">
-      <header class="q-mb-lg">
+      <header v-if="hasHeader" class="q-mb-lg">
         <slot name="header">
           <div class="items-center justify-between row">
             <h5 class="text-grey-9 text-h5">{{ card.title }}</h5>
 
-            <qas-btn v-if="isInfoDialog" v-close-popup dense flat icon="sym_r_close" rounded />
+            <qas-btn v-if="isInfoDialog" v-close-popup color="grey-9" dense flat icon="sym_r_close" rounded />
           </div>
         </slot>
       </header>
@@ -112,8 +112,8 @@ export default {
     },
 
     persistent: {
-      default: true,
-      type: Boolean
+      type: Boolean,
+      default: true
     },
 
     useForm: {
@@ -196,6 +196,14 @@ export default {
 
     hasSingleAction () {
       return (this.hasOk && !this.hasCancel) || (!this.hasOk && this.hasCancel)
+    },
+
+    hasHeaderSlot () {
+      return !!this.$slots.header
+    },
+
+    hasHeader () {
+      return this.hasHeaderSlot || this.card.title
     },
 
     isInfoDialog () {

--- a/ui/src/components/dialog/QasDialog.yml
+++ b/ui/src/components/dialog/QasDialog.yml
@@ -15,11 +15,6 @@ props:
     type: [Object, Boolean]
     examples: ["{ label: 'Meu botão de cancelar', onClick: () => alert('fui clicado!') }"]
 
-  card-props:
-    desc: Props repassadas para o componente "<q-card />".
-    default: {}
-    type: Object
-
   card:
     desc: Objeto contendo as informações para serem exibidas dentro do dialog como "title" e "description".
     default: {}
@@ -50,10 +45,6 @@ props:
   persistent:
     desc: Define se o dialog vai fechar ou não após clicar fora do dialog.
     default: true
-    type: Boolean
-
-  use-close-button:
-    desc: Define se vai ter ou não Ícone de fechar o dialog.
     type: Boolean
 
   use-form:

--- a/ui/src/components/form-view/QasFormView.vue
+++ b/ui/src/components/form-view/QasFormView.vue
@@ -150,7 +150,6 @@ export default {
 
       defaultDialogProps: {
         card: {
-          title: 'Atenção!',
           description: 'Você está deixando a página e suas alterações serão perdidas. Tem certeza que deseja sair sem salvar?'
         },
 

--- a/ui/src/components/signature-uploader/QasSignatureUploader.vue
+++ b/ui/src/components/signature-uploader/QasSignatureUploader.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <qas-uploader ref="uploader" v-model="model" :label="uploadLabel" :readonly="readonly" :use-resize="false" v-bind="$attrs">
+    <qas-uploader ref="uploader" v-model="model" :label="uploadLabel" v-bind="$attrs" :readonly="readonly" :use-resize="false">
       <template #header="{ scope }">
         <div class="cursor-pointer flex flex-center full-width justify-between no-border no-wrap q-gutter-xs text-white transparent" :class="headerClass" @click="openDialog">
           <div class="col column items-start justify-center">
@@ -26,10 +26,10 @@
         </div>
       </template>
 
-      <template #actions>
+      <!-- <template #actions>
         <qas-btn class="full-width" color="primary" :disable="isEmpty" label="Salvar" no-caps @click="getSignatureData" />
         <qas-btn class="full-width q-mt-sm" color="primary" flat label="Cancelar" no-caps @click="closeSignature" />
-      </template>
+      </template> -->
     </qas-dialog>
   </div>
 </template>
@@ -111,7 +111,11 @@ export default {
     defaultDialogProps () {
       return {
         maxWidth: '620px',
-        ...this.dialogProps
+        ...this.dialogProps,
+        ok: {
+          label: 'Salvar',
+          onClick: () => this.getSignatureData()
+        }
       }
     },
 

--- a/ui/src/components/signature-uploader/QasSignatureUploader.vue
+++ b/ui/src/components/signature-uploader/QasSignatureUploader.vue
@@ -25,11 +25,6 @@
           <qas-signature-pad ref="signaturePadModal" v-model:empty="isEmpty" :height="signaturePadHeight" />
         </div>
       </template>
-
-      <!-- <template #actions>
-        <qas-btn class="full-width" color="primary" :disable="isEmpty" label="Salvar" no-caps @click="getSignatureData" />
-        <qas-btn class="full-width q-mt-sm" color="primary" flat label="Cancelar" no-caps @click="closeSignature" />
-      </template> -->
     </qas-dialog>
   </div>
 </template>

--- a/ui/src/components/text-truncate/QasTextTruncate.vue
+++ b/ui/src/components/text-truncate/QasTextTruncate.vue
@@ -81,7 +81,6 @@ export default {
       return {
         cancel: false,
         ok: false,
-        useCloseButton: true,
         ...this.dialogProps,
         card: {
           title: this.dialogTitle,

--- a/ui/src/components/tree-generator/QasTreeGenerator.vue
+++ b/ui/src/components/tree-generator/QasTreeGenerator.vue
@@ -169,7 +169,6 @@ export default {
     destroyDialogConfig () {
       return {
         card: {
-          title: 'Excluir ramo da árvore?',
           description: 'Todas as informações serão perdidas. Deseja realmente continuar?'
         },
         ok: {

--- a/ui/src/css/utils/index.scss
+++ b/ui/src/css/utils/index.scss
@@ -7,4 +7,3 @@
 @import './opacity';
 @import './text';
 @import './unset';
-@import './shadow';

--- a/ui/src/css/utils/shadow.scss
+++ b/ui/src/css/utils/shadow.scss
@@ -1,4 +1,0 @@
-// TODO rever
-.shadow-2 {
-  box-shadow: 0 4px 8px $accent;
-}

--- a/ui/src/css/variables/index.scss
+++ b/ui/src/css/variables/index.scss
@@ -1,3 +1,4 @@
 @import './button';
+@import './shadow';
 @import './spacing';
 @import './typography';

--- a/ui/src/css/variables/shadow.scss
+++ b/ui/src/css/variables/shadow.scss
@@ -1,0 +1,3 @@
+$shadow-2: 0 4px 8px $accent;
+
+$shadows: ($shadow-2);

--- a/ui/src/css/variables/spacing.scss
+++ b/ui/src/css/variables/spacing.scss
@@ -47,6 +47,21 @@ $spaces: (
   xl: $space-xl
 );
 
+$flex-gutter-xs : map.get($space-xs, 'x');
+$flex-gutter-sm : map.get($space-sm, 'x');
+$flex-gutter-md : map.get($space-md, 'x');
+$flex-gutter-lg : map.get($space-lg, 'x');
+$flex-gutter-xl : map.get($space-xl, 'x');
+
+$flex-gutter: (
+  none: 0,
+  xs: $flex-gutter-xs,
+  sm: $flex-gutter-sm,
+  md: $flex-gutter-md,
+  lg: $flex-gutter-lg,
+  xl: $flex-gutter-xl
+);
+
 :root {
   @each $key, $space in $spaces {
     --qas-spacing-#{$key}: #{map.get($space, 'x')};

--- a/ui/src/mixins/delete.js
+++ b/ui/src/mixins/delete.js
@@ -25,7 +25,6 @@ export default {
     mx_defaultDialogProps () {
       return {
         card: {
-          title: 'Confirmar',
           description: 'Tem certeza que deseja excluir este item?'
         },
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
## Não publicado
### Adicionado
- `QasActions`: adicionado propriedade `use-full-width` para deixar as colunas 100%, com col-12.
- `QasActions`: adicionado propriedade `use-equal-width` para deixar as colunas 50% no desktop e 100% no mobile, col-12 col-sm-6.
`ui/src/css/variables/shadow.scss`: adicionado shadow.scss para modificar através de variável.

### Modificado
- `QasActions`: modificado default da propriedade `gutter` para `lg` porém no mobile ela continua `md`.
- `QasDialog`: modificado estilos do dialog.
- [`QasDelete`, `delete.js`, `QasFormView`]: removido titulo do dialog.
- `QasTreeGenerator`: removido titulo do dialog de excluir ramo.
- `spacing.scss`: modificado variáveis de gutter para aplicar mudanças do spacing.
- `QasSignatureUploader`: modificado customização do template `actions` do `qas-dialog` para utilizar o default.

### Removido
- `ui/src/css/utils/shadow.scss`: removido util shadow.scss para mudar shadow por variável.
- `QasDialog`: removido propriedade `cardProps` pois não utilizamos mais o `QCard`.
- `QasDialog`: removido propriedade `useCloseButton` pois agora o controle de mostrar o botão é feito automaticamente.

clickup: https://app.clickup.com/t/864dm81bx

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [x] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [x] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [x] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
