### PR TITLE
fix(QasDialog): fix prop actionsProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ### Modificado
 - `QasNumericInput`: modificado o valor padrão da propriedade `use-negative` para `false`.
+- `QasDialog`: modificado a forma de repassar as props para o `QasActions`, para que sobrescreva os valores defaults.
+- `QasActions`: modificado a lógica de inverter os botões a partir do momento que for passada a prop `useFullWidth`.
 
 ## [3.7.0-beta.1] - 23-02-2023
 ### Corrigido

--- a/ui/src/components/actions/QasActions.vue
+++ b/ui/src/components/actions/QasActions.vue
@@ -41,7 +41,7 @@ export default {
       return [
         `justify-${this.align}`,
         `q-col-gutter-${this.defaultGutter}`,
-        this.$qas.screen.isSmall ? 'column reverse' : 'row'
+        (this.$qas.screen.isSmall || this.useFullWidth) ? 'column reverse' : 'row'
       ]
     },
 

--- a/ui/src/components/dialog/QasDialog.vue
+++ b/ui/src/components/dialog/QasDialog.vue
@@ -21,7 +21,7 @@
 
       <footer v-if="!isInfoDialog">
         <slot name="actions">
-          <qas-actions v-bind="actionsProps" :use-equal-width="hasAllActions" :use-full-width="hasSingleAction">
+          <qas-actions v-bind="formattedActionsProps">
             <template v-if="hasOk" #primary>
               <qas-btn v-close-popup="!useForm" class="full-width" variant="primary" v-bind="defaultOk" @click="submitHandler" />
             </template>
@@ -172,6 +172,20 @@ export default {
 
     isInfoDialog () {
       return !this.hasOk && !this.hasCancel
+    },
+
+    formattedActionsProps () {
+      const { useFullWidth, useEqualWidth } = this.actionsProps
+
+      if (useFullWidth || useEqualWidth) {
+        return this.actionsProps
+      }
+
+      return {
+        useFullWidth: this.hasSingleAction,
+        useEqualWidth: this.hasAllActions,
+        ...this.actionsProps
+      }
     }
   },
 


### PR DESCRIPTION
- Tratativa do dialog para aceitar passar props para o QasActions, como por exemplo o "useFullWidth"
![image](https://user-images.githubusercontent.com/29342573/222822109-3e62cfba-0d1a-463e-aa42-b48f1e184c79.png)


<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
