### PR TITLE
Added prop useAutoRefetchOnDelete in QasListView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasListView`: adicionado propriedade `useAutoRefetchOnDelete` para controlar se o componente vai fazer o fetch novamente quando acontecer algum delete compatível com a listagem.
+
 ## [3.8.0-beta.7] - 11-04-2023
 ### Corrigido
 - `QasAppMenu`: Corrigido separator que não estava aparecendo de uma forma correta, adicionado pelo componente `QSeparator` ao invés de css.

--- a/docs/src/examples/QasListView/CommonUsage.vue
+++ b/docs/src/examples/QasListView/CommonUsage.vue
@@ -1,5 +1,5 @@
 <template>
-  <qas-list-view v-model:fields="fields" v-model:results="results" :entity="entity">
+  <qas-list-view v-model:fields="fields" v-model:results="results" :entity="entity" use-auto-handle-on-delete>
     <template #header>
       <qas-page-header title="Lista de materiais" :use-breadcrumbs="false">
         <qas-btn icon="sym_r_add" label="Novo [item]" />

--- a/docs/src/examples/QasListView/ExAutoRefetchOnDelete.vue
+++ b/docs/src/examples/QasListView/ExAutoRefetchOnDelete.vue
@@ -1,0 +1,52 @@
+<template>
+  <qas-list-view v-model:fields="fields" v-model:results="results" :entity="entity" use-auto-refetch-on-delete>
+    <template #header>
+      <qas-page-header title="Lista de materiais" :use-breadcrumbs="false">
+        <qas-btn icon="sym_r_add" label="Novo [item]" />
+      </qas-page-header>
+    </template>
+
+    <template #default>
+      <qas-table-generator :columns="columns" :fields="fields" :results="results" row-key="uuid">
+        <template #body-cell-isActive="{ row }">
+          <div class="text-weight-bold">{{ row.isActive }}</div>
+        </template>
+        <template #body-cell-actions="{ row }">
+          <div class="flex justify-end no-wrap q-gutter-x-sm">
+            <qas-btn icon="sym_r_edit" />
+            <qas-delete :custom-id="row.uuid" entity="users" icon="sym_r_delete" />
+          </div>
+        </template>
+      </qas-table-generator>
+    </template>
+  </qas-list-view>
+</template>
+
+<script>
+export default {
+  name: 'UsersList',
+
+  data () {
+    return {
+      fields: {},
+      errors: {},
+      results: [],
+      metadata: {}
+    }
+  },
+
+  computed: {
+    entity () {
+      return 'users'
+    },
+
+    columns () {
+      return [
+        'isActive',
+        'name',
+        { align: 'right', name: 'actions' }
+      ]
+    }
+  }
+}
+</script>

--- a/docs/src/pages/components/list-view.md
+++ b/docs/src/pages/components/list-view.md
@@ -60,3 +60,4 @@ Agora ao fazer o fetch, o valor da url enviada para a action do fetchList será 
 :::
 
 <doc-example file="QasListView/BeforeFetch" title="Controlando fetch" />
+<doc-example file="QasListView/ExAutoRefetchOnDelete" title="Controle de refetch ao deletar automático" />

--- a/docs/src/pages/components/list-view.md
+++ b/docs/src/pages/components/list-view.md
@@ -6,23 +6,25 @@ Componente para C.R.U.D. responsável pela parte de listagem (Read).
 
 <doc-api file="list-view/QasListView" name="QasListView" />
 
-:::warning
-Quando utilizar deleção de itens na listagem, lembre-se de utilizar a propriedade `use-auto-handle-on-delete`.
+:::info
+- Quando utilizar deleção de itens na listagem, lembre-se de utilizar a propriedade `use-auto-handle-on-delete` ou `use-auto-refetch-on-delete`.
+- A diferença do `use-auto-refetch-on-delete` para o `use-auto-handle-on-delete` é que ela não usa nenhuma validação referente a quantidade de itens e paginação, ela faz com que o componente **sempre** faça um novo fetch ao identificar que um item da listagem foi deletado.
 :::
 
-:::warning
-Este componente depende do `Vuex`, utiliza módulos com actions, state e getters para manipular/recuperar os dados. Por exemplo, para você utilizar em uma entidade de listagem de usuários, você **deve** ter um modulo de `users` e dentro de dele ter os seguinte requisitos:
+:::info
+Este componente depende do `Vuex` ou `Pinia`, utiliza módulos com actions e state para manipular/recuperar os dados. Por exemplo, para você utilizar em uma entidade de listagem de usuários, você **deve** ter um modulo de `users` e dentro de dele ter os seguinte requisitos:
 - state: list e totalPages.
-- getters: list e totalPages.
 - actions: fetchList (que vai popular o state de list e totalPages).
 
-Hoje Utilizamos 2 bibliotecas com propósitos diferentes que são compatíveis com o asteroid para lidar com o Vuex, elas são:
-[VuexStoreModule](https://github.com/bildvitta/vuex-store-module) e [VuexOffline](https://github.com/bildvitta/vuex-offline).
+Hoje Utilizamos 3 bibliotecas com propósitos diferentes que são compatíveis com o asteroid para lidar com o Vuex, elas são:
+- [StoreModule](https://github.com/bildvitta/store-module) (recomendado)
+- [VuexStoreModule](https://github.com/bildvitta/vuex-store-module)
+- [VuexOffline](https://github.com/bildvitta/vuex-offline).
 
 Para fazer esses exemplos na documentação, estamos utilizando o `VuexOffline`, para saber mais, veja o código fonte da documentação.
 :::
 
-:::tip
+:::info
 Este componente serve para lidar com **listagem**, se você precisar de um componente para lidar com um item unitário, como por exemplo, um único usuário, use o componente `QasSingleView`.
 :::
 
@@ -37,7 +39,7 @@ Para usar `QasFilters` você não precisa fazer nada! Porém, em alguns casos, v
 
 <doc-example file="QasListView/CustomFilter" title="Com filtro customizado" />
 
-:::tip
+:::info
 O callback do `beforeFetch` recebe 2 parâmetros, `:before-submit="onBeforeSubmit({ payload, resolve, done })"`
 
 ##### payload: `Object` -> { id, payload, url }

--- a/ui/src/components/list-view/QasListView.vue
+++ b/ui/src/components/list-view/QasListView.vue
@@ -70,6 +70,10 @@ export default {
       type: Boolean
     },
 
+    useAutoRefetchOnDelete: {
+      type: Boolean
+    },
+
     useRefresh: {
       default: true,
       type: Boolean
@@ -100,6 +104,10 @@ export default {
   },
 
   computed: {
+    hasDeleteEventListener () {
+      return this.useAutoHandleOnDelete || this.useAutoRefetchOnDelete
+    },
+
     hasHeaderSlot () {
       return !!this.$slots.header
     },
@@ -153,13 +161,13 @@ export default {
   },
 
   mounted () {
-    if (!this.useAutoHandleOnDelete) return
+    if (!this.hasDeleteEventListener) return
 
     window.addEventListener('delete-success', this.onDeleteResult)
   },
 
   unmounted () {
-    if (!this.useAutoHandleOnDelete) return
+    if (!this.hasDeleteEventListener) return
 
     window.removeEventListener('delete-success', this.onDeleteResult)
   },
@@ -235,7 +243,7 @@ export default {
       this.page = parseInt(this.$route.query.page || 1)
     },
 
-    onDeleteResult ({ detail: { entity } }) {
+    onAutoHandleDelete ({ detail: { entity } }) {
       const { page } = this.mx_context
 
       /*
@@ -269,6 +277,15 @@ export default {
       * ex: estou na pagina 2 e existem 3 paginas, removo um item da pagina 2, então chamo o método fetchList
       */
       this.mx_fetchHandler({ ...this.mx_context, url: this.url }, this.fetchList)
+    },
+
+    onDeleteResult (event) {
+      if (this.useAutoRefetchOnDelete) {
+        this.mx_fetchHandler({ ...this.mx_context, url: this.url }, this.fetchList)
+        return
+      }
+
+      this.onAutoHandleDelete(event)
     }
   }
 }

--- a/ui/src/components/list-view/QasListView.yml
+++ b/ui/src/components/list-view/QasListView.yml
@@ -62,6 +62,10 @@ props:
     desc: Controla se o componente vai lidar automaticamente quando acontecer algum delete compatível com a listagem.
     type: Boolean
 
+  use-auto-refetch-on-delete:
+    desc: Controla se o componente vai fazer o fetch novamente quando acontecer algum delete compatível com a listagem.
+    type: Boolean
+
   use-boundary:
     desc: Controla o limite que o FormView terá, quando é "false", a tag pai deixa de ser um "QPage" para ser uma "div" e é removido as classes "container" e "spaced", comumente utilizando quando precisa usar o QasFormView dentro de um dialog.
     default: true


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Adicionado
- `QasListView`: adicionado propriedade `useAutoRefetchOnDelete` para controlar se o componente vai fazer o fetch novamente quando acontecer algum delete compatível com a listagem.

clickup: https://app.clickup.com/t/864dvnux9

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
