### PR TITLE
feat(QasFilters): :sparkles: Support to emit events, some new slots, …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasFilters`: Adicionado documentação para o slot `right-side`.
 - `QasFilters`: Adicionado propriedade `use-spacing` com o valor default `true` para habilitar ou não o espaçamento padrão do componente.
 - `QasFilters`: Adicionado propriedade `use-update-route` com o valor default `true` para habilitar ou não a atualização da rota com base nos filtros.
+- `QasFilters`: Adicionado evento `@update` que dispara sempre que é realizada alguma atualização no filtro.
 
 ### Corrigido
 - `QasFilters`: corrigido problema onde não era possível ter o botão de filtro sem o campo de busca.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasFilters`: Adicionado slot `filter-button`.
 - `QasFilters`: Adicionado documentação para o slot `right-side`.
 - `QasFilters`: Adicionado propriedade `use-spacing` com o valor default `true` para habilitar ou não o espaçamento padrão do componente.
-- `QasFilters`: Adicionado propriedade `use-route-update` com o valor default `true` para habilitar ou não a atualização da rota com base nos filtros.
+- `QasFilters`: Adicionado propriedade `use-update-route` com o valor default `true` para habilitar ou não a atualização da rota com base nos filtros.
 
 ### Corrigido
 - `QasFilters`: corrigido problema onde não era possível ter o botão de filtro sem o campo de busca.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasFilters`: Adicionado slot `filter-button`.
+- `QasFilters`: Adicionado documentação para o slot `right-side`.
+- `QasFilters`: Adicionado propriedade `use-spacing` com o valor default `true` para habilitar ou não o espaçamento padrão do componente.
+- `QasFilters`: Adicionado propriedade `use-route-update` com o valor default `true` para habilitar ou não a atualização da rota com base nos filtros.
+
+### Corrigido
+- `QasFilters`: corrigido problema onde não era possível ter o botão de filtro sem o campo de busca.
+
 ## [3.7.0-beta.3] - 09-03-2023
 ## BREAKING CHANGES
 - `QasPasswordInput`: removido propriedade `iconColor` uma vez que não deve ser possível mudar a cor do ícone.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasFilters`: Adicionado documentação para o slot `right-side`.
 - `QasFilters`: Adicionado propriedade `use-spacing` com o valor default `true` para habilitar ou não o espaçamento padrão do componente.
 - `QasFilters`: Adicionado propriedade `use-update-route` com o valor default `true` para habilitar ou não a atualização da rota com base nos filtros.
