### PR TITLE
Changed default style of Loading from quasar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- [`app-extension/src/boot/loading.js`, `ui/src/css/plugins/loading.scss`]: adicionado novos arquivos para mudar o estilo do Loading.
+
+### Modificado
+- `Loading` adicionado estilos default para o Loading do `quasar`.
+
 ## [3.6.0] - 14-02-2023
 ## BREAKING CHANGES
 - `QasBtn`: componente passou por muitas mudanças, é preciso repassar em **TODOS** os lugares que utilizam ele e rever as propriedades adicionando o comportamento / estilo correto.

--- a/app-extension/src/boot/loading.js
+++ b/app-extension/src/boot/loading.js
@@ -1,0 +1,12 @@
+import { boot } from 'quasar/wrappers'
+import { Loading } from 'quasar'
+
+export default boot(() => {
+  Loading.setDefaults({
+    spinnerColor: 'primary',
+    messageColor: 'primary',
+    backgroundColor: 'white',
+    message: 'Carregando...',
+    boxClass: 'text-body1'
+  })
+})

--- a/app-extension/src/index.js
+++ b/app-extension/src/index.js
@@ -9,6 +9,7 @@ function extendQuasar (quasar) {
     'boot/error-pages.js',
     'boot/register.js',
     'boot/history.js',
+    'boot/loading.js',
     'boot/store-adapter'
   ))
 

--- a/ui/src/css/plugins/index.scss
+++ b/ui/src/css/plugins/index.scss
@@ -1,1 +1,2 @@
 @import './notify';
+@import './loading';

--- a/ui/src/css/plugins/loading.scss
+++ b/ui/src/css/plugins/loading.scss
@@ -1,0 +1,5 @@
+.q-loading {
+  &__backdrop {
+    opacity: 0.9;
+  }
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Adicionado
- [`app-extension/src/boot/loading.js`, `ui/src/css/plugins/loading.scss`]: adicionado novos arquivos para mudar o estilo do Loading.

### Modificado
- `Loading` adicionado estilos default para o Loading do `quasar`.

clickup: https://app.clickup.com/t/864dyu54n

Novo estilo:
![image](https://user-images.githubusercontent.com/32134017/218830963-ef952638-590b-4970-927a-9990a0c1e5f1.png)


<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [x] CSS
- [ ] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [x] Plugins
- [ ] Testes
- [x] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
