### PR TITLE
Changes in Notifies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- [`NotifyError`, `NotifySuccess`]: adicionado flag para diferenciar notifies de erro e sucesso.
+- `QasFormView`: alterado mensagem de erro de "Existem campos no formulário que ainda não foram preenchidos. Complete todas as informações para avançar." para "Não conseguimos salvar as informações. Por favor, revise os campos e tente novamente."
+
 ## [3.6.0-beta.0] - 31-01-2023
 ### Adicionado
 - `QasBadge` adicionado novo componente wrapper do quasar para badges.

--- a/ui/src/components/form-view/QasFormView.vue
+++ b/ui/src/components/form-view/QasFormView.vue
@@ -195,7 +195,7 @@ export default {
 
     defaultNotifyMessages () {
       return {
-        validationError: 'Existem campos no formulário que ainda não foram preenchidos. Complete todas as informações para avançar.',
+        validationError: 'Não conseguimos salvar as informações. Por favor, revise os campos e tente novamente.',
         error: 'Não conseguimos salvar as informações. Por favor, tente novamente em alguns minutos.',
         success: 'Informações salvas com sucesso.'
       }
@@ -434,8 +434,9 @@ export default {
       } catch (error) {
         const errors = error?.response?.data?.errors
         const message = error?.response?.data?.status?.text
+        const hasFieldError = !!Object.keys(errors || {})?.length
 
-        const defaultMessage = error
+        const defaultMessage = hasFieldError
           ? this.defaultNotifyMessages.validationError
           : this.defaultNotifyMessages.error
 

--- a/ui/src/css/plugins/notify.scss
+++ b/ui/src/css/plugins/notify.scss
@@ -3,12 +3,23 @@
   max-width: 560px;
 
   &.qas-notification {
-    &--success {
-      box-shadow: inset 4px 0 0 0 var(--q-positive);
+    &--error::before,
+    &--success::before {
+      border-radius: var(--qas-generic-border-radius) 0 0 var(--qas-generic-border-radius);
+      bottom: 0;
+      content: '';
+      left: calc(var(--qas-spacing-md) * -1);
+      position: relative;
+      top: 0;
+      width: 4px;
     }
 
-    &--error {
-      box-shadow: inset 4px 0 0 0 var(--q-negative);
+    &--error::before {
+      background-color: var(--q-negative);
+    }
+
+    &--success::before {
+      background-color: var(--q-positive);
     }
   }
 

--- a/ui/src/css/plugins/notify.scss
+++ b/ui/src/css/plugins/notify.scss
@@ -2,6 +2,16 @@
   margin-top: 80px;
   max-width: 560px;
 
+  &.qas-notification {
+    &--success {
+      box-shadow: inset 4px 0 0 0 var(--q-positive);
+    }
+
+    &--error {
+      box-shadow: inset 4px 0 0 0 var(--q-negative);
+    }
+  }
+
   &__content {
     .q-icon {
       margin-right: var(--qas-spacing-sm);

--- a/ui/src/plugins/notify-error/NotifyError.js
+++ b/ui/src/plugins/notify-error/NotifyError.js
@@ -1,11 +1,12 @@
 import { Notify } from 'quasar'
 import notifyConfig from '../../shared/notify-config.js'
 
-Notify.registerType('error', { icon: 'sym_r_cancel', ...notifyConfig })
+Notify.registerType('error', notifyConfig)
 
 export default (message, caption) => {
   Notify.create({
     caption,
+    classes: 'qas-notification--error',
     message,
     type: 'error'
   })

--- a/ui/src/plugins/notify-success/NotifySuccess.js
+++ b/ui/src/plugins/notify-success/NotifySuccess.js
@@ -1,11 +1,12 @@
 import { Notify } from 'quasar'
 import notifyConfig from '../../shared/notify-config.js'
 
-Notify.registerType('success', { icon: 'sym_r_check_circle', ...notifyConfig })
+Notify.registerType('success', notifyConfig)
 
 export default (message, caption) => {
   Notify.create({
     caption,
+    classes: 'qas-notification--success',
     message,
     type: 'success'
   })


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

### Modificado
- [`NotifyError`, `NotifySuccess`]: adicionado flag para diferenciar notifies de erro e sucesso.
- `QasFormView`: alterado mensagem de erro de "Existem campos no formulário que ainda não foram preenchidos. Complete todas as informações para avançar." para "Não conseguimos salvar as informações. Por favor, revise os campos e tente novamente."

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [x] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
