### PR TITLE
Feature/main homolog/qas table generator sticky header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasTableGenerator`: Adicionado propriedade `use-sticky-header` e `sticky-header-table-height` para manter o header da tabela fixo na rolagem do conteúdo.
+- `scrollbar.scss`: Adicionado estilo padrão para o scrollbar.
+
 ## [3.7.0-beta.3] - 09-03-2023
 ## BREAKING CHANGES
 - `QasPasswordInput`: removido propriedade `iconColor` uma vez que não deve ser possível mudar a cor do ícone.

--- a/docs/src/examples/QasTableGenerator/StickyHeader.vue
+++ b/docs/src/examples/QasTableGenerator/StickyHeader.vue
@@ -1,0 +1,27 @@
+<template>
+  <!-- Utilizando o list-view apenas para facilitar para recuperar os dados dos dados. -->
+  <qas-list-view v-model:fields="fields" v-model:results="results" :entity="entity" :use-filter="false">
+    <template #default>
+      <qas-table-generator :fields="fields" :results="results" row-key="uuid" use-sticky-header />
+    </template>
+  </qas-list-view>
+</template>
+
+<script>
+export default {
+  name: 'UsersList',
+
+  data () {
+    return {
+      fields: {},
+      results: []
+    }
+  },
+
+  computed: {
+    entity () {
+      return 'users'
+    }
+  }
+}
+</script>

--- a/docs/src/pages/components/table-generator.md
+++ b/docs/src/pages/components/table-generator.md
@@ -59,7 +59,7 @@ rowExternalRouteFn () {
 
 <doc-example file="QasTableGenerator/TableLink" title="Tabela com links" />
 
-A funcionalidade de header fixo em tabelas permite que o cabeçalho da tabela permaneça visível na parte superior enquanto o usuário faz rolagem do conteúdo da tabela. Para utilizar atribua a prop `use-sticky-header`.
+Funcionalidade que permite que o cabeçalho da tabela permaneça visível na parte superior enquanto o usuário faz rolagem do conteúdo da tabela. Para utilizar atribua a prop `use-sticky-header`.
 
 :::tip
 É possível alterar a altura máxima da tabela utilizando a prop `sticky-header-table-height`.

--- a/docs/src/pages/components/table-generator.md
+++ b/docs/src/pages/components/table-generator.md
@@ -62,7 +62,7 @@ rowExternalRouteFn () {
 A funcionalidade de header fixo em tabelas permite que o cabeçalho da tabela permaneça visível na parte superior enquanto o usuário faz rolagem do conteúdo da tabela. Para utilizar atribua a prop `use-sticky-header`.
 
 :::tip
-É possível alterar a altura máxima da tabela utilizando a prop `sticky-header-max-height`.
+É possível alterar a altura máxima da tabela utilizando a prop `sticky-header-table-height`.
 :::
 
 <doc-example file="QasTableGenerator/StickyHeader" title="Header fixo" />

--- a/docs/src/pages/components/table-generator.md
+++ b/docs/src/pages/components/table-generator.md
@@ -58,3 +58,11 @@ rowExternalRouteFn () {
 :::
 
 <doc-example file="QasTableGenerator/TableLink" title="Tabela com links" />
+
+A funcionalidade de header fixo em tabelas permite que o cabeçalho da tabela permaneça visível na parte superior enquanto o usuário faz rolagem do conteúdo da tabela. Para utilizar atribua a prop `use-sticky-header`.
+
+:::tip
+É possível alterar a altura máxima da tabela utilizando a prop `sticky-header-max-height`.
+:::
+
+<doc-example file="QasTableGenerator/StickyHeader" title="Header fixo" />

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -1,6 +1,6 @@
 <template>
   <qas-box class="q-px-lg q-py-md">
-    <q-table ref="table" class="bg-white qas-table-generator text-grey-8" :class="tableClass" v-bind="attributes">
+    <q-table ref="table" class="bg-white qas-table-generator text-grey-8" v-bind="attributes">
       <template v-for="(_, name) in slots" #[name]="context">
         <slot :name="name" v-bind="context" />
       </template>
@@ -65,6 +65,15 @@ export default {
 
     useExternalLink: {
       type: Boolean
+    },
+
+    useStickyHeader: {
+      type: Boolean
+    },
+
+    stickyHeaderMaxHeight: {
+      default: '528px',
+      type: String
     }
   },
 
@@ -110,12 +119,14 @@ export default {
 
     attributes () {
       const attributes = {
+        class: this.tableClass,
         columns: this.columnsByFields,
-        rows: this.resultsByFields,
         flat: true,
         hideBottom: true,
         pagination: { rowsPerPage: 0 },
         rowKey: this.rowKey,
+        rows: this.resultsByFields,
+        style: this.tableStyles,
 
         // Eventos.
         onRowClick: this.$attrs.onRowClick && this.onRowClick
@@ -196,7 +207,16 @@ export default {
     },
 
     tableClass () {
-      return this.$qas.screen.isSmall && 'qas-table-generator--mobile'
+      return {
+        'qas-table-generator--mobile': this.$qas.screen.isSmall,
+        'qas-table-generator--sticky-header': this.useStickyHeader
+      }
+    },
+
+    tableStyles () {
+      return {
+        maxHeight: this.useStickyHeader ? this.stickyHeaderMaxHeight : 'initial'
+      }
     },
 
     hasScrollOnGrab () {
@@ -337,6 +357,26 @@ export default {
 
     .q-table {
       margin-left: 10px;
+    }
+  }
+
+  &--sticky-header {
+    .q-table {
+      thead {
+        tr {
+          th {
+            position: sticky;
+            z-index: 1;
+          }
+
+          &:first-child {
+            th {
+              background-color: #fff;
+              top: 0;
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -361,20 +361,16 @@ export default {
   }
 
   &--sticky-header {
-    .q-table {
-      thead {
-        tr {
-          th {
-            position: sticky;
-            z-index: 1;
-          }
+    .q-table thead tr {
+      th {
+        position: sticky;
+        z-index: 1;
+      }
 
-          &:first-child {
-            th {
-              background-color: #fff;
-              top: 0;
-            }
-          }
+      &:first-child {
+        th {
+          background-color: white;
+          top: 0;
         }
       }
     }

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -126,7 +126,7 @@ export default {
         pagination: { rowsPerPage: 0 },
         rowKey: this.rowKey,
         rows: this.resultsByFields,
-        style: this.tableStyles,
+        style: this.tableStyle,
 
         // Eventos.
         onRowClick: this.$attrs.onRowClick && this.onRowClick
@@ -213,7 +213,7 @@ export default {
       }
     },
 
-    tableStyles () {
+    tableStyle () {
       return {
         maxHeight: this.useStickyHeader ? this.stickyHeaderTableHeight : 'initial'
       }

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -71,7 +71,7 @@ export default {
       type: Boolean
     },
 
-    stickyHeaderMaxHeight: {
+    stickyHeaderTableHeight: {
       default: '528px',
       type: String
     }
@@ -215,7 +215,7 @@ export default {
 
     tableStyles () {
       return {
-        maxHeight: this.useStickyHeader ? this.stickyHeaderMaxHeight : 'initial'
+        maxHeight: this.useStickyHeader ? this.stickyHeaderTableHeight : 'initial'
       }
     },
 

--- a/ui/src/components/table-generator/QasTableGenerator.yml
+++ b/ui/src/components/table-generator/QasTableGenerator.yml
@@ -46,6 +46,16 @@ props:
     default: false
     type: Boolean
 
+  use-sticky-header:
+    desc: Usado para manter o header da tabela (thead) fixo.
+    default: false
+    type: Boolean
+
+  sticky-header-max-height:
+    desc: Usado para definir a altura máxima da tabela e exibir o scroll vertical.
+    default: 528px
+    type: String
+
 slots:
   body:
     desc: Acesso direto dentro do `tbody`.

--- a/ui/src/components/table-generator/QasTableGenerator.yml
+++ b/ui/src/components/table-generator/QasTableGenerator.yml
@@ -51,8 +51,8 @@ props:
     default: false
     type: Boolean
 
-  sticky-header-max-height:
-    desc: Usado para definir a altura máxima da tabela e exibir o scroll vertical.
+  sticky-header-table-height:
+    desc: Usado para definir a altura máxima da tabela e exibir o scroll vertical quando a propriedade "use-sticky-header" é utilizada.
     default: 528px
     type: String
 

--- a/ui/src/css/components/index.scss
+++ b/ui/src/css/components/index.scss
@@ -3,4 +3,5 @@
 @import './field';
 @import './item';
 @import './radio';
+@import './scrollbar';
 @import './tabs';

--- a/ui/src/css/components/scrollbar.scss
+++ b/ui/src/css/components/scrollbar.scss
@@ -1,32 +1,20 @@
-:root {
-  --scrollbar-size: 9px;
-  --scrollbar-background: #E0E0E0;
-  --scrollbar-thumb-background: var(--q-primary);
-  --scrollbar-thumb-background-hover: var(--q-primary-contrast);
-  --scrollbar-border-radius: calc(var(--qas-generic-border-radius) * 2);
-
-  // Firefox support
-  scrollbar-color: var(--scrollbar-thumb-background) var(--scrollbar-background);
-  scrollbar-width: thin;
-}
-
 // Webkit browsers
 ::-webkit-scrollbar {
-  background: var(--scrollbar-background);
-  border-radius: var(--scrollbar-border-radius);
-  height: var(--scrollbar-size);
-  width: var(--scrollbar-size);
+  background: var(--qas-scrollbar-background);
+  border-radius: var(--qas-scrollbar-border-radius);
+  height: var(--qas-scrollbar-size);
+  width: var(--qas-scrollbar-size);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--scrollbar-thumb-background);
+  background: var(--qas-scrollbar-thumb-background);
   background-clip: padding-box;
   border: 1px solid rgba(0%, 0%, 0%, 0%);
-  border-radius: var(--scrollbar-border-radius);
+  border-radius: var(--qas-scrollbar-border-radius);
   transition: background-color var(--qas-generic-transition);
-  width: var(--scrollbar-size);
+  width: var(--qas-scrollbar-size);
 
   &:hover {
-    background: var(--scrollbar-thumb-background-hover);
+    background: var(--qas-scrollbar-thumb-background-hover);
   }
 }

--- a/ui/src/css/components/scrollbar.scss
+++ b/ui/src/css/components/scrollbar.scss
@@ -1,10 +1,12 @@
 :root {
   --scrollbar-size: 9px;
   --scrollbar-background: #E0E0E0;
+  --scrollbar-thumb-background: var(--q-primary);
+  --scrollbar-thumb-background-hover: var(--q-primary-contrast);
   --scrollbar-border-radius: calc(var(--qas-generic-border-radius) * 2);
 
   // Firefox support
-  scrollbar-color: var(--q-primary) var(--scrollbar-background);
+  scrollbar-color: var(--scrollbar-thumb-background) var(--scrollbar-background);
   scrollbar-width: thin;
 }
 
@@ -17,7 +19,7 @@
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--q-primary);
+  background: var(--scrollbar-thumb-background);
   background-clip: padding-box;
   border: 1px solid rgba(0%, 0%, 0%, 0%);
   border-radius: var(--scrollbar-border-radius);
@@ -25,6 +27,6 @@
   width: var(--scrollbar-size);
 
   &:hover {
-    background: var(--q-primary-contrast);
+    background: var(--scrollbar-thumb-background-hover);
   }
 }

--- a/ui/src/css/components/scrollbar.scss
+++ b/ui/src/css/components/scrollbar.scss
@@ -1,0 +1,30 @@
+:root {
+  --scrollbar-size: 9px;
+  --scrollbar-background: #E0E0E0;
+  --scrollbar-border-radius: calc(var(--qas-generic-border-radius) * 2);
+
+  // Firefox support
+  scrollbar-color: var(--q-primary) var(--scrollbar-background);
+  scrollbar-width: thin;
+}
+
+// Webkit browsers
+::-webkit-scrollbar {
+  background: var(--scrollbar-background);
+  border-radius: var(--scrollbar-border-radius);
+  height: var(--scrollbar-size);
+  width: var(--scrollbar-size);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--q-primary);
+  background-clip: padding-box;
+  border: 1px solid rgba(0%, 0%, 0%, 0%);
+  border-radius: var(--scrollbar-border-radius);
+  transition: background-color var(--qas-generic-transition);
+  width: var(--scrollbar-size);
+
+  &:hover {
+    background: var(--q-primary-contrast);
+  }
+}

--- a/ui/src/css/variables/index.scss
+++ b/ui/src/css/variables/index.scss
@@ -1,4 +1,5 @@
 @import './button';
+@import './scrollbar';
 @import './separator';
 @import './shadow';
 @import './spacing';

--- a/ui/src/css/variables/scrollbar.scss
+++ b/ui/src/css/variables/scrollbar.scss
@@ -1,0 +1,11 @@
+:root {
+  --qas-scrollbar-size: 9px;
+  --qas-scrollbar-background: #E0E0E0;
+  --qas-scrollbar-thumb-background: var(--q-primary);
+  --qas-scrollbar-thumb-background-hover: var(--q-primary-contrast);
+  --qas-scrollbar-border-radius: calc(var(--qas-generic-border-radius) * 2);
+
+  // Firefox support
+  scrollbar-color: var(--qas-scrollbar-thumb-background) var(--qas-scrollbar-background);
+  scrollbar-width: thin;
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- (Remova este texto de descrição.) -->
Funcionalidade que permite que o cabeçalho da tabela permaneça visível na parte superior enquanto o usuário faz rolagem do conteúdo da tabela.

![Screen Shot 2023-03-17 at 15 51 12](https://user-images.githubusercontent.com/19765074/225993431-f8922aed-20b2-4276-b514-3d34ddbd879e.jpg)

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
