### PR TITLE
Changes in QasActionsMenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasActions`: adicionado propriedade `use-full-width` para deixar as colunas 100%, com col-12.
 - `QasActions`: adicionado propriedade `use-equal-width` para deixar as colunas 50% no desktop e 100% no mobile, col-12 col-sm-6.
 `ui/src/css/variables/shadow.scss`: adicionado shadow.scss para modificar através de variável.
+- `QasActionsMenu`: adicionado propriedade `useLabel` com default `true` para esconder o label em todas as telas necessárias.
+- `QasActionsMenu`: adicionado propriedade `color` com default `grey-9` para controlar cor do botão.
 
 ### Modificado
 - `QasNumericInput`: adicionado manualmente prefixo `R$ ` com espaçamento a mais propositalmente.
@@ -25,6 +27,9 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasTreeGenerator`: removido titulo do dialog de excluir ramo.
 - `spacing.scss`: modificado variáveis de gutter para aplicar mudanças do spacing.
 - `QasSignatureUploader`: modificado customização do template `actions` do `qas-dialog` para utilizar o default.
+- `QasActionsMenu`: alterado cor padrão em todos os casos para `grey-9`.
+- `item.scss`: modificado cor do hover para `$primary-color`;
+- `item.scss`: modificado cor do item quando clicável para `grey-9` e quando não clicável para `grey-8`;
 
 ### Removido
 - `ui/src/css/utils/shadow.scss`: removido util shadow.scss para mudar shadow por variável.

--- a/docs/src/examples/QasActionsMenu/ExUseLabel.vue
+++ b/docs/src/examples/QasActionsMenu/ExUseLabel.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="container q-py-lg">
+    <qas-actions-menu :delete-props="{ entity: 'users', customId: 'my-custom-id-from-user', onSuccess: onDeleteSuccess }" :use-label="false" />
+  </div>
+</template>
+
+<script>
+export default {
+  methods: {
+    onDeleteSuccess () {
+      this.$qas.success('fui deletado com sucesso!')
+    }
+  }
+}
+</script>

--- a/docs/src/pages/components/actions-menu.md
+++ b/docs/src/pages/components/actions-menu.md
@@ -56,3 +56,5 @@ Para receber o evento de sucesso ao deletar, dentro da propriedade `deleteProps`
 <doc-example file="QasActionsMenu/Delete" title="QasDelete como padrão" />
 
 <doc-example file="QasActionsMenu/CustomSlot" title="Templates dinâmicos" />
+
+<doc-example file="QasActionsMenu/ExUseLabel" title="Ícone sem label" />

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -17,7 +17,7 @@
         </q-list>
       </q-menu>
 
-      <q-tooltip v-if="!hasMoreThanOneAction" class="text-caption">
+      <q-tooltip v-if="hasTooltip" class="text-caption">
         {{ tooltipLabel }}
       </q-tooltip>
     </component>
