### PR TITLE
Added QasStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasStatus`: adicionado componente circular de status.
+
+### Modificado
+- `QasTabsGenerator`: utilizando `QasStatus` no lugar do `PvTabsGeneratorStatus`.
+
+### Removido
+- `PvTabsGeneratorStatus`: removido componente privado em favor do componente publico `QasStatus`.
+
 ## [3.5.0-beta.14] - 17-01-2023
 ### Corrigido
 - `QasAppMenu`: corrigido tamanho do drawer, estava invertido, 320px deve ser no mobile e não desktop.

--- a/docs/src/assets/menu.js
+++ b/docs/src/assets/menu.js
@@ -221,6 +221,10 @@ module.exports = [
         path: '/components/sortable'
       },
       {
+        name: 'Status',
+        path: '/components/Status'
+      },
+      {
         name: 'TableGenerator',
         path: '/components/table-generator'
       },

--- a/docs/src/examples/QasStatus/Basic.vue
+++ b/docs/src/examples/QasStatus/Basic.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="container flex justify-center q-gutter-x-md q-py-lg">
+    <qas-status v-for="(color, index) in colors" :key="index" :color="color" />
+  </div>
+</template>
+
+<script>
+export default {
+  computed: {
+    colors () {
+      return [
+        'light-blue-2',
+        'green-14',
+        'blue-8',
+        'grey-10',
+        'orange-8',
+        'red-14',
+        'yellow-14',
+        'grey-7',
+        'purple-7',
+        'amber-2',
+        'green-11'
+      ]
+    }
+  }
+}
+</script>

--- a/docs/src/pages/components/status.md
+++ b/docs/src/pages/components/status.md
@@ -1,0 +1,11 @@
+---
+title: QasStatus
+---
+
+Componente que gera um status circular com a cor do status.
+
+<doc-api file="status/QasStatus" name="QasStatus" />
+
+## Uso
+
+<doc-example file="QasStatus/Basic" title="Básico" />

--- a/ui/src/components/status/QasStatus.vue
+++ b/ui/src/components/status/QasStatus.vue
@@ -1,17 +1,17 @@
 <template>
-  <div class="pv-tabs-generator-status" :class="backgroundClass" />
+  <div aria-live="polite" class="qas-status" :class="backgroundClass" role="status" />
 </template>
 
 <script>
 export default {
-  name: 'PvTabsGeneratorStatus',
+  name: 'QasStatus',
 
   inheritAttrs: false,
 
   props: {
     color: {
       type: String,
-      default: ''
+      default: 'light-blue-2'
     }
   },
 
@@ -24,7 +24,7 @@ export default {
 </script>
 
 <style lang="scss">
-.pv-tabs-generator-status {
+.qas-status {
   border-radius: 100%;
   height: 16px;
   width: 16px;

--- a/ui/src/components/status/QasStatus.yml
+++ b/ui/src/components/status/QasStatus.yml
@@ -1,0 +1,10 @@
+type: component
+
+meta:
+  desc: Componente que gera um status circular com a cor do status.
+
+props:
+  color:
+    desc: cor dos status.
+    default: light-blue-2
+    type: String

--- a/ui/src/components/tabs-generator/QasTabsGenerator.vue
+++ b/ui/src/components/tabs-generator/QasTabsGenerator.vue
@@ -6,7 +6,7 @@
           <slot :item="tab" :name="`tab-after-${tab.value}`">
             <q-icon v-if="tab.icon" :name="tab.icon" size="sm" />
 
-            <pv-tabs-generator-status v-if="tab.status" :color="tab.status" />
+            <qas-status v-if="tab.status" :color="tab.status" />
 
             <div class="q-ml-xs">
               {{ getFormattedLabel(tab) }}
@@ -19,7 +19,7 @@
 </template>
 
 <script>
-import PvTabsGeneratorStatus from './private/PvTabsGeneratorStatus.vue'
+import QasStatus from '../status/QasStatus.vue'
 
 import { extend } from 'quasar'
 
@@ -27,7 +27,7 @@ export default {
   name: 'QasTabsGenerator',
 
   components: {
-    PvTabsGeneratorStatus
+    QasStatus
   },
 
   props: {

--- a/ui/src/vue-plugin.js
+++ b/ui/src/vue-plugin.js
@@ -45,6 +45,7 @@ import QasSignaturePad from './components/signature-pad/QasSignaturePad.vue'
 import QasSignatureUploader from './components/signature-uploader/QasSignatureUploader.vue'
 import QasSingleView from './components/single-view/QasSingleView.vue'
 import QasSortable from './components/sortable/QasSortable.vue'
+import QasStatus from './components/status/QasStatus.vue'
 import QasTableGenerator from './components/table-generator/QasTableGenerator.vue'
 import QasTabsGenerator from './components/tabs-generator/QasTabsGenerator.vue'
 import QasTextTruncate from './components/text-truncate/QasTextTruncate.vue'
@@ -120,6 +121,7 @@ function install (app) {
   app.component('QasSignatureUploader', QasSignatureUploader)
   app.component('QasSingleView', QasSingleView)
   app.component('QasSortable', QasSortable)
+  app.component('QasStatus', QasStatus)
   app.component('QasTableGenerator', QasTableGenerator)
   app.component('QasTabsGenerator', QasTabsGenerator)
   app.component('QasTextTruncate', QasTextTruncate)
@@ -196,6 +198,7 @@ export {
   QasSignatureUploader,
   QasSingleView,
   QasSortable,
+  QasStatus,
   QasTableGenerator,
   QasTabsGenerator,
   QasTextTruncate,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Adicionado
- `QasStatus`: adicionado componente circular de status.

### Modificado
- `QasTabsGenerator`: utilizando `QasStatus` no lugar do `PvTabsGeneratorStatus`.

### Removido
- `PvTabsGeneratorStatus`: removido componente privado em favor do componente publico `QasStatus`.


<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [x] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [ ] Fiz meu próprio _code review_ antes de abrir este _pull request_.
