### PR TITLE
Changes in QasAppUser / QasAppMenu / QasAppBar / QasListView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
+## BREAKING CHANGES
+- [`QasAppMenu`, `QasAppBar`]: removido propriedade `user` em favor da nova propriedade `appUserProps`.
+- `QasAppBar`: removido escopo `user` do slot `user`, uma vez que já temos essa informação fora do componente.
+
 ### Adicionado
 - `QasAppUser`: adicionado propriedade `currentCompany` para setar empresa atual vinculada.
 - `QasAppUser`: adicionado propriedade `companiesOptions` para enviar opções de possíveis empresas para troca de vínculo.
@@ -21,8 +25,6 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - [`QasAppMenu`, `QasAppBar`]: removido propriedade `user` em favor da nova propriedade `appUserProps`.
 - `QasAppBar`: removido escopo `user` do slot `user`, uma vez que já temos essa informação fora do componente.
 
-### Modificado
-- `QasAppMenu`: 
 ## [3.9.0-beta.0] - 14-04-2023
 ## BREAKING CHANGES
 - `QasGallery`: removido slot `destroy` para dar lugar aos slots do `QasGalleryCard`, olhar documentação.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasAppUser`: adicionado propriedade `currentCompany` para setar empresa atual vinculada.
+- `QasAppUser`: adicionado propriedade `companiesOptions` para enviar opções de possíveis empresas para troca de vínculo.
+- `QasAppUser`: adicionado recurso para troca de vínculo de empresa.
+- [`QasAppMenu`, `QasAppBar`]: adicionado propriedade `appUserProps` para repassar todas props do `QasAppUser`.
+
+### Removido
+- [`QasAppMenu`, `QasAppBar`]: removido propriedade `user` em favor da nova propriedade `appUserProps`.
+- `QasAppBar`: removido escopo `user` do slot `user`, uma vez que já temos essa informação fora do componente.
+
+### Modificado
+- `QasAppMenu`: 
 ## [3.9.0-beta.0] - 14-04-2023
 ## BREAKING CHANGES
 - `QasGallery`: removido slot `destroy` para dar lugar aos slots do `QasGalleryCard`, olhar documentação.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasAppUser`: adicionado propriedade `companiesOptions` para enviar opções de possíveis empresas para troca de vínculo.
 - `QasAppUser`: adicionado recurso para troca de vínculo de empresa.
 - [`QasAppMenu`, `QasAppBar`]: adicionado propriedade `appUserProps` para repassar todas props do `QasAppUser`.
+- `QasListView`: adicionado nova propriedade `usePagination` para controlar paginação com default `true`.
 
 ### Removido
 - [`QasAppMenu`, `QasAppBar`]: removido propriedade `user` em favor da nova propriedade `appUserProps`.

--- a/docs/src/examples/QasAppBar/Basic.vue
+++ b/docs/src/examples/QasAppBar/Basic.vue
@@ -1,6 +1,6 @@
 <template>
   <q-layout>
-    <qas-app-bar title="QasAppBar" :user="user" />
+    <qas-app-bar :app-user-props="appUserProps" title="QasAppBar" />
   </q-layout>
 </template>
 
