### PR TITLE
Changes in QasPasswordInput / QasStrengthChecker / QasInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+## BREAKING CHANGES
+- `QasPasswordInput`: removido propriedade `iconColor` uma vez que não deve ser possível mudar a cor do ícone.
+- `QasStrengthChecker`: removido model `modelValue` pois não estava sendo repassado para o `QasPasswordInput`.
+
+### Adicionado
+- [`QasPasswordInput`, `QasStrengthChecker`]: model `currentLevel` que retorna o level atual.
+
+### Modificado
+- `QasPasswordInput`: Corrigido `QIcon` que foi substituído para um `QasBtn`.
+
+### Corrigido
+- `QasPasswordInput`: Corrigido slot do hint que texto ficava em cima de conteúdos abaixo do input.
+
+### Removido
+- `QasPasswordInput`: removido propriedade `iconColor` uma vez que não deve ser possível mudar a cor do ícone.
+- `QasStrengthChecker`: removido model `modelValue` pois não estava sendo repassado para o `QasPasswordInput`.
+
 ## [3.7.0-beta.2] - 06-03-2023
 ## BREAKING CHANGES
 - `QasActionsMenu`: removido propriedades [`useLabelOnSmallScreen`, `color`, `icon`] pois agora é possível passar as propriedades para o `buttonProps` e `dropdownIcon`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ## Não publicado
 ## BREAKING CHANGES
 - `QasPasswordInput`: removido propriedade `iconColor` uma vez que não deve ser possível mudar a cor do ícone.
-- `QasStrengthChecker`: removido model `modelValue` pois não estava sendo repassado para o `QasPasswordInput`.
+- `QasPasswordStrengthChecker`: removido model `modelValue` pois não estava sendo repassado para o `QasPasswordInput`.
 
 ### Adicionado
-- [`QasPasswordInput`, `QasStrengthChecker`]: model `currentLevel` que retorna o level atual.
+- [`QasPasswordInput`, `QasPasswordStrengthChecker`]: model `currentLevel` que retorna o level atual.
 
 ### Modificado
 - `QasPasswordInput`: Corrigido `QIcon` que foi substituído para um `QasBtn`.
@@ -27,7 +27,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ### Removido
 - `QasPasswordInput`: removido propriedade `iconColor` uma vez que não deve ser possível mudar a cor do ícone.
-- `QasStrengthChecker`: removido model `modelValue` pois não estava sendo repassado para o `QasPasswordInput`.
+- `QasPasswordStrengthChecker`: removido model `modelValue` pois não estava sendo repassado para o `QasPasswordInput`.
 
 ## [3.7.0-beta.2] - 06-03-2023
 ## BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ### Corrigido
 - `QasPasswordInput`: Corrigido slot do hint que texto ficava em cima de conteúdos abaixo do input.
+- `QasInput`: corrigido `errorMessage` que não deveria ser resetado ao usar a propriedade `use-remove-error-on-type`.
 
 ### Removido
 - `QasPasswordInput`: removido propriedade `iconColor` uma vez que não deve ser possível mudar a cor do ícone.

--- a/docs/src/examples/QasPasswordInput/Basic.vue
+++ b/docs/src/examples/QasPasswordInput/Basic.vue
@@ -1,7 +1,12 @@
 <template>
   <div class="container q-py-lg">
-    <qas-password-input v-model="password" />
+    <qas-password-input v-model="password" v-model:currentLevel="currentLevel" :error="error" error-message="testeee" label="senha" :strength-checker-props="props" />
+
     Senha: {{ password }}
+
+    {{ currentLevel }}
+
+    <qas-btn label="teste" @click="error = !error" />
   </div>
 </template>
 
@@ -9,7 +14,17 @@
 export default {
   data () {
     return {
-      password: ''
+      error: false,
+      password: '',
+      currentLevel: 0
+    }
+  },
+
+  computed: {
+    props () {
+      return {
+        useNumbers: false
+      }
     }
   }
 }

--- a/docs/src/examples/QasPasswordInput/Basic.vue
+++ b/docs/src/examples/QasPasswordInput/Basic.vue
@@ -1,12 +1,13 @@
 <template>
   <div class="container q-py-lg">
-    <qas-password-input v-model="password" v-model:currentLevel="currentLevel" :error="error" error-message="testeee" label="senha" :strength-checker-props="props" />
+    <qas-password-input v-model="password" v-model:currentLevel="currentLevel" label="Senha" />
 
-    Senha: {{ password }}
-
-    {{ currentLevel }}
-
-    <qas-btn label="teste" @click="error = !error" />
+    <div>
+      Senha: {{ password }}
+    </div>
+    <div>
+      currentLevel: {{ currentLevel }}
+    </div>
   </div>
 </template>
 
