### PR TITLE
Change copy message on copyToClipboard / QasCopy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `copyToClipboard`: modificado helper, agora no notify aparece sempre uma mensagem genérica "Item copiado com sucesso." ao invés do texto copiado anteriormente (isto impacta diretamente no componente `QasCopy`).
+
 ## [3.8.0-beta.7] - 11-04-2023
 ### Corrigido
 - `QasAppMenu`: Corrigido separator que não estava aparecendo de uma forma correta, adicionado pelo componente `QSeparator` ao invés de css.

--- a/docs/src/examples/QasCopy/Basic.vue
+++ b/docs/src/examples/QasCopy/Basic.vue
@@ -1,5 +1,5 @@
 <template>
   <div class="container q-py-lg">
-    <qas-copy text="Este texto vai ser copiado" />
+    <qas-copy text="Este texto muito muuuuuuuito mas muuuuuuiito grande mesmo vai ser copiado" />
   </div>
 </template>

--- a/docs/src/examples/QasCopy/Basic.vue
+++ b/docs/src/examples/QasCopy/Basic.vue
@@ -1,5 +1,5 @@
 <template>
   <div class="container q-py-lg">
-    <qas-copy text="Este texto muito muuuuuuuito mas muuuuuuiito grande mesmo vai ser copiado" />
+    <qas-copy text="Este texto vai ser copiado" />
   </div>
 </template>

--- a/ui/src/helpers/copy-to-clipboard.js
+++ b/ui/src/helpers/copy-to-clipboard.js
@@ -6,9 +6,9 @@ export default async (text, onLoading = () => {}) => {
 
   try {
     await copyToClipboard(text)
-    NotifySuccess('Copiado!', text)
+    NotifySuccess('Item copiado com sucesso.')
   } catch {
-    NotifyError('Não foi possível copiar.', text)
+    NotifyError('Não foi possível copiar o item.')
   } finally {
     setTimeout(() => { onLoading(false) }, 500)
   }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Modificado
- `copyToClipboard`: modificado helper, agora no notify aparece sempre uma mensagem genérica "Item copiado com sucesso." ao invés do texto copiado anteriormente (isto impacta diretamente no componente `QasCopy`).

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [ ] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [x] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
