### PR TITLE
finished changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,11 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `spacing.scss`: modificado variáveis de gutter para aplicar mudanças do spacing.
 - `QasSignatureUploader`: modificado customização do template `actions` do `qas-dialog` para utilizar o default.
 - `item.scss`: modificado cor do hover para `$primary-color`;
-- `item.scss`: modificado cor do item quando clicável para `grey-9` e quando não clicável para `grey-8`;
+- `item.scss`: modificado cor do item quando clicável para `grey-9` e quando não clicável para `grey-8`.
+
+### Corrigido
+- `QasAppMenu`: corrigido tamanho do drawer, estava invertido, 320px deve ser no mobile e não desktop.
+- `QasAppMenu`: corrigido botão de fechar drawer no mobile, não tinha nenhuma ação ao clicar nele.
 
 ### Removido
 - `ui/src/css/utils/shadow.scss`: removido util shadow.scss para mudar shadow por variável.

--- a/ui/src/components/app-menu/QasAppMenu.vue
+++ b/ui/src/components/app-menu/QasAppMenu.vue
@@ -18,7 +18,7 @@
           </div>
 
           <div v-if="$qas.screen.isSmall" class="q-ml-xl">
-            <qas-btn color="grey-9" dense flat icon="sym_r_close" rounded />
+            <qas-btn color="grey-9" dense flat icon="sym_r_close" rounded @click="closeDrawer" />
           </div>
         </div>
 
@@ -172,7 +172,7 @@ export default {
     },
 
     drawerWidth () {
-      return this.$qas.screen.isSmall ? 280 : 320
+      return this.$qas.screen.isSmall ? 320 : 280
     },
 
     hasDevelopmentBadge () {
@@ -247,6 +247,10 @@ export default {
 
     signOut () {
       this.$emit('sign-out')
+    },
+
+    closeDrawer () {
+      this.$emit('update:modelValue', false)
     }
   }
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Corrigido
- `QasAppMenu`: corrigido tamanho do drawer, estava invertido, 320px deve ser no mobile e não desktop.
- `QasAppMenu`: corrigido botão de fechar drawer no mobile, não tinha nenhuma ação ao clicar nele.

clickup: https://app.clickup.com/t/864dqvuzw

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
