### PR TITLE
fix undefined text on QasTextTruncate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasTextTruncate`: corrigido bug quando o texto tinha como valor inicial `undefined`.
+
 ## [3.5.0-beta.14] - 17-01-2023
 ### Corrigido
 - `QasAppMenu`: corrigido tamanho do drawer, estava invertido, 320px deve ser no mobile e não desktop.

--- a/docs/src/examples/QasTextTruncate/Basic.vue
+++ b/docs/src/examples/QasTextTruncate/Basic.vue
@@ -1,5 +1,19 @@
 <template>
   <div class="container q-py-lg">
-    <qas-text-truncate dialog-title="Aqui está meu título!" text="Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis voluptatem dolorem animi molestias quasi sit, ipsa suscipit quaerat." />
+    <qas-text-truncate dialog-title="Aqui está meu título!" :text="text" />
   </div>
 </template>
+
+<script>
+export default {
+  data () {
+    return {
+      text: ''
+    }
+  },
+
+  created () {
+    this.text = 'Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis voluptatem dolorem animi molestias quasi sit, ipsa suscipit quaerat.'
+  }
+}
+</script>

--- a/ui/src/components/text-truncate/QasTextTruncate.vue
+++ b/ui/src/components/text-truncate/QasTextTruncate.vue
@@ -4,16 +4,13 @@
       <div ref="truncate" :class="truncateTextClass">
         <slot>{{ text }}</slot>
       </div>
-      <div v-if="isTruncated" class="cursor-pointer text-primary" @click.stop="toggleDialog">{{ seeMoreLabel }}</div>
+
+      <div v-if="isTruncated" class="cursor-pointer text-primary" @click.stop="toggleDialog">
+        {{ seeMoreLabel }}
+      </div>
     </div>
 
-    <qas-dialog v-model="showDialog" v-bind="defaultDialogProps">
-      <template #description>
-        <slot>
-          <div>{{ text }}</div>
-        </slot>
-      </template>
-    </qas-dialog>
+    <qas-dialog v-model="showDialog" v-bind="defaultDialogProps" aria-label="Diálogo de texto completo" role="dialog" />
   </div>
 </template>
 
@@ -60,7 +57,8 @@ export default {
     return {
       maxPossibleWidth: '',
       showDialog: false,
-      textWidth: ''
+      textWidth: '',
+      observer: null
     }
   },
 
@@ -98,6 +96,11 @@ export default {
 
   mounted () {
     this.truncateText()
+    this.observeContentChange()
+  },
+
+  unmounted () {
+    this.observer.disconnect()
   },
 
   methods: {
@@ -110,6 +113,18 @@ export default {
 
     toggleDialog () {
       this.showDialog = !this.showDialog
+    },
+
+    observeContentChange () {
+      const element = this.$refs.truncate
+      const config = { childList: true, subtree: true, characterData: true }
+
+      const callback = mutationList => {
+        mutationList.forEach(() => this.truncateText())
+      }
+
+      this.observer = new MutationObserver(callback)
+      this.observer.observe(element, config)
     }
   }
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Corrigido
- `QasTextTruncate`: corrigido bug quando o texto tinha como valor inicial `undefined`.

clickup: https://app.clickup.com/t/3cxpy79

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