@@ -13,8 +13,22 @@ const user = {
 
 export default {
   computed: {
-    user () {
-      return user
+    appUserProps () {
+      return {
+        companiesOptions: [
+          {
+            label: 'Empresa 1',
+            value: '1'
+          },
+          {
+            label: 'Empresa 2',
+            value: '2'
+          }
+        ],
+
+        currentCompany: '1',
+        user
+      }
     }
   }
 }

--- a/docs/src/examples/QasAppMenu/Basic.vue
+++ b/docs/src/examples/QasAppMenu/Basic.vue
@@ -61,7 +61,21 @@ export default {
         brand: 'https://placehold.co/208x40',
         miniBrand: 'https://placehold.co/40x40',
         modules,
-        user,
+        appUserProps: {
+          companiesOptions: [
+            {
+              label: 'Empresa 1',
+              value: '1'
+            },
+            {
+              label: 'Empresa 2',
+              value: '2'
+            }
+          ],
+
+          currentCompany: '1',
+          user
+        },
         title: 'Documentação',
 
         items: [

--- a/docs/src/examples/QasAppUser/Basic.vue
+++ b/docs/src/examples/QasAppUser/Basic.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="q-pa-md">
-    <qas-app-user :user="user" />
+    <qas-app-user :companies-options="[{ label: 'Opção', value: '1' }, { label: 'Opção 2', value: '2' }]" current-company="1" :user="user" />
   </div>
 </template>
 
@@ -15,6 +15,12 @@ export default {
   computed: {
     user () {
       return user
+    }
+  },
+
+  methods: {
+    onBoundFn (value) {
+      console.log(value, '>>>> value do user')
     }
   }
 }

--- a/docs/src/examples/QasAppUser/Basic.vue
+++ b/docs/src/examples/QasAppUser/Basic.vue
@@ -16,12 +16,6 @@ export default {
     user () {
       return user
     }
-  },
-
-  methods: {
-    onBoundFn (value) {
-      console.log(value, '>>>> value do user')
-    }
   }
 }
 </script>

--- a/docs/src/examples/QasAppUser/Basic.vue
+++ b/docs/src/examples/QasAppUser/Basic.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="q-pa-md">
-    <qas-app-user :companies-options="[{ label: 'Opção', value: '1' }, { label: 'Opção 2', value: '2' }]" current-company="1" :user="user" />
+    <qas-app-user v-bind="props" />
   </div>
 </template>
 
@@ -13,8 +13,21 @@ const user = {
 
 export default {
   computed: {
-    user () {
-      return user
+    props () {
+      return {
+        user,
+        companiesOptions: [
+          {
+            label: 'Empresa 1',
+            value: '1'
+          },
+          {
+            label: 'Empresa 2',
+            value: '2'
+          }
+        ],
+        currentCompany: '1'
+      }
     }
   }
 }

--- a/docs/src/examples/QasLayout/Basic.vue
+++ b/docs/src/examples/QasLayout/Basic.vue
@@ -74,7 +74,21 @@ export default {
 
     appBarProps () {
       return {
-        user,
+        appUserProps: {
+          companiesOptions: [
+            {
+              label: 'Empresa 1',
+              value: '1'
+            },
+            {
+              label: 'Empresa 2',
+              value: '2'
+            }
+          ],
+
+          currentCompany: '1',
+          user
+        },
         title: 'QasLayout'
       }
     },

--- a/docs/src/pages/components/app-user.md
+++ b/docs/src/pages/components/app-user.md
@@ -7,7 +7,7 @@ Componente utilizado no `QasAppBar` e `QasAppMenu` para exibir o nome do usuári
 <doc-api file="app-user/QasAppUser" name="QasAppUser" />
 
 :::info
-A funcionalidade de troca de vínculo de empresa é ativada quando existe mais de 1 opção no na prop `companiesOptions`, é executado uma API com o seguinte endpoint:
+A funcionalidade de troca de vínculo de empresa é ativada quando existe mais de 1 opção na prop `companiesOptions`, é executado uma API com o seguinte endpoint:
 
 `PATCH -> users/me`
 

--- a/docs/src/pages/components/app-user.md
+++ b/docs/src/pages/components/app-user.md
@@ -6,6 +6,13 @@ Componente utilizado no `QasAppBar` e `QasAppMenu` para exibir o nome do usuári
 
 <doc-api file="app-user/QasAppUser" name="QasAppUser" />
 
+:::info
+A funcionalidade de troca de vínculo de empresa é ativada quando existe mais de 1 opção no na prop `companiesOptions`, é executado uma API com o seguinte endpoint:
+
+`PATCH -> users/me`
+
+Enviando para o body da requisição o novo `companies`.
+:::
 
 ## Uso
 <doc-example file="QasAppUser/Basic" title="Básico" />

--- a/ui/src/components/app-bar/QasAppBar.vue
+++ b/ui/src/components/app-bar/QasAppBar.vue
@@ -11,8 +11,8 @@
         </router-link>
       </q-toolbar-title>
 
-      <slot v-if="hasUser" name="user" :user="user">
-        <qas-app-user :menu-props="appUserMenuProps" :user="user" @sign-out="signOut" />
+      <slot v-if="hasUser" name="user">
+        <qas-app-user v-bind="defaultAppUserProps" />
       </slot>
     </q-toolbar>
   </q-header>
@@ -31,6 +31,12 @@ export default {
   },
 
   props: {
+    appUserProps: {
+      type: Object,
+      required: true,
+      default: () => ({})
+    },
+
     brand: {
       default: '',
       type: String
@@ -44,12 +50,6 @@ export default {
     title: {
       required: true,
       type: String
-    },
-
-    user: {
-      default: () => ({}),
-      require: true,
-      type: Object
     }
   },
 
@@ -67,6 +67,19 @@ export default {
         anchor: 'bottom end',
         offset: [0, 5],
         self: 'top end'
+      }
+    },
+
+    defaultAppUserProps () {
+      return {
+        menuProps: {
+          anchor: 'bottom end',
+          offset: [0, 5],
+          self: 'top end'
+        },
+
+        onSignOut: this.signOut,
+        ...this.appUserProps
       }
     },
 
@@ -92,7 +105,7 @@ export default {
     },
 
     hasUser () {
-      return !!Object.keys(this.user).length
+      return !!Object.keys(this.defaultAppUserProps.user || {}).length
     },
 
     rootRoute () {

--- a/ui/src/components/app-bar/QasAppBar.yml
+++ b/ui/src/components/app-bar/QasAppBar.yml
@@ -4,6 +4,12 @@ meta:
   desc: Gerencia a barra superior da aplicação
 
 props:
+  app-user-props:
+    desc: Props repassadas para o QasAppUser.
+    default: {}
+    type: Object
+    required: true
+
   brand:
     desc: Path do logotipo.
     type: String
@@ -17,20 +23,6 @@ props:
     desc: Título da aplicação.
     required: true
     type: String
-
-  user:
-    desc: Informações do usuário.
-    type: Object
-    default: {}
-    examples: [
-      "
-      {
-        photo: 'minha-img',
-        name: 'Eduardo Lima',
-        email: 'eduardolima@gmail.com'
-      }
-      "
-    ]
 
 slots:
   user:

--- a/ui/src/components/app-menu/QasAppMenu.vue
+++ b/ui/src/components/app-menu/QasAppMenu.vue
@@ -76,8 +76,8 @@
         </div>
 
         <!-- User -->
-        <div v-if="showUser" class="full-width q-pb-lg q-px-lg">
-          <qas-app-user v-bind="appUserProps" />
+        <div v-if="showAppUser" class="full-width q-pb-lg q-px-lg">
+          <qas-app-user v-bind="defaultAppUserProps" />
         </div>
       </div>
     </q-drawer>
@@ -102,6 +102,12 @@ export default {
   inheritAttrs: false,
 
   props: {
+    appUserProps: {
+      type: Object,
+      required: true,
+      default: () => ({})
+    },
+
     brand: {
       default: '',
       required: true,
@@ -137,12 +143,6 @@ export default {
     title: {
       default: '',
       type: String
-    },
-
-    user: {
-      default: () => ({}),
-      require: true,
-      type: Object
     }
   },
 
@@ -165,20 +165,6 @@ export default {
 
         currentModule: this.currentModelOption,
         modules: this.defaultModules
-      }
-    },
-
-    appUserProps () {
-      return {
-        avatarSize: '40px',
-        user: this.user,
-
-        menuProps: {
-          'onUpdate:modelValue': this.setHasOpenedMenu
-        },
-
-        // eventos
-        onSignOut: this.signOut
       }
     },
 
@@ -211,6 +197,20 @@ export default {
     currentModule () {
       const hostname = window.location.hostname
       return this.defaultModules.find(module => module?.value.includes(hostname))?.value
+    },
+
+    defaultAppUserProps () {
+      return {
+        avatarSize: '40px',
+
+        menuProps: {
+          'onUpdate:modelValue': this.setHasOpenedMenu
+        },
+
+        // eventos
+        onSignOut: this.signOut,
+        ...this.appUserProps
+      }
     },
 
     defaultModules () {
@@ -289,7 +289,7 @@ export default {
       return this.$router.hasRoute('Root') ? { name: 'Root' } : { path: '/' }
     },
 
-    showUser () {
+    showAppUser () {
       return this.hasUser && !this.isUntilLarge
     },
 
@@ -339,7 +339,7 @@ export default {
     },
 
     hasUser () {
-      return !!Object.keys(this.user).length
+      return !!Object.keys(this.defaultAppUserProps.user || {}).length
     },
 
     isActive ({ to }) {

--- a/ui/src/components/app-menu/QasAppMenu.yml
+++ b/ui/src/components/app-menu/QasAppMenu.yml
@@ -4,6 +4,12 @@ meta:
   desc: Menu lateral.
 
 props:
+  app-user-props:
+    desc: Props repassadas para o QasAppUser.
+    default: {}
+    type: Object
+    required: true
+
   brand:
     desc: Logotipo quando menu esta aberto.
     type: String
@@ -37,20 +43,6 @@ props:
   title:
     desc: Título que vai ficar no label do select de módulos.
     type: String
-
-  user:
-    desc: Informações do usuário.
-    type: Object
-    default: {}
-    examples: [
-      "
-      {
-        photo: 'minha-img',
-        name: 'Eduardo Lima',
-        email: 'eduardolima@gmail.com'
-      }
-      "
-    ]
 
 slots:
   user:

--- a/ui/src/components/app-user/QasAppUser.vue
+++ b/ui/src/components/app-user/QasAppUser.vue
@@ -138,8 +138,6 @@ export default {
       this.loading = true
 
       try {
-        // TODO remover
-        await new Promise(resolve => setTimeout(resolve, 2000))
         await this.$axios.patch('users/me', { companies: value })
 
         this.$qas.success('Vínculo alterado com sucesso.')

--- a/ui/src/components/app-user/QasAppUser.vue
+++ b/ui/src/components/app-user/QasAppUser.vue
@@ -17,6 +17,8 @@
         <div class="ellipsis qas-app-user__menu-name">{{ userName }}</div>
         <div class="ellipsis">{{ user.email }}</div>
 
+        <qas-select v-if="hasCompaniesSelect" v-model="companiesModel" class="q-my-md" label="Vínculo" :loading="loading" :options="companiesOptions" @update:model-value="setCompanies" />
+
         <q-list class="q-mt-md">
           <q-item v-close-popup :active="false" class="qas-app-user__menu-item" clickable :to="user.to">
             <q-item-section avatar>
@@ -67,6 +69,16 @@ export default {
       type: String
     },
 
+    companiesOptions: {
+      type: Array,
+      default: () => []
+    },
+
+    currentCompany: {
+      type: String,
+      default: ''
+    },
+
     menuProps: {
       default: () => ({}),
       type: Object
@@ -86,6 +98,13 @@ export default {
 
   emits: ['sign-out'],
 
+  data () {
+    return {
+      companiesModel: '',
+      loading: false
+    }
+  },
+
   computed: {
     hasNotifications () {
       return !!Object.keys(this.notifications).length
@@ -93,12 +112,45 @@ export default {
 
     userName () {
       return this.user.name || this.user.givenName
+    },
+
+    hasCompaniesSelect () {
+      return this.companiesOptions.length > 1
+    }
+  },
+
+  watch: {
+    currentCompany: {
+      handler (value) {
+        this.companiesModel = value
+      },
+
+      immediate: true
     }
   },
 
   methods: {
     signOut () {
       this.$emit('sign-out')
+    },
+
+    async setCompanies (value) {
+      this.loading = true
+
+      try {
+        // TODO remover
+        await new Promise(resolve => setTimeout(resolve, 2000))
+        await this.$axios.patch('users/me', { companies: value })
+
+        this.$qas.success('Vínculo alterado com sucesso.')
+
+        setTimeout(() => location.reload(), 1500)
+      } catch {
+        this.companiesModel = this.currentCompany
+        this.$qas.error('Falha ao alterar vínculo.')
+      } finally {
+        this.loading = false
+      }
     }
   }
 }

--- a/ui/src/components/app-user/QasAppUser.yml
+++ b/ui/src/components/app-user/QasAppUser.yml
@@ -4,6 +4,26 @@ meta:
   desc: Exibe o avatar e o nome do usuário, ao clicar abre um menu com as opções.
 
 props:
+  avatar-size:
+    desc: Define o tamanho do avatar.
+    default: 36px
+    type: String
+
+  companies-options:
+    desc: Opções para o select de vínculo de empresas.
+    default: []
+    type: Array
+
+  current-company:
+    desc: Empresa atual vinculada
+    default: ''
+    type: String
+
+  menu-props:
+    desc: Repassa props pro QMenu.
+    default: {}
+    type: Object
+
   notifications:
     desc: Lista com as notificações do usuário.
     type: Object

--- a/ui/src/components/list-view/QasListView.vue
+++ b/ui/src/components/list-view/QasListView.vue
@@ -74,12 +74,17 @@ export default {
       type: Boolean
     },
 
-    useRefresh: {
+    useFilter: {
       default: true,
       type: Boolean
     },
 
-    useFilter: {
+    usePagination: {
+      default: true,
+      type: Boolean
+    },
+
+    useRefresh: {
       default: true,
       type: Boolean
     },
@@ -113,7 +118,7 @@ export default {
     },
 
     hasPages () {
-      return this.totalPages > 1
+      return this.totalPages > 1 && this.usePagination
     },
 
     hasResults () {

--- a/ui/src/components/list-view/QasListView.yml
+++ b/ui/src/components/list-view/QasListView.yml
@@ -76,6 +76,11 @@ props:
     default: true
     type: Boolean
 
+  use-pagination:
+    desc: Controla se vai ter ou não paginação.
+    default: true
+    type: Boolean
+
   use-refresh:
     desc: Controla o [pull-to-refresh](https://quasar.dev/vue-components/pull-to-refresh#basic).
     default: true


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
## BREAKING CHANGES
- [`QasAppMenu`, `QasAppBar`]: removido propriedade `user` em favor da nova propriedade `appUserProps`.
- `QasAppBar`: removido escopo `user` do slot `user`, uma vez que já temos essa informação fora do componente.

### Adicionado
- `QasAppUser`: adicionado propriedade `currentCompany` para setar empresa atual vinculada.
- `QasAppUser`: adicionado propriedade `companiesOptions` para enviar opções de possíveis empresas para troca de vínculo.
- `QasAppUser`: adicionado recurso para troca de vínculo de empresa.
- [`QasAppMenu`, `QasAppBar`]: adicionado propriedade `appUserProps` para repassar todas props do `QasAppUser`.
- `QasListView`: adicionado nova propriedade `usePagination` para controlar paginação com default `true`.

### Removido
- [`QasAppMenu`, `QasAppBar`]: removido propriedade `user` em favor da nova propriedade `appUserProps`.
- `QasAppBar`: removido escopo `user` do slot `user`, uma vez que já temos essa informação fora do componente.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `main-homolog`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [x] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