@@ -14,17 +15,8 @@
 export default {
   data () {
     return {
-      error: false,
       password: '',
       currentLevel: 0
-    }
-  },
-
-  computed: {
-    props () {
-      return {
-        useNumbers: false
-      }
     }
   }
 }

--- a/ui/src/components/input/QasInput.vue
+++ b/ui/src/components/input/QasInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-input ref="input" v-model="model" bottom-slots :error="errorData" v-bind="$attrs" :error-message="errorMessageData" :mask="mask" :outlined="outlined" :unmasked-value="unmaskedValue" @paste="onPaste">
+  <q-input ref="input" v-model="model" bottom-slots :error="errorData" v-bind="$attrs" :error-message="errorMessage" :mask="mask" :outlined="outlined" :unmasked-value="unmaskedValue" @paste="onPaste">
     <template v-for="(_, name) in $slots" #[name]="context">
       <slot :name="name" v-bind="context || {}" />
     </template>
@@ -47,7 +47,6 @@ export default {
   data () {
     return {
       errorData: false,
-      messageErrorData: '',
       mask: ''
     }
   },
@@ -108,14 +107,6 @@ export default {
       },
 
       immediate: true
-    },
-
-    errorMessage: {
-      handler (value) {
-        this.errorMessageData = value
-      },
-
-      immediate: true
     }
   },
 
@@ -156,7 +147,6 @@ export default {
     handleErrors () {
       if (this.useRemoveErrorOnType && this.error) {
         this.errorData = false
-        this.errorMessageData = ''
       }
     },
 

--- a/ui/src/components/password-input/QasPasswordInput.vue
+++ b/ui/src/components/password-input/QasPasswordInput.vue
@@ -1,7 +1,11 @@
 <template>
-  <qas-input v-model="model" :bottom-slots="hasBottomSlots" v-bind="$attrs" :type="type" use-remove-error-on-type>
+  <qas-input v-model="model" class="qas-password-input" :hide-bottom-space="hideBottomSpace" v-bind="$attrs" :type="type" use-remove-error-on-type>
+    <template #prepend>
+      <q-icon color="grey-8" name="sym_r_lock" />
+    </template>
+
     <template #append>
-      <q-icon class="cursor-pointer" :color="iconColor" :name="icon" @click="toggle" />
+      <qas-btn color="primary" :icon="icon" variant="tertiary" @click="toggle" />
     </template>
 
     <template v-for="(_, name) in $slots" #[name]="context">
@@ -9,7 +13,7 @@
     </template>
 
     <template v-if="hasStrengthChecker" #hint>
-      <qas-password-strength-checker v-bind="strengthCheckerProps" :password="model" />
+      <qas-password-strength-checker v-bind="strengthCheckerProps" :password="model" @update:current-level="updateCurrentLevel" />
     </template>
   </qas-input>
 </template>
@@ -37,18 +41,13 @@ export default {
       type: Boolean
     },
 
-    iconColor: {
-      type: String,
-      default: 'primary'
-    },
-
     modelValue: {
       type: String,
       default: ''
     }
   },
 