@@ -127,6 +127,10 @@ export default {
 
     hasMoreThanOneAction () {
       return Object.keys(this.list || {}).length + Number(this.hasDelete) > 1
+    },
+
+    hasTooltip () {
+      return !this.hasMoreThanOneAction && !this.useLabel
     },
 
     tooltipLabel () {

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="hasActions">
-    <component :is="component.is" flat v-bind="component.props" :use-label-on-small-screen="useLabelOnSmallScreen" @click="onClick()">
+    <component :is="component.is" :color="color" flat v-bind="component.props" :use-label-on-small-screen="useLabelOnSmallScreen" @click="onClick()">
       <q-menu v-if="hasMoreThanOneAction" auto-close class="q-py-xs">
         <q-list>
           <slot v-for="(item, key) in actions" :item="item" :name="key">
@@ -16,6 +16,10 @@
           </slot>
         </q-list>
       </q-menu>
+
+      <q-tooltip v-if="!hasMoreThanOneAction" class="text-caption">
+        {{ tooltipLabel }}
+      </q-tooltip>
     </component>
   </div>
 </template>
@@ -33,13 +37,13 @@ export default {
   },
 
   props: {
-    icon: {
-      default: 'sym_r_more_vert',
+    color: {
+      default: 'grey-9',
       type: String
     },
 
-    label: {
-      default: 'Opções',
+    icon: {
+      default: 'sym_r_more_vert',
       type: String
     },
 
@@ -61,6 +65,11 @@ export default {
     deleteProps: {
       default: () => ({}),
       type: Object
+    },
+
+    useLabel: {
+      default: true,
+      type: Boolean
     },
 
     useLabelOnSmallScreen: {
@@ -89,13 +98,11 @@ export default {
       const props = {}
 
       if (this.hasMoreThanOneAction) {
-        props.label = 'Opções'
+        props.label = this.useLabel ? 'Opções' : ''
         props.iconRight = this.icon
-        props.textColor = 'dark'
       } else {
         props.icon = this.actions[this.firstItemKey]?.icon
-        props.label = this.actions[this.firstItemKey]?.label
-        props.color = 'primary'
+        props.label = this.useLabel ? this.actions[this.firstItemKey]?.label : ''
       }
 
       this.hasDelete && Object.assign(props, this.deleteProps)
@@ -120,6 +127,10 @@ export default {
 
     hasMoreThanOneAction () {
       return Object.keys(this.list || {}).length + Number(this.hasDelete) > 1
+    },
+
+    tooltipLabel () {
+      return this.actions[this.firstItemKey]?.label
     }
   },
 

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="hasActions">
-    <component :is="component.is" :color="color" flat v-bind="component.props" :use-label-on-small-screen="useLabelOnSmallScreen" @click="onClick()">
+    <component :is="component.is" flat v-bind="component.props" :use-label-on-small-screen="useLabelOnSmallScreen" @click="onClick()">
       <q-menu v-if="hasMoreThanOneAction" auto-close class="q-py-xs">
         <q-list>
           <slot v-for="(item, key) in actions" :item="item" :name="key">
@@ -38,7 +38,7 @@ export default {
 
   props: {
     color: {
-      default: 'grey-9',
+      default: '',
       type: String
     },
 
@@ -97,10 +97,13 @@ export default {
     component () {
       const props = {}
 
+      // TODO: solução do color é temporária até ser definido o novo QasBtn.
       if (this.hasMoreThanOneAction) {
-        props.label = this.useLabel ? 'Opções' : ''
+        props.color = this.color || 'grey-9'
         props.iconRight = this.icon
+        props.label = this.useLabel ? 'Opções' : ''
       } else {
+        props.color = this.color || 'primary'
         props.icon = this.actions[this.firstItemKey]?.icon
         props.label = this.useLabel ? this.actions[this.firstItemKey]?.label : ''
       }

--- a/ui/src/components/actions-menu/QasActionsMenu.yml
+++ b/ui/src/components/actions-menu/QasActionsMenu.yml
@@ -6,7 +6,6 @@ meta:
 props:
   color:
     desc: Cor do ícone.
-    default: grey-9
     type: String
 
   delete-icon:

--- a/ui/src/components/actions-menu/QasActionsMenu.yml
+++ b/ui/src/components/actions-menu/QasActionsMenu.yml
@@ -4,6 +4,11 @@ meta:
   desc: Componente para abrir um menu de ação a partir de um botão, muito utilizado em tela de edição.
 
 props:
+  color:
+    desc: Cor do ícone.
+    default: grey-9
+    type: String
+
   delete-icon:
     desc: Ícone do botão de deletar.
     default: sym_r_delete
@@ -41,6 +46,11 @@ props:
 
   use-label-on-small-screen:
     desc: Esconde o rótulo (label) do botão quando o tamanho da tela for pequeno (esta propriedade só funciona se o "rotulo") for passado via propriedade "label".
+    default: true
+    type: Boolean
+
+  use-label:
+    desc: Habilita ou não o label no botão.
     default: true
     type: Boolean
 

--- a/ui/src/css/components/item.scss
+++ b/ui/src/css/components/item.scss
@@ -5,6 +5,10 @@
     font-weight: 600;
   }
 
+  &:not(&--clickable) {
+    color: $grey-8;
+  }
+
   &.q-router-link--active {
     background-color: transparent !important;
     font-weight: 600;
@@ -22,10 +26,11 @@
   }
 
   &--clickable {
+    color: $grey-9;
     transition: color 300ms;
 
-    &:hover {
-      color: var(--q-primary);
+    &:not(&.q-router-link--active):hover {
+      color: var(--q-primary-contrast);
     }
   }
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Adicionado
- `QasActionsMenu`: adicionado propriedade `useLabel` com default `true` para esconder o label em todas as telas necessárias.
- `QasActionsMenu`: adicionado propriedade `color` com default `grey-9` para controlar cor do botão.

### Modificado
- `QasActionsMenu`: alterado cor padrão em todos os casos para `grey-9`.
- `item.scss`: modificado cor do hover para `$primary-color`;
- `item.scss`: modificado cor do item quando clicável para `grey-9` e quando não clicável para `grey-8`;

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [x] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