-- `QasFilters`: Adicionado evento `@update` que dispara sempre que é realizada alguma atualização no filtro.
+- `QasFilters`: Adicionado evento `@update:current-filters` que dispara sempre que é realizada alguma atualização no filtro.
 
 ### Corrigido
 - `QasFilters`: corrigido problema onde não era possível ter o botão de filtro sem o campo de busca.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasFilters`: Adicionado documentação para o slot `right-side`.
 - `QasFilters`: Adicionado propriedade `use-spacing` com o valor default `true` para habilitar ou não o espaçamento padrão do componente.
 - `QasFilters`: Adicionado propriedade `use-update-route` com o valor default `true` para habilitar ou não a atualização da rota com base nos filtros.
-- `QasFilters`: Adicionado evento `@update:current-filters` que dispara sempre que é realizada alguma atualização no filtro.
+- `QasFilters`: Adicionado evento `@update:currentFilters` que dispara sempre que é realizada alguma atualização no filtro.
 
 ### Corrigido
 - `QasFilters`: corrigido problema onde não era possível ter o botão de filtro sem o campo de busca.

--- a/docs/src/examples/QasFilters/Basic.vue
+++ b/docs/src/examples/QasFilters/Basic.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container spaced">
-    <qas-filters :entity="entity" :fields-props="fieldsProps" search-placeholder="Gabriel Assen de Vasconcelos Belin Queiroz Gabrielle Ra" />
+    <qas-filters :entity="entity" :fields-props="fieldsProps" search-placeholder="Pesquisar por nome do usuário" />
   </div>
 </template>
 

--- a/docs/src/examples/QasFilters/CustomFilterButton.vue
+++ b/docs/src/examples/QasFilters/CustomFilterButton.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="container spaced">
+    <qas-filters :entity="entity">
+      <template #filter-button="{ filter }">
+        <qas-btn label="Filtrar" @click="filter({ name: 'John Doe' })" />
+      </template>
+    </qas-filters>
+  </div>
+</template>
+
+<script>
+export default {
+  computed: {
+    entity () {
+      return 'users'
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QasFilters/NoRouteUpdate.vue
+++ b/docs/src/examples/QasFilters/NoRouteUpdate.vue
@@ -1,25 +1,19 @@
 <template>
   <div class="container spaced">
-    <qas-filters v-model:current-filters="currentFilters" :entity="entity" search-placeholder="Pesquisar por nome do usuário" :use-update-route="false" />
+    <qas-filters :entity="entity" :use-update-route="false" @update:current-filters="onUpdateCurrentFilters" />
   </div>
 </template>
 
 <script>
 export default {
-  data () {
-    return {
-      currentFilters: {}
-    }
-  },
-
   computed: {
     entity () {
       return 'users'
     }
   },
 
-  watch: {
-    currentFilters (query) {
+  methods: {
+    onUpdateCurrentFilters (query) {
       // console.log(query)
     }
   }

--- a/docs/src/examples/QasFilters/NoRouteUpdate.vue
+++ b/docs/src/examples/QasFilters/NoRouteUpdate.vue
@@ -14,7 +14,7 @@ export default {
 
   methods: {
     onFilterUpdate (query) {
-      console.log(query)
+      // console.log(query)
     }
   }
 }

--- a/docs/src/examples/QasFilters/NoRouteUpdate.vue
+++ b/docs/src/examples/QasFilters/NoRouteUpdate.vue
@@ -1,19 +1,25 @@
 <template>
   <div class="container spaced">
-    <qas-filters :entity="entity" search-placeholder="Pesquisar por nome do usuário" :use-update-route="false" @update="onFilterUpdate" />
+    <qas-filters v-model:current-filters="currentFilters" :entity="entity" search-placeholder="Pesquisar por nome do usuário" :use-update-route="false" />
   </div>
 </template>
 
 <script>
 export default {
+  data () {
+    return {
+      currentFilters: {}
+    }
+  },
+
   computed: {
     entity () {
       return 'users'
     }
   },
 
-  methods: {
-    onFilterUpdate (query) {
+  watch: {
+    currentFilters (query) {
       // console.log(query)
     }
   }

--- a/docs/src/examples/QasFilters/NoRouteUpdate.vue
+++ b/docs/src/examples/QasFilters/NoRouteUpdate.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="container spaced">
+    <qas-filters :entity="entity" search-placeholder="Pesquisar por nome do usuário" :use-update-route="false" @clear="onClear" @filter="onFilter" />
+  </div>
+</template>
+
+<script>
+export default {
+  computed: {
+    entity () {
+      return 'users'
+    }
+  },
+
+  methods: {
+    onFilter (query) {
+      console.log(query)
+    },
+
+    onClear (query) {
+      console.log(query)
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QasFilters/NoRouteUpdate.vue
+++ b/docs/src/examples/QasFilters/NoRouteUpdate.vue
@@ -1,20 +1,20 @@
 <template>
   <div class="container spaced">
-    <qas-filters :entity="entity" :use-update-route="false" @update:current-filters="onUpdateCurrentFilters" />
+    <qas-filters v-model:currentFilters="currentFilters" :entity="entity" :use-update-route="false" />
   </div>
 </template>
 
 <script>
 export default {
-  computed: {
-    entity () {
-      return 'users'
+  data () {
+    return {
+      currentFilters: {}
     }
   },
 
-  methods: {
-    onUpdateCurrentFilters (query) {
-      // console.log(query)
+  computed: {
+    entity () {
+      return 'users'
     }
   }
 }

--- a/docs/src/examples/QasFilters/NoRouteUpdate.vue
+++ b/docs/src/examples/QasFilters/NoRouteUpdate.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container spaced">
-    <qas-filters :entity="entity" search-placeholder="Pesquisar por nome do usuário" :use-update-route="false" @clear="onClear" @filter="onFilter" />
+    <qas-filters :entity="entity" search-placeholder="Pesquisar por nome do usuário" :use-update-route="false" @update="onFilterUpdate" />
   </div>
 </template>
 
@@ -13,11 +13,7 @@ export default {
   },
 
   methods: {
-    onFilter (query) {
-      console.log(query)
-    },
-
-    onClear (query) {
+    onFilterUpdate (query) {
       console.log(query)
     }
   }

--- a/docs/src/examples/QasFilters/NoSearch.vue
+++ b/docs/src/examples/QasFilters/NoSearch.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="container spaced">
+    <qas-filters :entity="entity" :use-search="false" :use-spacing="false" />
+  </div>
+</template>
+
+<script>
+export default {
+  computed: {
+    entity () {
+      return 'users'
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QasFilters/RightSide.vue
+++ b/docs/src/examples/QasFilters/RightSide.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="container spaced">
+    <qas-filters :entity="entity">
+      <template #right-side>
+        Seção direita
+      </template>
+    </qas-filters>
+  </div>
+</template>
+
+<script>
+export default {
+  computed: {
+    entity () {
+      return 'users'
+    }
+  }
+}
+</script>

--- a/docs/src/pages/components/filters.md
+++ b/docs/src/pages/components/filters.md
@@ -31,6 +31,8 @@ Normalmente este componente é utilizando junto ao `QasListView` para filtrar os
 
 <doc-example file="QasFilters/NoSearch" title="Sem o campo de busca" />
 
+<doc-example file="QasFilters/NoRouteUpdate" title="Não realizando a atualização padrão da rota" />
+
 <doc-example file="QasFilters/CustomFilter" title="Usando slot default com funções 'filter' e 'removeFilter'" />
 
 <doc-example file="QasFilters/CustomFilterButton" title="Usando slot filter-button com a função 'filter'" />

--- a/docs/src/pages/components/filters.md
+++ b/docs/src/pages/components/filters.md
@@ -31,6 +31,9 @@ Normalmente este componente é utilizando junto ao `QasListView` para filtrar os
 
 <doc-example file="QasFilters/NoSearch" title="Sem o campo de busca" />
 
+:::warning
+Ao utilizar a propriedade `:use-update-route="false"`, a leitura dos filtros assim como a escrita na rota não acontecerá.
+:::
 <doc-example file="QasFilters/NoRouteUpdate" title="Não realizando a atualização padrão da rota" />
 
 <doc-example file="QasFilters/CustomFilter" title="Usando slot default com funções 'filter' e 'removeFilter'" />

--- a/docs/src/pages/components/filters.md
+++ b/docs/src/pages/components/filters.md
@@ -29,5 +29,10 @@ Normalmente este componente é utilizando junto ao `QasListView` para filtrar os
 
 <doc-example file="QasFilters/CommonUsage" title="Normalmente utilizado" />
 
+<doc-example file="QasFilters/NoSearch" title="Sem o campo de busca" />
+
 <doc-example file="QasFilters/CustomFilter" title="Usando slot default com funções 'filter' e 'removeFilter'" />
 
+<doc-example file="QasFilters/CustomFilterButton" title="Usando slot filter-button com a função 'filter'" />
+
+<doc-example file="QasFilters/RightSide" title="Usando o slot right-side" />

--- a/ui/src/components/filters/QasFilters.vue
+++ b/ui/src/components/filters/QasFilters.vue
@@ -121,7 +121,7 @@ export default {
     }
   },
 
-  emits: ['fetch-success', 'fetch-error', 'update:current-filters'],
+  emits: ['fetch-success', 'fetch-error', 'update:currentFilters'],
 
   data () {
     return {
@@ -340,7 +340,7 @@ export default {
         ...(this.search && { search: this.search })
       }
 
-      this.$emit('update:current-filters', this.currentFilters)
+      this.$emit('update:currentFilters', this.currentFilters)
     },
 
     updateRouteQuery (query) {

--- a/ui/src/components/filters/QasFilters.vue
+++ b/ui/src/components/filters/QasFilters.vue
@@ -257,8 +257,7 @@ export default {
       }
 
       this.setCurrentFilters()
-
-      this.useUpdateRoute && this.$router.push({ query })
+      this.setQuery(query)
     },
 
     clearSearch () {
@@ -317,8 +316,7 @@ export default {
       }
 
       this.setCurrentFilters()
-
-      this.useUpdateRoute && this.$router.push({ query })
+      this.setQuery(query)
     },
 
     getChipValue (value) {
@@ -332,8 +330,7 @@ export default {
       delete this.filters[name]
 
       this.setCurrentFilters()
-
-      this.useUpdateRoute && this.$router.push({ query })
+      this.setQuery(query)
     },
 
     setCurrentFilters () {
@@ -343,6 +340,10 @@ export default {
       }
 
       this.$emit('update:current-filters', this.currentFilters)
+    },
+
+    setQuery (query) {
+      this.useUpdateRoute && this.$router.push({ query })
     },
 
     updateValues () {

--- a/ui/src/components/filters/QasFilters.vue
+++ b/ui/src/components/filters/QasFilters.vue
@@ -110,12 +110,12 @@ export default {
       type: Boolean
     },
 
-    useUpdateRoute: {
+    useSpacing: {
       default: true,
       type: Boolean
     },
 
-    useSpacing: {
+    useUpdateRoute: {
       default: true,
       type: Boolean
     }
@@ -183,6 +183,7 @@ export default {
         fields: this.fields,
         fieldsProps: this.fieldsProps,
         loading: this.isFetching,
+
         onClear: this.clearFilters,
         onFilter: () => this.filter()
       }
@@ -256,8 +257,8 @@ export default {
         this.filters = {}
       }
 
-      this.setCurrentFilters()
-      this.setQuery(query)
+      this.updateCurrentFilters()
+      this.updateRouteQuery(query)
     },
 
     clearSearch () {
@@ -315,8 +316,8 @@ export default {
         search: this.search || undefined
       }
 
-      this.setCurrentFilters()
-      this.setQuery(query)
+      this.updateCurrentFilters()
+      this.updateRouteQuery(query)
     },
 
     getChipValue (value) {
@@ -329,11 +330,11 @@ export default {
       delete query[name]
       delete this.filters[name]
 
-      this.setCurrentFilters()
-      this.setQuery(query)
+      this.updateCurrentFilters()
+      this.updateRouteQuery(query)
     },
 
-    setCurrentFilters () {
+    updateCurrentFilters () {
       this.currentFilters = {
         ...this.filters,
         ...(this.search && { search: this.search })
@@ -342,7 +343,7 @@ export default {
       this.$emit('update:current-filters', this.currentFilters)
     },
 
-    setQuery (query) {
+    updateRouteQuery (query) {
       this.useUpdateRoute && this.$router.push({ query })
     },
 
@@ -368,7 +369,7 @@ export default {
       const watchOnce = this.$watch('fields', values => {
         if (Object.keys(values).length) {
           this.updateValues()
-          this.setCurrentFilters()
+          this.updateCurrentFilters()
           watchOnce()
         }
       })

--- a/ui/src/components/filters/QasFilters.vue
+++ b/ui/src/components/filters/QasFilters.vue
@@ -121,7 +121,7 @@ export default {
     }
   },
 
-  emits: ['clear', 'fetch-success', 'fetch-error', 'filter'],
+  emits: ['fetch-success', 'fetch-error', 'update'],
 
   data () {
     return {
@@ -241,8 +241,8 @@ export default {
     clearFilters () {
       const { filters, ...query } = this.mx_context
       const allFilters = {
-        ...this.filters,
-        ...filters
+        ...filters,
+        ...this.filters
       }
 
       if (this.hasFields) {
@@ -261,7 +261,11 @@ export default {
         this.filters = {}
       }
 
-      this.$emit('clear', query)
+      this.$emit('update', {
+        ...query,
+        search: this.search || undefined
+      })
+
       this.useUpdateRoute && this.$router.push({ query })
     },
 
@@ -323,7 +327,8 @@ export default {
         search: this.search || undefined
       }
 
-      this.$emit('filter', query)
+      this.$emit('update', query)
+
       this.useUpdateRoute && this.$router.push({ query })
     },
 
@@ -337,7 +342,8 @@ export default {
       delete query[name]
       delete this.filters[name]
 
-      this.$emit('filter', query)
+      this.$emit('update', query)
+
       this.useUpdateRoute && this.$router.push({ query })
     },
 

--- a/ui/src/components/filters/QasFilters.vue
+++ b/ui/src/components/filters/QasFilters.vue
@@ -110,7 +110,7 @@ export default {
       type: Boolean
     },
 
-    useRouteUpdate: {
+    useUpdateRoute: {
       default: true,
       type: Boolean
     },
@@ -240,11 +240,15 @@ export default {
   methods: {
     clearFilters () {
       const { filters, ...query } = this.mx_context
+      const allFilters = {
+        ...this.filters,
+        ...filters
+      }
 
       if (this.hasFields) {
         const fields = Object.keys(this.fields)
 
-        for (const key in filters) {
+        for (const key in allFilters) {
           const camelizedKey = camelize(key)
           const hasField = fields.includes(camelizedKey)
 
@@ -258,12 +262,15 @@ export default {
       }
 
       this.$emit('clear', query)
-      this.useRouteUpdate && this.$router.push({ query })
+      this.useUpdateRoute && this.$router.push({ query })
     },
 
     clearSearch () {
       this.search = ''
-      this.filter()
+
+      if (!this.debounce) {
+        this.filter()
+      }
     },
 
     async fetchFilters () {
@@ -317,7 +324,7 @@ export default {
       }
 
       this.$emit('filter', query)
-      this.useRouteUpdate && this.$router.push({ query })
+      this.useUpdateRoute && this.$router.push({ query })
     },
 
     getChipValue (value) {
@@ -331,7 +338,7 @@ export default {
       delete this.filters[name]
 
       this.$emit('filter', query)
-      this.useRouteUpdate && this.$router.push({ query })
+      this.useUpdateRoute && this.$router.push({ query })
     },
 
     updateValues () {

--- a/ui/src/components/filters/QasFilters.yml
+++ b/ui/src/components/filters/QasFilters.yml
@@ -63,16 +63,16 @@ slots:
     desc: Slot para acessar o final do componente.
     scope:
       filter:
-        desc: Função usada para realizar o filtro
+        desc: Função usada para realizar o filtro.
         type: Function
 
       filters:
-        desc: Objeto que retorna os filtros ativos
+        desc: Objeto que retorna os filtros ativos.
         default: {}
         type: Object
 
       remove-filter:
-        desc: Função usada para remover os filtro
+        desc: Função usada para remover os filtro.
         type: Function
         examples: ["removeFilter({ name: '[nome-do-filtro]' })"]
 
@@ -85,16 +85,16 @@ slots:
     desc: Slot para seção do botão de filtro.
     scope:
       filter:
-        desc: Função usada para realizar o filtro
+        desc: Função usada para realizar o filtro.
         type: Function
 
       filters:
-        desc: Objeto que retorna os filtros ativos
+        desc: Objeto que retorna os filtros ativos.
         default: {}
         type: Object
 
       remove-filter:
-        desc: Função usada para remover os filtro
+        desc: Função usada para remover os filtro.
         type: Function
         examples: ["removeFilter({ name: '[nome-do-filtro]' })"]
 
@@ -110,7 +110,7 @@ slots:
     desc: Slot para seção do campo de busca.
     scope:
       filter:
-        desc: função usada para realizar o filtro
+        desc: função usada para realizar o filtro.
         type: Function
 
 events:

--- a/ui/src/components/filters/QasFilters.yml
+++ b/ui/src/components/filters/QasFilters.yml
@@ -4,6 +4,13 @@ meta:
   desc: Componente para criação de filtros dinâmicos.
 
 props:
+  current-filters:
+    model: true
+    desc: Model utilizado para recuperar os filtros realizados pelo componente.
+    default: {}
+    type: Object
+    examples: [v-model:current-filters="currentFilters"]
+
   entity:
     desc: Entidade da store, por exemplo se tiver que trabalhar com modulo de usuários, teremos o model "users" na store, que vai ser nossa "entity".
     required: true
@@ -128,7 +135,7 @@ events:
         desc: Retorna todos os dados "cru" respondido na exceção do fetch.
         type: Object
 
-  '@update -> function(value)':
+  '@update:current-filters -> function(value)':
     desc: Dispara quando é realizado ou removido uma pesquisa no campo de busca e quando é clicado no botão "Filtrar" ou "Limpar" do filtro.
     params:
       value:

--- a/ui/src/components/filters/QasFilters.yml
+++ b/ui/src/components/filters/QasFilters.yml
@@ -128,7 +128,7 @@ events:
         desc: Retorna todos os dados "cru" respondido na exceção do fetch.
         type: Object
 
-  '@update:current-filters -> function(value)':
+  '@update:currentFilters -> function(value)':
     desc: Dispara quando é realizado ou removido uma pesquisa no campo de busca e quando é clicado no botão "Filtrar" ou "Limpar" do filtro.
     params:
       value:

--- a/ui/src/components/filters/QasFilters.yml
+++ b/ui/src/components/filters/QasFilters.yml
@@ -127,3 +127,10 @@ events:
       value:
         desc: Retorna todos os dados "cru" respondido na exceção do fetch.
         type: Object
+
+  '@update -> function(value)':
+    desc: Dispara quando é realizado ou removido uma pesquisa no campo de busca e quando é clicado no botão "Filtrar" ou "Limpar" do filtro.
+    params:
+      value:
+        desc: Retorna todos os filtros realizados.
+        type: Object

--- a/ui/src/components/filters/QasFilters.yml
+++ b/ui/src/components/filters/QasFilters.yml
@@ -4,13 +4,6 @@ meta:
   desc: Componente para criação de filtros dinâmicos.
 
 props:
-  current-filters:
-    model: true
-    desc: Model utilizado para recuperar os filtros realizados pelo componente.
-    default: {}
-    type: Object
-    examples: [v-model:current-filters="currentFilters"]
-
   entity:
     desc: Entidade da store, por exemplo se tiver que trabalhar com modulo de usuários, teremos o model "users" na store, que vai ser nossa "entity".
     required: true

--- a/ui/src/components/filters/QasFilters.yml
+++ b/ui/src/components/filters/QasFilters.yml
@@ -24,7 +24,7 @@ props:
     desc: Envia como parâmetro para a action "fetchFilters" do modulo correspondente a "entity".
     type: String
 
-  use-badges:
+  use-chip:
     desc: Habilita ou não os "chips" mostrando os filtros ativos.
     default: true
     type: Boolean
@@ -38,6 +38,11 @@ props:
     desc: Força refazer o "fetch" mesmo caso já exista dados na store de filters.
     type: Boolean
 
+  use-route-update:
+    desc: Habilita ou não a atualização da rota com base nos filtros.
+    default: true
+    type: Boolean
+
   use-search-on-type:
     desc: Habilita ou não o filtro de busca sempre que o usuário digita.
     default: true
@@ -48,19 +53,17 @@ props:
     default: true
     type: Boolean
 
-slots:
-  search:
-    desc: Slot para seção do campo de busca.
-    scope:
-      filter:
-        desc: função usada para fazer o filtro
-        type: Function
+  use-spacing:
+    desc: Habilita ou não o espaçamento padrão do componente.
+    default: true
+    type: Boolean
 
+slots:
   default:
     desc: Slot para acessar o final do componente.
     scope:
       filter:
-        desc: Função usada para fazer o filtro
+        desc: Função usada para realizar o filtro
         type: Function
 
       filters:
@@ -77,6 +80,38 @@ slots:
         desc: Contexto referente a query da url.
         default: { filters: {}, page: 1 }
         type: Object
+
+  filter-button:
+    desc: Slot para seção do botão de filtro.
+    scope:
+      filter:
+        desc: Função usada para realizar o filtro
+        type: Function
+
+      filters:
+        desc: Objeto que retorna os filtros ativos
+        default: {}
+        type: Object
+
+      remove-filter:
+        desc: Função usada para remover os filtro
+        type: Function
+        examples: ["removeFilter({ name: '[nome-do-filtro]' })"]
+
+      context:
+        desc: Contexto referente a query da url.
+        default: { filters: {}, page: 1 }
+        type: Object
+
+  right-side:
+    desc: Slot para a seção na lateral direita.
+
+  search:
+    desc: Slot para seção do campo de busca.
+    scope:
+      filter:
+        desc: função usada para realizar o filtro
+        type: Function
 
 events:
   '@fetch-success -> function(value)':

--- a/ui/src/components/filters/QasFilters.yml
+++ b/ui/src/components/filters/QasFilters.yml
@@ -38,7 +38,7 @@ props:
     desc: Força refazer o "fetch" mesmo caso já exista dados na store de filters.
     type: Boolean
 
-  use-route-update:
+  use-update-route:
     desc: Habilita ou não a atualização da rota com base nos filtros.
     default: true
     type: Boolean

--- a/ui/src/components/filters/private/PvFiltersButton.vue
+++ b/ui/src/components/filters/private/PvFiltersButton.vue
@@ -1,0 +1,88 @@
+<template>
+  <qas-btn :color="color" data-cy="filters-btn" icon="sym_r_tune" variant="tertiary">
+    <q-menu anchor="center right" class="full-width" max-width="270px" self="top right">
+      <div v-if="loading" class="q-pa-xl text-center">
+        <q-spinner color="grey" size="2em" />
+      </div>
+
+      <div v-else-if="error" class="q-pa-xl text-center">
+        <q-icon color="negative" name="sym_r_warning" size="2em" />
+      </div>
+
+      <q-form v-else class="q-gutter-y-md q-pa-md" @submit.prevent="$emit('filter')">
+        <div v-for="(field, index) in fields" :key="index">
+          <qas-field v-model="filters[field.name]" :data-cy="`filters-${field.name}-field`" :field="field" v-bind="fieldsProps[field.name]" />
+        </div>
+
+        <div class="q-col-gutter-x-md q-mt-xl row">
+          <div class="col-6">
+            <qas-btn class="full-width" data-cy="filters-clear-btn" label="Limpar" variant="secondary" @click="$emit('clear')" />
+          </div>
+
+          <div class="col-6">
+            <qas-btn class="full-width" data-cy="filters-submit-btn" label="Filtrar" type="submit" variant="primary" />
+          </div>
+        </div>
+      </q-form>
+    </q-menu>
+  </qas-btn>
+</template>
+
+<script>
+import QasField from '../../field/QasField.vue'
+import QasBtn from '../../btn/QasBtn.vue'
+
+export default {
+  name: 'PvFiltersButton',
+
+  components: {
+    QasField,
+    QasBtn
+  },
+
+  props: {
+    color: {
+      type: String,
+      default: 'grey-9',
+      validator: value => ['grey-9', 'primary', 'white'].includes(value)
+    },
+
+    error: {
+      type: Boolean
+    },
+
+    fields: {
+      default: () => ({}),
+      type: Object
+    },
+
+    fieldsProps: {
+      default: () => ({}),
+      type: Object
+    },
+
+    loading: {
+      type: Boolean
+    },
+
+    modelValue: {
+      default: () => ({}),
+      type: Object
+    }
+  },
+
+  emits: ['clear', 'filter', 'update:modelValue'],
+
+  computed: {
+    filters: {
+      get () {
+        return this.modelValue
+      },
+
+      set (value) {
+        return this.$emit('update:modelValue', value)
+      }
+    }
+  }
+}
+</script>

--- a/ui/src/components/filters/private/PvFiltersButton.vue
+++ b/ui/src/components/filters/private/PvFiltersButton.vue
@@ -14,30 +14,31 @@
           <qas-field v-model="filters[field.name]" :data-cy="`filters-${field.name}-field`" :field="field" v-bind="fieldsProps[field.name]" />
         </div>
 
-        <div class="q-col-gutter-x-md q-mt-xl row">
-          <div class="col-6">
-            <qas-btn class="full-width" data-cy="filters-clear-btn" label="Limpar" variant="secondary" @click="$emit('clear')" />
-          </div>
-
-          <div class="col-6">
+        <qas-actions gutter="sm" use-equal-width>
+          <template #primary>
             <qas-btn class="full-width" data-cy="filters-submit-btn" label="Filtrar" type="submit" variant="primary" />
-          </div>
-        </div>
+          </template>
+          <template #secondary>
+            <qas-btn class="full-width" data-cy="filters-clear-btn" label="Limpar" variant="secondary" @click="$emit('clear')" />
+          </template>
+        </qas-actions>
       </q-form>
     </q-menu>
   </qas-btn>
 </template>
 
 <script>
-import QasField from '../../field/QasField.vue'
+import QasActions from '../../actions/QasActions.vue'
 import QasBtn from '../../btn/QasBtn.vue'
+import QasField from '../../field/QasField.vue'
 
 export default {
   name: 'PvFiltersButton',
 
   components: {
-    QasField,
-    QasBtn
+    QasActions,
+    QasBtn,
+    QasField
   },
 
   props: {


### PR DESCRIPTION

<!-- PULL REQUEST TEMPLATE -->

<!-- (Remova este texto de descrição.) -->
## Adicionado
- `QasFilters`: Adicionado slot `filter-button`.
- `QasFilters`: Adicionado documentação para o slot `right-side`.
- `QasFilters`: Adicionado propriedade `use-spacing` com o valor default `true` para habilitar ou não o espaçamento padrão do componente.
- `QasFilters`: Adicionado propriedade `use-update-route` com o valor default `true` para habilitar ou não a atualização da rota com base nos filtros.
- `QasFilters`: Adicionado evento `@update:current-filters` que dispara sempre que é realizada alguma atualização no filtro.

## Corrigido
- `QasFilters`: corrigido problema onde não era possível ter o botão de filtro sem o campo de busca.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