-  emits: ['update:modelValue'],
+  emits: ['update:modelValue', 'update:currentLevel'],
 
   data () {
     return {
@@ -72,7 +71,12 @@ export default {
     },
 
     strengthCheckerProps () {
-      const { modelValue, ...props } = this.$props
+      const {
+        modelValue,
+        useStrengthChecker,
+        ...props
+      } = this.$props
+
       return props
     },
 
@@ -86,12 +90,20 @@ export default {
 
     hasStrengthChecker () {
       return this.useStrengthChecker && this.hasBottomSlots
+    },
+
+    hideBottomSpace () {
+      return this.$attrs.error || !!this.model.length
     }
   },
 
   methods: {
     toggle () {
       this.toggleType = !this.toggleType
+    },
+
+    updateCurrentLevel (currentLevel) {
+      this.$emit('update:currentLevel', currentLevel)
     }
   }
 }

--- a/ui/src/components/password-input/QasPasswordInput.yml
+++ b/ui/src/components/password-input/QasPasswordInput.yml
@@ -7,10 +7,11 @@ mixins:
   - '@bildvitta/quasar-ui-asteroid/dist/api/QasInput.json'
   - quasar/dist/api/QInput.json
 props:
-  icon-color:
-    desc: Cor do ícone do input.
-    default: primary
-    type: String
+  current-level:
+    desc: model que tem o valor atual do level.
+    default: 0
+    type: Number
+    model: true
 
   levels:
     desc: Níveis de força da senha, é um objeto de objeto.

--- a/ui/src/components/password-input/QasPasswordInput.yml
+++ b/ui/src/components/password-input/QasPasswordInput.yml
@@ -102,3 +102,10 @@ events:
       value:
         desc: Novo valor do v-model
         type: Boolean
+
+  '@update:current-level -> function (level)':
+    desc: Dispara toda vez que o level (score) é atualizado.
+    params:
+      level:
+        desc: Novo valor do v-model:currentLevel
+        type: Boolean

--- a/ui/src/components/password-strength-checker/QasPasswordStrengthChecker.vue
+++ b/ui/src/components/password-strength-checker/QasPasswordStrengthChecker.vue
@@ -1,8 +1,8 @@
 <template>
   <div v-if="length">
     <slot :level="level">
-      <q-linear-progress :color="level.color" :track-color="trackColor" :value="level.progress" />
-      <div class="text-caption" :class="level.textClass">{{ level.label }}</div>
+      <q-linear-progress :color="level.color" rounded :track-color="trackColor" :value="level.progress" />
+      <div class="q-mt-sm text-subtitle2" :class="level.textClass">{{ level.label }}</div>
     </slot>
   </div>
 </template>
@@ -16,18 +16,13 @@ export default {
   mixins: [passwordMixin],
 
   props: {
-    modelValue: {
-      default: false,
-      type: Boolean
-    },
-
     password: {
       default: '',
       type: String
     }
   },
 
-  emits: ['update:modelValue'],
+  emits: ['update:modelValue', 'update:currentLevel'],
 
   computed: {
     length () {
@@ -64,18 +59,12 @@ export default {
   },
 
   watch: {
-    password () {
-      this.emitValue()
-    }
-  },
+    score: {
+      handler (score) {
+        this.$emit('update:currentLevel', score)
+      },
 
-  created () {
-    this.emitValue()
-  },
-
-  methods: {
-    emitValue () {
-      this.$emit('update:modelValue', this.score === 4)
+      immediate: true
     }
   }
 }

--- a/ui/src/components/password-strength-checker/QasPasswordStrengthChecker.yml
+++ b/ui/src/components/password-strength-checker/QasPasswordStrengthChecker.yml
@@ -95,9 +95,9 @@ slots:
         type: Object
 
 events:
-  '@update:model-value -> function (value)':
-    desc: Dispara toda vez que o model é atualizado, também utilizado para v-model.
+  '@update:current-level -> function (level)':
+    desc: Dispara toda vez que o level (score) é atualizado.
     params:
-      value:
-        desc: Novo valor do v-model
+      level:
+        desc: Novo valor do v-model:currentLevel
         type: Boolean

--- a/ui/src/components/password-strength-checker/QasPasswordStrengthChecker.yml
+++ b/ui/src/components/password-strength-checker/QasPasswordStrengthChecker.yml
@@ -4,6 +4,12 @@ meta:
   desc: Componente para checar nível de força da senha.
 
 props:
+  current-level:
+    desc: model que tem o valor atual do level.
+    default: 0
+    type: Number
+    model: true
+
   levels:
     desc: Níveis de força da senha, é um objeto de objeto.
     type: [Object, Boolean]
@@ -43,12 +49,6 @@ props:
   password:
     desc: Senha para ser usado nas validações.
     type: String
-
-  model-value:
-    desc: Model do componente, retorna se passou ou não na validação de senha.
-    type: Boolean
-    examples: [v-model="value"]
-    model: true
 
   minlength:
     desc: Número mínimo de caracteres.

--- a/ui/src/mixins/password.js
+++ b/ui/src/mixins/password.js
@@ -37,6 +37,11 @@ const levels = {
 
 export default {
   props: {
+    currentLevel: {
+      default: 0,
+      type: Number
+    },
+
     levels: {
       default: () => levels,
       type: Object


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
## BREAKING CHANGES
- `QasPasswordInput`: removido propriedade `iconColor` uma vez que não deve ser possível mudar a cor do ícone.
- `QasStrengthChecker`: removido model `modelValue` pois não estava sendo repassado para o `QasPasswordInput`.

### Adicionado
- [`QasPasswordInput`, `QasStrengthChecker`]: model `currentLevel` que retorna o level atual.

### Modificado
- `QasPasswordInput`: Corrigido `QIcon` que foi substituído para um `QasBtn`.

### Corrigido
- `QasPasswordInput`: Corrigido slot do hint que texto ficava em cima de conteúdos abaixo do input.
- `QasInput`: corrigido `errorMessage` que não deveria ser resetado ao usar a propriedade `use-remove-error-on-type`.

### Removido
- `QasPasswordInput`: removido propriedade `iconColor` uma vez que não deve ser possível mudar a cor do ícone.
- `QasStrengthChecker`: removido model `modelValue` pois não estava sendo repassado para o `QasPasswordInput`.


<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [x] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
