### PR TITLE
QasNumericInput use negative default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+## BREAKING CHANGES
+- `QasNumericInput`: modificado o valor padrão da propriedade `use-negative` para `false`. Anteriormente por padrão era possível inserir valores negativos, porém com essa modificação será necessário passar a propriedade `use-negative` como `true` para ter o mesmo comportamento anterior.
+
+### Modificado
+- `QasNumericInput`: modificado o valor padrão da propriedade `use-negative` para `false`.
+
 ## [3.7.0-beta.1] - 23-02-2023
 ### Corrigido
 - [`loading.js`, `loading.scss`]: adicionado custom class `qas-loading` para só estilizar o loading quando existir esta classe.

--- a/docs/src/examples/QasNumericInput/Negative.vue
+++ b/docs/src/examples/QasNumericInput/Negative.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="container spaced">
+    <div>
+      <qas-numeric-input v-model="integer" entity="test" label="integer" use-negative />
+      integer: {{ integer }}
+    </div>
+    <div class="q-my-lg">
+      <qas-numeric-input v-model="decimal" entity="test" label="decimal" mode="decimal" use-negative />
+      decimal: {{ decimal }}
+    </div>
+    <div class="q-my-lg">
+      <qas-numeric-input v-model="percent" entity="test" label="percent" mode="percent" use-negative />
+      percent: {{ percent }}
+    </div>
+    <div class="q-my-lg">
+      <qas-numeric-input v-model="money" entity="test" label="money" mode="money" use-negative />
+      money: {{ money }}
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      integer: -10,
+      decimal: -0.10,
+      percent: -0.10,
+      money: -0.10
+    }
+  }
+}
+</script>

--- a/docs/src/pages/components/numeric-input.md
+++ b/docs/src/pages/components/numeric-input.md
@@ -18,3 +18,9 @@ Este componente utiliza a biblioteca [autonumeric](http://autonumeric.org/).
 ## Uso
 
 <doc-example file="QasNumericInput/Basic" title="Básico" />
+
+:::tip
+Para utilizar valores negativos, utilize a propriedade `use-negative` com o valor `true`.
+:::
+
+<doc-example file="QasNumericInput/Negative" title="Valores negativos" />

--- a/docs/src/pages/components/numeric-input.md
+++ b/docs/src/pages/components/numeric-input.md
@@ -20,7 +20,7 @@ Este componente utiliza a biblioteca [autonumeric](http://autonumeric.org/).
 <doc-example file="QasNumericInput/Basic" title="Básico" />
 
 :::tip
-Para utilizar valores negativos, utilize a propriedade `use-negative` com o valor `true`.
+Utilize a propriedade `use-negative` com o valor `true` para permitir valores negativos.
 :::
 
 <doc-example file="QasNumericInput/Negative" title="Valores negativos" />

--- a/ui/src/components/numeric-input/QasNumericInput.vue
+++ b/ui/src/components/numeric-input/QasNumericInput.vue
@@ -55,7 +55,6 @@ export default {
     },
 
     useNegative: {
-      default: true,
       type: Boolean
     },
 

--- a/ui/src/components/numeric-input/QasNumericInput.yml
+++ b/ui/src/components/numeric-input/QasNumericInput.yml
@@ -35,7 +35,7 @@ props:
 
   use-negative:
     desc: Controla se pode ou não números negativos.
-    default: true
+    default: false
     type: Boolean
 
   use-positive:


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- (Remova este texto de descrição.) -->
`QasNumericInput`: modificado o valor padrão da propriedade `use-negative` para `false`.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
