### PR TITLE
Releasing v3.9.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ Inclua uma pequena descrição explicando o motivo do _pull request_ e o número
 ## Versão do asteroid
 
 - [ ] v2 -> a partir da branch `v2`.
-- [ ] v3-beta.x -> a partir da branch `main-homolog`.
+- [ ] v3-beta.x -> a partir da branch `develop`.
 - [ ] v3-stable -> a partir da branch `main`.
 
 ## Tipo de alteração

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+## BREAKING CHANGES
+- [`QasAppMenu`, `QasAppBar`]: removido propriedade `user` em favor da nova propriedade `appUserProps`.
+- `QasAppBar`: removido escopo `user` do slot `user`, uma vez que já temos essa informação fora do componente.
+
+### Adicionado
+- `QasAppUser`: adicionado propriedade `currentCompany` para setar empresa atual vinculada.
+- `QasAppUser`: adicionado propriedade `companiesOptions` para enviar opções de possíveis empresas para troca de vínculo.
+- `QasAppUser`: adicionado recurso para troca de vínculo de empresa.
+- [`QasAppMenu`, `QasAppBar`]: adicionado propriedade `appUserProps` para repassar todas props do `QasAppUser`.
+- `QasListView`: adicionado nova propriedade `usePagination` para controlar paginação com default `true`.
+
+### Removido
+- [`QasAppMenu`, `QasAppBar`]: removido propriedade `user` em favor da nova propriedade `appUserProps`.
+- `QasAppBar`: removido escopo `user` do slot `user`, uma vez que já temos essa informação fora do componente.
+
 ## [3.9.0-beta.0] - 14-04-2023
 ## BREAKING CHANGES
 - `QasGallery`: removido slot `destroy` para dar lugar aos slots do `QasGalleryCard`, olhar documentação.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasListView`: adicionado propriedade `useAutoRefetchOnDelete` para controlar se o componente vai fazer o fetch novamente quando acontecer algum delete compatível com a listagem.
+
 ## [3.8.0] - 14-04-2023
 ## BREAKING CHANGES
 - `QasAppMenu`: adicionado propriedade `miniBrand` sendo `required` para passar logo em modo "mini".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## Não publicado
+## [3.9.0-beta.1] - 19-04-2023
 ## BREAKING CHANGES
 - [`QasAppMenu`, `QasAppBar`]: removido propriedade `user` em favor da nova propriedade `appUserProps`.
 - `QasAppBar`: removido escopo `user` do slot `user`, uma vez que já temos essa informação fora do componente.
@@ -1371,3 +1371,4 @@ Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitt
 [3.8.0-beta.7]: https://github.com/bildvitta/asteroid/compare/v3.8.0-beta.6...v3.8.0-beta.7?expand=1
 [3.8.0]: https://github.com/bildvitta/asteroid/compare/v3.7.0...v3.8.0?expand=1
 [3.9.0-beta.0]: https://github.com/bildvitta/asteroid/compare/v3.8.0...v3.9.0-beta.0?expand=1
+[3.9.0-beta.1]: https://github.com/bildvitta/asteroid/compare/v3.9.0-beta.0...v3.9.0-beta.1?expand=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,26 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
+## BREAKING CHANGES
+- `QasGallery`: removido slot `destroy` para dar lugar aos slots do `QasGalleryCard`, olhar documentação.
+- `QasGallery`: breaking changes nos slots, verificar documentação.
+- `QasActionsMenu` agora precisa passar a prop `useTooltip` para controle de tooltip.
+
 ### Adicionado
 - `QasListView`: adicionado propriedade `useAutoRefetchOnDelete` para controlar se o componente vai fazer o fetch novamente quando acontecer algum delete compatível com a listagem.
+- `QasGallery`: adicionado propriedade `galleryCardProps`.
+- `QasGalleryCard`: adicionado novo slot `actions`.
+- `QasActionsMenu`: adicionado propriedade `useTooltip` com default `false` para controle de tooltip.
+
+### Modificado
+- `QasGallery`: implementado componente `QasGalleryCard`.
+- `QasGallery`: com a implementação do componente `QasGalleryCard`, a altura do card passou de `150px` para `180px`.
+- `QasGallery`: componente repassa todos os slots do `QasGalleryCard` passando como escopo `image` e `index`.
+- `QasGalleryCard`: mudanças de espaçamento e no `defaultActionsMenuProps`.
+- `QasActionsMenu`: agora o tooltip precisa de controle por prop `useTooltip`.
+
+### Removido
+- `QasGallery`: removido slot `destroy` para dar lugar aos slots do `QasGalleryCard`, olhar documentação.
 
 ## [3.8.0] - 14-04-2023
 ## BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,38 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+## BREAKING CHANGES
+- `QasGallery`: removido slot `destroy` para dar lugar aos slots do `QasGalleryCard`, olhar documentação.
+- `QasGallery`: breaking changes nos slots, verificar documentação.
+- `QasActionsMenu` agora precisa passar a prop `useTooltip` para controle de tooltip.
+- [`QasAppMenu`, `QasAppBar`]: removido propriedade `user` em favor da nova propriedade `appUserProps`.
+- `QasAppBar`: removido escopo `user` do slot `user`, uma vez que já temos essa informação fora do componente.
+
+### Adicionado
+- `QasListView`: adicionado propriedade `useAutoRefetchOnDelete` para controlar se o componente vai fazer o fetch novamente quando acontecer algum delete compatível com a listagem.
+- `QasGallery`: adicionado propriedade `galleryCardProps`.
+- `QasGalleryCard`: adicionado novo slot `actions`.
+- `QasActionsMenu`: adicionado propriedade `useTooltip` com default `false` para controle de tooltip.
+- `QasAppUser`: adicionado propriedade `currentCompany` para setar empresa atual vinculada.
+- `QasAppUser`: adicionado propriedade `companiesOptions` para enviar opções de possíveis empresas para troca de vínculo.
+- `QasAppUser`: adicionado recurso para troca de vínculo de empresa.
+- [`QasAppMenu`, `QasAppBar`]: adicionado propriedade `appUserProps` para repassar todas props do `QasAppUser`.
+- `QasListView`: adicionado nova propriedade `usePagination` para controlar paginação com default `true`.
+
+### Modificado
+- `QasGallery`: implementado componente `QasGalleryCard`.
+- `QasGallery`: com a implementação do componente `QasGalleryCard`, a altura do card passou de `150px` para `180px`.
+- `QasGallery`: componente repassa todos os slots do `QasGalleryCard` passando como escopo `image` e `index`.
+- `QasGalleryCard`: mudanças de espaçamento e no `defaultActionsMenuProps`.
+- `QasActionsMenu`: agora o tooltip precisa de controle por prop `useTooltip`.
+- `copyToClipboard`: modificado helper, agora no notify aparece sempre uma mensagem genérica "Item copiado com sucesso." ao invés do texto copiado anteriormente (isto impacta diretamente no componente `QasCopy`).
+
+### Removido
+- `QasGallery`: removido slot `destroy` para dar lugar aos slots do `QasGalleryCard`, olhar documentação.
+- [`QasAppMenu`, `QasAppBar`]: removido propriedade `user` em favor da nova propriedade `appUserProps`.
+- `QasAppBar`: removido escopo `user` do slot `user`, uma vez que já temos essa informação fora do componente.
+
 ## [3.9.0-beta.1] - 19-04-2023
 ## BREAKING CHANGES
 - [`QasAppMenu`, `QasAppBar`]: removido propriedade `user` em favor da nova propriedade `appUserProps`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasGallery`: componente repassa todos os slots do `QasGalleryCard` passando como escopo `image` e `index`.
 - `QasGalleryCard`: mudanças de espaçamento e no `defaultActionsMenuProps`.
 - `QasActionsMenu`: agora o tooltip precisa de controle por prop `useTooltip`.
+- `copyToClipboard`: modificado helper, agora no notify aparece sempre uma mensagem genérica "Item copiado com sucesso." ao invés do texto copiado anteriormente (isto impacta diretamente no componente `QasCopy`).
 
 ### Removido
 - `QasGallery`: removido slot `destroy` para dar lugar aos slots do `QasGalleryCard`, olhar documentação.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## Não publicado
+## [3.9.0-beta.0] - 14-04-2023
 ## BREAKING CHANGES
 - `QasGallery`: removido slot `destroy` para dar lugar aos slots do `QasGalleryCard`, olhar documentação.
 - `QasGallery`: breaking changes nos slots, verificar documentação.
@@ -1354,3 +1354,4 @@ Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitt
 [3.8.0-beta.6]: https://github.com/bildvitta/asteroid/compare/v3.8.0-beta.5...v3.8.0-beta.6?expand=1
 [3.8.0-beta.7]: https://github.com/bildvitta/asteroid/compare/v3.8.0-beta.6...v3.8.0-beta.7?expand=1
 [3.8.0]: https://github.com/bildvitta/asteroid/compare/v3.7.0...v3.8.0?expand=1
+[3.9.0-beta.0]: https://github.com/bildvitta/asteroid/compare/v3.8.0...v3.9.0-beta.0?expand=1

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
-  "version": "3.9.0-beta.0",
+  "version": "3.9.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-app-extension-asteroid",
-      "version": "3.9.0-beta.0",
+      "version": "3.9.0-beta.1",
       "license": "MIT",
       "dependencies": {
-        "@bildvitta/quasar-ui-asteroid": "3.9.0-beta.0",
+        "@bildvitta/quasar-ui-asteroid": "3.9.0-beta.1",
         "@bildvitta/store-adapter": "^1.0.0",
         "humps": "^2.0.1"
       },
@@ -20,9 +20,9 @@
       }
     },
     "node_modules/@bildvitta/quasar-ui-asteroid": {
-      "version": "3.9.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.9.0-beta.0.tgz",
-      "integrity": "sha512-Pcoa2DmlJS7KxeMloTY+DACHivG6HgccULspX3972lnOK8M+eNR7l+4VtpTLwBxI4AOuhlgoonqu/DTiTVlgtg==",
+      "version": "3.9.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.9.0-beta.1.tgz",
+      "integrity": "sha512-mAqOzloUhTPhkKKyBm71g8Nmn+lL+6wryROgkztM9TvcgrjirZn5hHuJBWpLdN5vYaYEeIpBkiDyKu093Ogw6w==",
       "dependencies": {
         "@bildvitta/store-adapter": "^1.0.0",
         "@fawmi/vue-google-maps": "^0.9.4",
@@ -1500,9 +1500,9 @@
   },
   "dependencies": {
     "@bildvitta/quasar-ui-asteroid": {
-      "version": "3.9.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.9.0-beta.0.tgz",
-      "integrity": "sha512-Pcoa2DmlJS7KxeMloTY+DACHivG6HgccULspX3972lnOK8M+eNR7l+4VtpTLwBxI4AOuhlgoonqu/DTiTVlgtg==",
+      "version": "3.9.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.9.0-beta.1.tgz",
+      "integrity": "sha512-mAqOzloUhTPhkKKyBm71g8Nmn+lL+6wryROgkztM9TvcgrjirZn5hHuJBWpLdN5vYaYEeIpBkiDyKu093Ogw6w==",
       "requires": {
         "@bildvitta/store-adapter": "^1.0.0",
         "@fawmi/vue-google-maps": "^0.9.4",

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
-  "version": "3.8.0",
+  "version": "3.9.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-app-extension-asteroid",
-      "version": "3.8.0",
+      "version": "3.9.0-beta.0",
       "license": "MIT",
       "dependencies": {
-        "@bildvitta/quasar-ui-asteroid": "3.8.0",
+        "@bildvitta/quasar-ui-asteroid": "3.9.0-beta.0",
         "@bildvitta/store-adapter": "^1.0.0",
         "humps": "^2.0.1"
       },
@@ -20,9 +20,9 @@
       }
     },
     "node_modules/@bildvitta/quasar-ui-asteroid": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.8.0.tgz",
-      "integrity": "sha512-D02HhACq0sVQHJnlAzOcgvGcw4K7MgkO2SAaWIQj2H3hZp4msO9r241Al0ceNkxxjYzCoSzvOEnKIgI0GHqVnw==",
+      "version": "3.9.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.9.0-beta.0.tgz",
+      "integrity": "sha512-Pcoa2DmlJS7KxeMloTY+DACHivG6HgccULspX3972lnOK8M+eNR7l+4VtpTLwBxI4AOuhlgoonqu/DTiTVlgtg==",
       "dependencies": {
         "@bildvitta/store-adapter": "^1.0.0",
         "@fawmi/vue-google-maps": "^0.9.4",
@@ -1500,9 +1500,9 @@
   },
   "dependencies": {
     "@bildvitta/quasar-ui-asteroid": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.8.0.tgz",
-      "integrity": "sha512-D02HhACq0sVQHJnlAzOcgvGcw4K7MgkO2SAaWIQj2H3hZp4msO9r241Al0ceNkxxjYzCoSzvOEnKIgI0GHqVnw==",
+      "version": "3.9.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.9.0-beta.0.tgz",
+      "integrity": "sha512-Pcoa2DmlJS7KxeMloTY+DACHivG6HgccULspX3972lnOK8M+eNR7l+4VtpTLwBxI4AOuhlgoonqu/DTiTVlgtg==",
       "requires": {
         "@bildvitta/store-adapter": "^1.0.0",
         "@fawmi/vue-google-maps": "^0.9.4",

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
   "description": "Asteroid",
-  "version": "3.8.0",
+  "version": "3.9.0-beta.0",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "src/index.js",
@@ -29,7 +29,7 @@
     "yarn": ">= 1.6.0"
   },
   "dependencies": {
-    "@bildvitta/quasar-ui-asteroid": "3.8.0",
+    "@bildvitta/quasar-ui-asteroid": "3.9.0-beta.0",
     "@bildvitta/store-adapter": "^1.0.0",
     "humps": "^2.0.1"
   }

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
   "description": "Asteroid",
-  "version": "3.9.0-beta.0",
+  "version": "3.9.0-beta.1",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "src/index.js",
@@ -29,7 +29,7 @@
     "yarn": ">= 1.6.0"
   },
   "dependencies": {
-    "@bildvitta/quasar-ui-asteroid": "3.9.0-beta.0",
+    "@bildvitta/quasar-ui-asteroid": "3.9.0-beta.1",
     "@bildvitta/store-adapter": "^1.0.0",
     "humps": "^2.0.1"
   }

--- a/build/build.js
+++ b/build/build.js
@@ -64,11 +64,11 @@ async function main () {
   )
 
   const currentBranch = execaSync('git', ['branch', '--show-current']).stdout
-  const acceptableBranch = ['main', 'main-homolog']
-  const isBeta = currentBranch === 'main-homolog'
+  const acceptableBranch = ['main', 'develop']
+  const isBeta = currentBranch === 'develop'
 
   if (!acceptableBranch.includes(currentBranch)) {
-    ora('Só é possível publicar nas branchs "main" e "main-homolog"').fail()
+    ora('Só é possível publicar nas branchs "main" e "develop"').fail()
     return
   }
 
@@ -141,7 +141,7 @@ async function main () {
   /*
   * Algumas informações importantes para utilização deste script:
   *
-  * - A publicação só é possível dentro das branchs "main" e "main-homolog", sendo "main" -> stable e "main-homolog" -> beta
+  * - A publicação só é possível dentro das branchs "main" e "develop", sendo "main" -> stable e "develop" -> beta
   * - Você precisa ter acesso de publicação dentro do NPM
   * - Você precisa ter acesso "write" nas branchs para conseguir dar push nas alterações
   * - Para ser gerado a release no github automaticamente você precisa ter setado em seu pc a variável "GITHUB_TOKEN"

--- a/build/release/create-github-release.js
+++ b/build/release/create-github-release.js
@@ -14,7 +14,7 @@ async function createGithubRelease ({ body, isBeta, version, ora, onSuccess = ()
       owner: 'bildvitta',
       repo: 'asteroid',
       tag_name: versionTag,
-      target_commitish: isBeta ? 'main-homolog' : 'main',
+      target_commitish: isBeta ? 'develop' : 'main',
       name: versionTag,
       body,
       draft: false,

--- a/build/release/git-handler.js
+++ b/build/release/git-handler.js
@@ -19,7 +19,7 @@ function gitHandler ({ ora, execaSync, nextVersion, isBeta, packages }) {
   // envia as alterações para o github
   const pushSpinner = ora('Enviando push para o github...').start()
   const pushCommands = ['push', 'origin']
-  pushCommands.push(isBeta ? 'main-homolog' : 'main')
+  pushCommands.push(isBeta ? 'develop' : 'main')
 
   execaSync('git', pushCommands, { cwd: packages.global.resolved })
   pushSpinner.succeed('Push enviado!')

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid-docs",
-  "version": "3.9.0-beta.0",
+  "version": "3.9.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid-docs",
-      "version": "3.9.0-beta.0",
+      "version": "3.9.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-js": "^1.6.2",
@@ -45,7 +45,7 @@
     },
     "../ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.8.0",
+      "version": "3.9.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/store-adapter": "^1.0.0",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid-docs",
-  "version": "3.8.0",
+  "version": "3.9.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid-docs",
-      "version": "3.8.0",
+      "version": "3.9.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-js": "^1.6.2",
@@ -45,7 +45,7 @@
     },
     "../ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.8.0-beta.7",
+      "version": "3.8.0",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/store-adapter": "^1.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid-docs",
   "description": "Asteroid",
-  "version": "3.8.0",
+  "version": "3.9.0-beta.0",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "productName": "Asteroid Docs",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid-docs",
   "description": "Asteroid",
-  "version": "3.9.0-beta.0",
+  "version": "3.9.0-beta.1",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "productName": "Asteroid Docs",

--- a/docs/src/examples/QasActionsMenu/ExUseTooltip.vue
+++ b/docs/src/examples/QasActionsMenu/ExUseTooltip.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="container q-py-lg">
+    <qas-actions-menu :delete-props="{ deleteActionParams: { entity: 'users', id: 'my-custom-id-from-user', onDeleteSuccess } }" :use-label="false" use-tooltip />
+  </div>
+</template>
+
+<script>
+export default {
+  methods: {
+    onDeleteSuccess () {
+      this.$qas.success('fui deletado com sucesso!')
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QasAppBar/Basic.vue
+++ b/docs/src/examples/QasAppBar/Basic.vue
@@ -1,6 +1,6 @@
 <template>
   <q-layout>
-    <qas-app-bar title="QasAppBar" :user="user" />
+    <qas-app-bar :app-user-props="appUserProps" title="QasAppBar" />
   </q-layout>
 </template>
 
@@ -13,8 +13,22 @@ const user = {
 
 export default {
   computed: {
-    user () {
-      return user
+    appUserProps () {
+      return {
+        companiesOptions: [
+          {
+            label: 'Empresa 1',
+            value: '1'
+          },
+          {
+            label: 'Empresa 2',
+            value: '2'
+          }
+        ],
+
+        currentCompany: '1',
+        user
+      }
     }
   }
 }

--- a/docs/src/examples/QasAppMenu/Basic.vue
+++ b/docs/src/examples/QasAppMenu/Basic.vue
@@ -61,7 +61,21 @@ export default {
         brand: 'https://placehold.co/208x40',
         miniBrand: 'https://placehold.co/40x40',
         modules,
-        user,
+        appUserProps: {
+          companiesOptions: [
+            {
+              label: 'Empresa 1',
+              value: '1'
+            },
+            {
+              label: 'Empresa 2',
+              value: '2'
+            }
+          ],
+
+          currentCompany: '1',
+          user
+        },
         title: 'Documentação',
 
         items: [

--- a/docs/src/examples/QasAppUser/Basic.vue
+++ b/docs/src/examples/QasAppUser/Basic.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="q-pa-md">
-    <qas-app-user :user="user" />
+    <qas-app-user v-bind="props" />
   </div>
 </template>
 
@@ -13,8 +13,21 @@ const user = {
 
 export default {
   computed: {
-    user () {
-      return user
+    props () {
+      return {
+        user,
+        companiesOptions: [
+          {
+            label: 'Empresa 1',
+            value: '1'
+          },
+          {
+            label: 'Empresa 2',
+            value: '2'
+          }
+        ],
+        currentCompany: '1'
+      }
     }
   }
 }

--- a/docs/src/examples/QasLayout/Basic.vue
+++ b/docs/src/examples/QasLayout/Basic.vue
@@ -74,7 +74,21 @@ export default {
 
     appBarProps () {
       return {
-        user,
+        appUserProps: {
+          companiesOptions: [
+            {
+              label: 'Empresa 1',
+              value: '1'
+            },
+            {
+              label: 'Empresa 2',
+              value: '2'
+            }
+          ],
+
+          currentCompany: '1',
+          user
+        },
         title: 'QasLayout'
       }
     },

--- a/docs/src/examples/QasListView/ExAutoRefetchOnDelete.vue
+++ b/docs/src/examples/QasListView/ExAutoRefetchOnDelete.vue
@@ -1,5 +1,5 @@
 <template>
-  <qas-list-view v-model:fields="fields" v-model:results="results" :entity="entity" use-auto-handle-on-delete>
+  <qas-list-view v-model:fields="fields" v-model:results="results" :entity="entity" use-auto-refetch-on-delete>
     <template #header>
       <qas-page-header title="Lista de materiais" :use-breadcrumbs="false">
         <qas-btn icon="sym_r_add" label="Novo [item]" />

--- a/docs/src/pages/components/actions-menu.md
+++ b/docs/src/pages/components/actions-menu.md
@@ -22,7 +22,7 @@ Caso a prop `list` contenha **apenas 1** item dentro, ele renderiza um `QasBtn`,
 - A prop `deleteProps` ativa o plugin `Delete.js`, quando é passada o `QasActionsMenu` adiciona a opção de deletar o item como padrão, caso não seja passado, o plugin `Delete.js` não é adicionado por padrão.
 :::
 
-:::tip
+:::info
 - A prop `list` é um objeto de objetos, que contem os seguintes atributos:
 
   ```js
@@ -42,8 +42,18 @@ Caso a prop `list` contenha **apenas 1** item dentro, ele renderiza um `QasBtn`,
   ```
 :::
 
+:::info
+###### Tooltip
+- O `tooltip` ira aparecer o caso ele respeite as regras:
+  - Propriedade `useLabel` for `false`.
+  - Propriedade `useTooltip` for `true`.
+  - O componente QasActionsMenu tenha apenas 1 opção (Modo QasBtn e não QasBtnDropdown).
+- A label do tooltip vai ser a label do item dentro do `list`.
+:::
+
 <doc-example file="QasActionsMenu/Basic" title="Básico" />
 <doc-example file="QasActionsMenu/ExWithSplit" title="Usando com split" />
 <doc-example file="QasActionsMenu/Delete" title="QasDelete como padrão" />
 <doc-example file="QasActionsMenu/CustomSlot" title="Templates dinâmicos" />
 <doc-example file="QasActionsMenu/ExUseLabel" title="Ícone sem label" />
+<doc-example file="QasActionsMenu/ExUseTooltip" title="Com tooltip" />

--- a/docs/src/pages/components/app-user.md
+++ b/docs/src/pages/components/app-user.md
@@ -6,6 +6,13 @@ Componente utilizado no `QasAppBar` e `QasAppMenu` para exibir o nome do usuári
 
 <doc-api file="app-user/QasAppUser" name="QasAppUser" />
 
+:::info
+A funcionalidade de troca de vínculo de empresa é ativada quando existe mais de 1 opção na prop `companiesOptions`, é executado uma API com o seguinte endpoint:
+
+`PATCH -> users/me`
+
+Enviando para o body da requisição o novo `companies`.
+:::
 
 ## Uso
 <doc-example file="QasAppUser/Basic" title="Básico" />

--- a/docs/src/pages/components/gallery-card.md
+++ b/docs/src/pages/components/gallery-card.md
@@ -6,10 +6,6 @@ Componente de card de galeria (utilizado no QasUploader, QasGallery e nos produt
 
 <doc-api file="gallery-card/QasGalleryCard" name="QasGalleryCard" />
 
-:::danger
-Componente adaptado somente para utilização dentro do `QasUploader`.
-:::
-
 ## Uso
 
 <doc-example file="QasGalleryCard/Basic" title="Básico" />

--- a/docs/src/pages/components/gallery.md
+++ b/docs/src/pages/components/gallery.md
@@ -4,14 +4,13 @@ title: QasGallery
 
 Componente para galeria, mostrando images dentro de um "QasDialog" ao clicar nelas.
 
-:::warning
+:::info
 Este componente depende do `Vuex` ou `Pinia`, utiliza módulos com actions. Por exemplo, para você conseguir remover uma imagem da galeria, você precisa ter:
 - action: update.
 
 Hoje Utilizamos 2 bibliotecas com propósitos diferentes que são compatíveis com o asteroid para lidar com o Vuex, elas são:
 [VuexStoreModule](https://github.com/bildvitta/vuex-store-module), [VuexOffline](https://github.com/bildvitta/vuex-offline) e [StoreModule](https://github.com/bildvitta/store-module).
 :::
-
 
 <doc-api file="gallery/QasGallery" name="QasGallery" />
 

--- a/docs/src/pages/components/list-view.md
+++ b/docs/src/pages/components/list-view.md
@@ -6,23 +6,25 @@ Componente para C.R.U.D. responsável pela parte de listagem (Read).
 
 <doc-api file="list-view/QasListView" name="QasListView" />
 
-:::warning
-Quando utilizar deleção de itens na listagem, lembre-se de utilizar a propriedade `use-auto-handle-on-delete`.
+:::info
+- Quando utilizar deleção de itens na listagem, lembre-se de utilizar a propriedade `use-auto-handle-on-delete` ou `use-auto-refetch-on-delete`.
+- A diferença do `use-auto-refetch-on-delete` para o `use-auto-handle-on-delete` é que ela não usa nenhuma validação referente a quantidade de itens e paginação, ela faz com que o componente **sempre** faça um novo fetch ao identificar que um item da listagem foi deletado.
 :::
 
-:::warning
-Este componente depende do `Vuex`, utiliza módulos com actions, state e getters para manipular/recuperar os dados. Por exemplo, para você utilizar em uma entidade de listagem de usuários, você **deve** ter um modulo de `users` e dentro de dele ter os seguinte requisitos:
+:::info
+Este componente depende do `Vuex` ou `Pinia`, utiliza módulos com actions e state para manipular/recuperar os dados. Por exemplo, para você utilizar em uma entidade de listagem de usuários, você **deve** ter um modulo de `users` e dentro de dele ter os seguinte requisitos:
 - state: list e totalPages.
-- getters: list e totalPages.
 - actions: fetchList (que vai popular o state de list e totalPages).
 
-Hoje Utilizamos 2 bibliotecas com propósitos diferentes que são compatíveis com o asteroid para lidar com o Vuex, elas são:
-[VuexStoreModule](https://github.com/bildvitta/vuex-store-module) e [VuexOffline](https://github.com/bildvitta/vuex-offline).
+Hoje Utilizamos 3 bibliotecas com propósitos diferentes que são compatíveis com o asteroid para lidar com o Vuex, elas são:
+- [StoreModule](https://github.com/bildvitta/store-module) (recomendado)
+- [VuexStoreModule](https://github.com/bildvitta/vuex-store-module)
+- [VuexOffline](https://github.com/bildvitta/vuex-offline).
 
 Para fazer esses exemplos na documentação, estamos utilizando o `VuexOffline`, para saber mais, veja o código fonte da documentação.
 :::
 
-:::tip
+:::info
 Este componente serve para lidar com **listagem**, se você precisar de um componente para lidar com um item unitário, como por exemplo, um único usuário, use o componente `QasSingleView`.
 :::
 
@@ -37,7 +39,7 @@ Para usar `QasFilters` você não precisa fazer nada! Porém, em alguns casos, v
 
 <doc-example file="QasListView/CustomFilter" title="Com filtro customizado" />
 
-:::tip
+:::info
 O callback do `beforeFetch` recebe 2 parâmetros, `:before-submit="onBeforeSubmit({ payload, resolve, done })"`
 
 ##### payload: `Object` -> { id, payload, url }
@@ -58,3 +60,4 @@ Agora ao fazer o fetch, o valor da url enviada para a action do fetchList será 
 :::
 
 <doc-example file="QasListView/BeforeFetch" title="Controlando fetch" />
+<doc-example file="QasListView/ExAutoRefetchOnDelete" title="Controle de refetch ao deletar automático" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid",
-  "version": "3.9.0-beta.0",
+  "version": "3.9.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid",
-      "version": "3.9.0-beta.0",
+      "version": "3.9.0-beta.1",
       "license": "MIT",
       "devDependencies": {
         "@bildvitta/quasar-ui-asteroid": "file:ui",
@@ -6934,7 +6934,7 @@
     },
     "ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.8.0",
+      "version": "3.9.0-beta.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid",
-  "version": "3.8.0",
+  "version": "3.9.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid",
-      "version": "3.8.0",
+      "version": "3.9.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@bildvitta/quasar-ui-asteroid": "file:ui",
@@ -6934,7 +6934,7 @@
     },
     "ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.8.0-beta.7",
+      "version": "3.8.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid",
   "description": "Asteroid",
-  "version": "3.8.0",
+  "version": "3.9.0-beta.0",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid",
   "description": "Asteroid",
-  "version": "3.9.0-beta.0",
+  "version": "3.9.0-beta.1",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "scripts": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
-  "version": "3.9.0-beta.0",
+  "version": "3.9.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.9.0-beta.0",
+      "version": "3.9.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/store-adapter": "^1.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
-  "version": "3.8.0",
+  "version": "3.9.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.8.0",
+      "version": "3.9.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/store-adapter": "^1.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
   "description": "Asteroid",
-  "version": "3.9.0-beta.0",
+  "version": "3.9.0-beta.1",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "dist/asteroid.cjs.min.js",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
   "description": "Asteroid",
-  "version": "3.8.0",
+  "version": "3.9.0-beta.0",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "dist/asteroid.cjs.min.js",

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -73,6 +73,10 @@ export default {
     useLabel: {
       default: true,
       type: Boolean
+    },
+
+    useTooltip: {
+      type: Boolean
     }
   },
 
@@ -136,7 +140,7 @@ export default {
     },
 
     hasTooltip () {
-      return !this.isBtnDropdown && !this.useLabel
+      return !this.isBtnDropdown && !this.useLabel && this.useTooltip
     },
 
     tooltipLabel () {

--- a/ui/src/components/actions-menu/QasActionsMenu.yml
+++ b/ui/src/components/actions-menu/QasActionsMenu.yml
@@ -45,6 +45,9 @@ props:
     type: String
     examples: [visibility]
 
+  use-tooltip:
+    desc: Controla se vai ter o tooltip caso passe nas regras de exibição de tooltip
+
   use-label:
     desc: Habilita ou não o label no botão.
     default: true

--- a/ui/src/components/app-bar/QasAppBar.vue
+++ b/ui/src/components/app-bar/QasAppBar.vue
@@ -11,8 +11,8 @@
         </router-link>
       </q-toolbar-title>
 
-      <slot v-if="hasUser" name="user" :user="user">
-        <qas-app-user :menu-props="appUserMenuProps" :user="user" @sign-out="signOut" />
+      <slot v-if="hasUser" name="user">
+        <qas-app-user v-bind="defaultAppUserProps" />
       </slot>
     </q-toolbar>
   </q-header>
@@ -31,6 +31,12 @@ export default {
   },
 
   props: {
+    appUserProps: {
+      type: Object,
+      required: true,
+      default: () => ({})
+    },
+
     brand: {
       default: '',
       type: String
@@ -44,12 +50,6 @@ export default {
     title: {
       required: true,
       type: String
-    },
-
-    user: {
-      default: () => ({}),
-      require: true,
-      type: Object
     }
   },
 
@@ -67,6 +67,19 @@ export default {
         anchor: 'bottom end',
         offset: [0, 5],
         self: 'top end'
+      }
+    },
+
+    defaultAppUserProps () {
+      return {
+        menuProps: {
+          anchor: 'bottom end',
+          offset: [0, 5],
+          self: 'top end'
+        },
+
+        onSignOut: this.signOut,
+        ...this.appUserProps
       }
     },
 
@@ -92,7 +105,7 @@ export default {
     },
 
     hasUser () {
-      return !!Object.keys(this.user).length
+      return !!Object.keys(this.defaultAppUserProps.user || {}).length
     },
 
     rootRoute () {

--- a/ui/src/components/app-bar/QasAppBar.yml
+++ b/ui/src/components/app-bar/QasAppBar.yml
@@ -4,6 +4,12 @@ meta:
   desc: Gerencia a barra superior da aplicação
 
 props:
+  app-user-props:
+    desc: Props repassadas para o QasAppUser.
+    default: {}
+    type: Object
+    required: true
+
   brand:
     desc: Path do logotipo.
     type: String
@@ -17,20 +23,6 @@ props:
     desc: Título da aplicação.
     required: true
     type: String
-
-  user:
-    desc: Informações do usuário.
-    type: Object
-    default: {}
-    examples: [
-      "
-      {
-        photo: 'minha-img',
-        name: 'Eduardo Lima',
-        email: 'eduardolima@gmail.com'
-      }
-      "
-    ]
 
 slots:
   user:

--- a/ui/src/components/app-menu/QasAppMenu.vue
+++ b/ui/src/components/app-menu/QasAppMenu.vue
@@ -76,8 +76,8 @@
         </div>
 
         <!-- User -->
-        <div v-if="showUser" class="full-width q-pb-lg q-px-lg">
-          <qas-app-user v-bind="appUserProps" />
+        <div v-if="showAppUser" class="full-width q-pb-lg q-px-lg">
+          <qas-app-user v-bind="defaultAppUserProps" />
         </div>
       </div>
     </q-drawer>
@@ -102,6 +102,12 @@ export default {
   inheritAttrs: false,
 
   props: {
+    appUserProps: {
+      type: Object,
+      required: true,
+      default: () => ({})
+    },
+
     brand: {
       default: '',
       required: true,
@@ -137,12 +143,6 @@ export default {
     title: {
       default: '',
       type: String
-    },
-
-    user: {
-      default: () => ({}),
-      require: true,
-      type: Object
     }
   },
 
@@ -165,20 +165,6 @@ export default {
 
         currentModule: this.currentModelOption,
         modules: this.defaultModules
-      }
-    },
-
-    appUserProps () {
-      return {
-        avatarSize: '40px',
-        user: this.user,
-
-        menuProps: {
-          'onUpdate:modelValue': this.setHasOpenedMenu
-        },
-
-        // eventos
-        onSignOut: this.signOut
       }
     },
 
@@ -211,6 +197,20 @@ export default {
     currentModule () {
       const hostname = window.location.hostname
       return this.defaultModules.find(module => module?.value.includes(hostname))?.value
+    },
+
+    defaultAppUserProps () {
+      return {
+        avatarSize: '40px',
+
+        menuProps: {
+          'onUpdate:modelValue': this.setHasOpenedMenu
+        },
+
+        // eventos
+        onSignOut: this.signOut,
+        ...this.appUserProps
+      }
     },
 
     defaultModules () {
@@ -289,7 +289,7 @@ export default {
       return this.$router.hasRoute('Root') ? { name: 'Root' } : { path: '/' }
     },
 
-    showUser () {
+    showAppUser () {
       return this.hasUser && !this.isUntilLarge
     },
 
@@ -339,7 +339,7 @@ export default {
     },
 
     hasUser () {
-      return !!Object.keys(this.user).length
+      return !!Object.keys(this.defaultAppUserProps.user || {}).length
     },
 
     isActive ({ to }) {

--- a/ui/src/components/app-menu/QasAppMenu.yml
+++ b/ui/src/components/app-menu/QasAppMenu.yml
@@ -4,6 +4,12 @@ meta:
   desc: Menu lateral.
 
 props:
+  app-user-props:
+    desc: Props repassadas para o QasAppUser.
+    default: {}
+    type: Object
+    required: true
+
   brand:
     desc: Logotipo quando menu esta aberto.
     type: String
@@ -37,20 +43,6 @@ props:
   title:
     desc: Título que vai ficar no label do select de módulos.
     type: String
-
-  user:
-    desc: Informações do usuário.
-    type: Object
-    default: {}
-    examples: [
-      "
-      {
-        photo: 'minha-img',
-        name: 'Eduardo Lima',
-        email: 'eduardolima@gmail.com'
-      }
-      "
-    ]
 
 slots:
   user:

--- a/ui/src/components/app-user/QasAppUser.vue
+++ b/ui/src/components/app-user/QasAppUser.vue
@@ -17,6 +17,8 @@
         <div class="ellipsis qas-app-user__menu-name">{{ userName }}</div>
         <div class="ellipsis">{{ user.email }}</div>
 
+        <qas-select v-if="hasCompaniesSelect" v-model="companiesModel" class="q-my-md" label="Vínculo" :loading="loading" :options="companiesOptions" @update:model-value="setCompanies" />
+
         <q-list class="q-mt-md">
           <q-item v-close-popup :active="false" class="qas-app-user__menu-item" clickable :to="user.to">
             <q-item-section avatar>
@@ -67,6 +69,16 @@ export default {
       type: String
     },
 
+    companiesOptions: {
+      type: Array,
+      default: () => []
+    },
+
+    currentCompany: {
+      type: String,
+      default: ''
+    },
+
     menuProps: {
       default: () => ({}),
       type: Object
@@ -86,6 +98,13 @@ export default {
 
   emits: ['sign-out'],
 
+  data () {
+    return {
+      companiesModel: '',
+      loading: false
+    }
+  },
+
   computed: {
     hasNotifications () {
       return !!Object.keys(this.notifications).length
@@ -93,12 +112,43 @@ export default {
 
     userName () {
       return this.user.name || this.user.givenName
+    },
+
+    hasCompaniesSelect () {
+      return this.companiesOptions.length > 1
+    }
+  },
+
+  watch: {
+    currentCompany: {
+      handler (value) {
+        this.companiesModel = value
+      },
+
+      immediate: true
     }
   },
 
   methods: {
     signOut () {
       this.$emit('sign-out')
+    },
+
+    async setCompanies (value) {
+      this.loading = true
+
+      try {
+        await this.$axios.patch('users/me', { companies: value })
+
+        this.$qas.success('Vínculo alterado com sucesso.')
+
+        setTimeout(() => location.reload(), 1500)
+      } catch {
+        this.companiesModel = this.currentCompany
+        this.$qas.error('Falha ao alterar vínculo.')
+      } finally {
+        this.loading = false
+      }
     }
   }
 }

--- a/ui/src/components/app-user/QasAppUser.yml
+++ b/ui/src/components/app-user/QasAppUser.yml
@@ -4,6 +4,26 @@ meta:
   desc: Exibe o avatar e o nome do usuário, ao clicar abre um menu com as opções.
 
 props:
+  avatar-size:
+    desc: Define o tamanho do avatar.
+    default: 36px
+    type: String
+
+  companies-options:
+    desc: Opções para o select de vínculo de empresas.
+    default: []
+    type: Array
+
+  current-company:
+    desc: Empresa atual vinculada
+    default: ''
+    type: String
+
+  menu-props:
+    desc: Repassa props pro QMenu.
+    default: {}
+    type: Object
+
   notifications:
     desc: Lista com as notificações do usuário.
     type: Object

--- a/ui/src/components/gallery-card/QasGalleryCard.vue
+++ b/ui/src/components/gallery-card/QasGalleryCard.vue
@@ -1,16 +1,17 @@
-<!-- TODO: componente adaptado somente para o uso do QasUploader, precisa ser revisitado para ser implementado no QasGallery -->
 <template>
   <div class="bg-white q-pa-md qas-gallery-card rounded-borders shadow-2" :class="classes">
-    <header class="flat items-center no-wrap q-mb-md row" :class="headerClasses">
+    <header class="flat items-center no-wrap row" :class="headerClasses">
       <slot name="header">
-        <div class="ellipsis q-mr-xs qas-gallery__name">
+        <div class="ellipsis q-mr-xs qas-gallery__name text-subtitle1">
           <slot v-if="card.name" name="name">
             {{ card.name }}
           </slot>
         </div>
 
-        <div v-if="hasActionsMenu">
-          <qas-actions-menu v-bind="defaultActionsMenuProps" />
+        <div v-if="hasActions">
+          <slot name="actions">
+            <qas-actions-menu v-bind="defaultActionsMenuProps" />
+          </slot>
         </div>
       </slot>
     </header>
@@ -84,8 +85,12 @@ export default {
       }
     },
 
-    hasActionsMenu () {
-      return !!Object.keys(this.actionsMenuProps).length
+    hasActions () {
+      return !!Object.keys(this.actionsMenuProps).length || this.hasActionsSlot
+    },
+
+    hasActionsSlot () {
+      return !!this.$slots.actions
     },
 
     hasBottom () {
@@ -100,7 +105,8 @@ export default {
       return {
         'justify-between': this.card.name,
         'justify-right': !this.card.name,
-        'text-grey-9': !this.disable
+        'text-grey-9': !this.disable,
+        'q-mb-md': this.hasActions || this.card.name
       }
     }
   }

--- a/ui/src/components/gallery-card/QasGalleryCard.yml
+++ b/ui/src/components/gallery-card/QasGalleryCard.yml
@@ -29,6 +29,9 @@ props:
     type: Object
 
 slots:
+  actions:
+    desc: Slot para ações do cabeçalho.
+
   bottom:
     desc: Slot para acessar o conteúdo abaixo da imagem.
 

--- a/ui/src/components/gallery/QasGallery.vue
+++ b/ui/src/components/gallery/QasGallery.vue
@@ -3,23 +3,11 @@
   <div class="qas-gallery">
     <div class="q-col-gutter-md row">
       <div v-for="(image, index) in getInitialImages()" :key="index" :class="galleryColumnsClasses" :data-cy="`gallery-image-${index}`">
-        <div class="bg-white q-pa-md rounded-borders shadow-2">
-          <div class="flat items-center justify-between no-wrap q-mb-xs row text-grey-9">
-            <div class="ellipsis q-mr-xs qas-gallery__name">
-              <slot v-if="image.name" :image="image" :index="index" name="header">
-                {{ image.name }}
-              </slot>
-            </div>
-
-            <div v-if="useDestroy">
-              <slot :destroy="onDestroy" :image="image" :index="index" name="destroy">
-                <qas-btn color="grey-9" :disabled="isDestroyDisabled(image)" icon="sym_r_delete" variant="tertiary" @click="onDestroy(image, index)" />
-              </slot>
-            </div>
-          </div>
-
-          <q-img class="cursor-pointer rounded-borders" height="150px" :src="image.url" @click="toggleCarouselDialog(index)" @error="onError(image.url)" />
-        </div>
+        <qas-gallery-card v-bind="getGalleryCardProps({ image, index })">
+          <template v-for="(_, name) in $slots" #[name]="context">
+            <slot v-bind="context" :image="image" :index="index" :name="name" />
+          </template>
+        </qas-gallery-card>
       </div>
 
       <slot>
@@ -62,6 +50,11 @@ export default {
     carouselPreviousIcon: {
       type: String,
       default: 'sym_r_chevron_left'
+    },
+
+    galleryCardProps: {
+      type: Object,
+      default: () => ({})
     },
 
     initialSize: {
@@ -184,6 +177,46 @@ export default {
       }
     },
 
+    getGalleryCardProps ({ image, index }) {
+      return {
+        card: image,
+        imageProps: this.getImageProps({ image, index }),
+        actionsMenuProps: this.getActionsMenuProps({ image, index }),
+        ...this.galleryCardProps
+      }
+    },
+
+    getActionsMenuProps ({ image, index }) {
+      if (!this.useDestroy) return {}
+
+      return {
+        useLabel: false,
+
+        buttonProps: {
+          disable: this.isDestroyDisabled(image)
+        },
+
+        list: {
+          destroy: {
+            label: 'Excluir',
+            color: 'grey-9',
+            icon: 'sym_r_delete',
+
+            handler: () => this.onDestroy(image, index)
+          }
+        }
+      }
+    },
+
+    getImageProps ({ image, index }) {
+      return {
+        class: 'cursor-pointer',
+
+        onClick: () => this.toggleCarouselDialog(index),
+        onError: () => this.onError(image.url)
+      }
+    },
+
     getInitialImages () {
       return this.useLoadAll
         ? this.normalizedImages
@@ -230,13 +263,3 @@ export default {
   }
 }
 </script>
-
-<!-- TODO rever tipografia -->
-<style lang="scss">
-.qas-gallery {
-  &__name {
-    font-size: 16px;
-    font-weight: 600;
-  }
-}
-</style>

--- a/ui/src/components/gallery/QasGallery.yml
+++ b/ui/src/components/gallery/QasGallery.yml
@@ -21,6 +21,11 @@ props:
     desc: Entidade da store, por exemplo se tiver que trabalhar com modulo de usuários, teremos o model "users" na store, que vai ser nossa "entity" (utilizado para remover imagem).
     type: String
 
+  gallery-card-props:
+    desc: Propriedades repassadas para o QasGalleryCard
+    default: {}
+    type: Object
+
   initial-size:
     desc: Quantidade de imagens iniciais.
     default: 6
@@ -61,17 +66,39 @@ props:
     type: Boolean
 
 slots:
+  actions:
+    desc: Slot para ações do cabeçalho.
+    scope:
+      index:
+        desc: index atual.
+        default: 0
+        type: Number
+
+      image:
+        desc: imagem atual.
+        default: {}
+        type: Object
+
+  bottom:
+    desc: Slot para acessar o conteúdo abaixo da imagem.
+    scope:
+      index:
+        desc: index atual.
+        default: 0
+        type: Number
+
+      image:
+        desc: imagem atual.
+        default: {}
+        type: Object
+
+
   default:
     desc: Slot para todo conteúdo onde fica o botão "mostrar mais".
 
-  destroy:
-    desc: Slot para o ícone de remover.
+  image:
+    desc: Slot para acessar o conteúdo da imagem (onde fica o QasGridGenerator).
     scope:
-      destroy:
-        desc: Função para remover e atualizar o model.
-        default: undefined
-        type: Function
-
       index:
         desc: index atual.
         default: 0
@@ -83,7 +110,20 @@ slots:
         type: Object
 
   header:
-    desc: Slot para o header.
+    desc: Slot para acessar o conteúdo do cabeçalho.
+    scope:
+      index:
+        desc: index atual.
+        default: 0
+        type: Number
+
+      image:
+        desc: imagem atual.
+        default: {}
+        type: Object
+
+  name:
+    desc: Slot para acessar o conteúdo do nome, acima da imagem.
     scope:
       index:
         desc: index atual.

--- a/ui/src/components/list-view/QasListView.vue
+++ b/ui/src/components/list-view/QasListView.vue
@@ -74,12 +74,17 @@ export default {
       type: Boolean
     },
 
-    useRefresh: {
+    useFilter: {
       default: true,
       type: Boolean
     },
 
-    useFilter: {
+    usePagination: {
+      default: true,
+      type: Boolean
+    },
+
+    useRefresh: {
       default: true,
       type: Boolean
     },
@@ -113,7 +118,7 @@ export default {
     },
 
     hasPages () {
-      return this.totalPages > 1
+      return this.totalPages > 1 && this.usePagination
     },
 
     hasResults () {

--- a/ui/src/components/list-view/QasListView.vue
+++ b/ui/src/components/list-view/QasListView.vue
@@ -70,6 +70,10 @@ export default {
       type: Boolean
     },
 
+    useAutoRefetchOnDelete: {
+      type: Boolean
+    },
+
     useRefresh: {
       default: true,
       type: Boolean
@@ -100,6 +104,10 @@ export default {
   },
 
   computed: {
+    hasDeleteEventListener () {
+      return this.useAutoHandleOnDelete || this.useAutoRefetchOnDelete
+    },
+
     hasHeaderSlot () {
       return !!this.$slots.header
     },
@@ -153,13 +161,13 @@ export default {
   },
 
   mounted () {
-    if (!this.useAutoHandleOnDelete) return
+    if (!this.hasDeleteEventListener) return
 
     window.addEventListener('delete-success', this.onDeleteResult)
   },
 
   unmounted () {
-    if (!this.useAutoHandleOnDelete) return
+    if (!this.hasDeleteEventListener) return
 
     window.removeEventListener('delete-success', this.onDeleteResult)
   },
@@ -235,7 +243,7 @@ export default {
       this.page = parseInt(this.$route.query.page || 1)
     },
 
-    onDeleteResult ({ detail: { entity } }) {
+    onAutoHandleDelete ({ detail: { entity } }) {
       const { page } = this.mx_context
 
       /*
@@ -269,6 +277,15 @@ export default {
       * ex: estou na pagina 2 e existem 3 paginas, removo um item da pagina 2, então chamo o método fetchList
       */
       this.mx_fetchHandler({ ...this.mx_context, url: this.url }, this.fetchList)
+    },
+
+    onDeleteResult (event) {
+      if (this.useAutoRefetchOnDelete) {
+        this.mx_fetchHandler({ ...this.mx_context, url: this.url }, this.fetchList)
+        return
+      }
+
+      this.onAutoHandleDelete(event)
     }
   }
 }

--- a/ui/src/components/list-view/QasListView.yml
+++ b/ui/src/components/list-view/QasListView.yml
@@ -62,6 +62,10 @@ props:
     desc: Controla se o componente vai lidar automaticamente quando acontecer algum delete compatível com a listagem.
     type: Boolean
 
+  use-auto-refetch-on-delete:
+    desc: Controla se o componente vai fazer o fetch novamente quando acontecer algum delete compatível com a listagem.
+    type: Boolean
+
   use-boundary:
     desc: Controla o limite que o FormView terá, quando é "false", a tag pai deixa de ser um "QPage" para ser uma "div" e é removido as classes "container" e "spaced", comumente utilizando quando precisa usar o QasFormView dentro de um dialog.
     default: true

--- a/ui/src/components/list-view/QasListView.yml
+++ b/ui/src/components/list-view/QasListView.yml
@@ -76,6 +76,11 @@ props:
     default: true
     type: Boolean
 
+  use-pagination:
+    desc: Controla se vai ter ou não paginação.
+    default: true
+    type: Boolean
+
   use-refresh:
     desc: Controla o [pull-to-refresh](https://quasar.dev/vue-components/pull-to-refresh#basic).
     default: true

--- a/ui/src/helpers/copy-to-clipboard.js
+++ b/ui/src/helpers/copy-to-clipboard.js
@@ -6,9 +6,9 @@ export default async (text, onLoading = () => {}) => {
 
   try {
     await copyToClipboard(text)
-    NotifySuccess('Copiado!', text)
+    NotifySuccess('Item copiado com sucesso.')
   } catch {
-    NotifyError('Não foi possível copiar.', text)
+    NotifyError('Não foi possível copiar o item.')
   } finally {
     setTimeout(() => { onLoading(false) }, 500)
   }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
## BREAKING CHANGES
- `QasGallery`: removido slot `destroy` para dar lugar aos slots do `QasGalleryCard`, olhar documentação.
- `QasGallery`: breaking changes nos slots, verificar documentação.
- `QasActionsMenu` agora precisa passar a prop `useTooltip` para controle de tooltip.
- [`QasAppMenu`, `QasAppBar`]: removido propriedade `user` em favor da nova propriedade `appUserProps`.
- `QasAppBar`: removido escopo `user` do slot `user`, uma vez que já temos essa informação fora do componente.

### Adicionado
- `QasListView`: adicionado propriedade `useAutoRefetchOnDelete` para controlar se o componente vai fazer o fetch novamente quando acontecer algum delete compatível com a listagem.
- `QasGallery`: adicionado propriedade `galleryCardProps`.
- `QasGalleryCard`: adicionado novo slot `actions`.
- `QasActionsMenu`: adicionado propriedade `useTooltip` com default `false` para controle de tooltip.
- `QasAppUser`: adicionado propriedade `currentCompany` para setar empresa atual vinculada.
- `QasAppUser`: adicionado propriedade `companiesOptions` para enviar opções de possíveis empresas para troca de vínculo.
- `QasAppUser`: adicionado recurso para troca de vínculo de empresa.
- [`QasAppMenu`, `QasAppBar`]: adicionado propriedade `appUserProps` para repassar todas props do `QasAppUser`.
- `QasListView`: adicionado nova propriedade `usePagination` para controlar paginação com default `true`.

### Modificado
- `QasGallery`: implementado componente `QasGalleryCard`.
- `QasGallery`: com a implementação do componente `QasGalleryCard`, a altura do card passou de `150px` para `180px`.
- `QasGallery`: componente repassa todos os slots do `QasGalleryCard` passando como escopo `image` e `index`.
- `QasGalleryCard`: mudanças de espaçamento e no `defaultActionsMenuProps`.
- `QasActionsMenu`: agora o tooltip precisa de controle por prop `useTooltip`.
- `copyToClipboard`: modificado helper, agora no notify aparece sempre uma mensagem genérica "Item copiado com sucesso." ao invés do texto copiado anteriormente (isto impacta diretamente no componente `QasCopy`).

### Removido
- `QasGallery`: removido slot `destroy` para dar lugar aos slots do `QasGalleryCard`, olhar documentação.
- [`QasAppMenu`, `QasAppBar`]: removido propriedade `user` em favor da nova propriedade `appUserProps`.
- `QasAppBar`: removido escopo `user` do slot `user`, uma vez que já temos essa informação fora do componente.


<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [ ] v3-beta.x -> a partir da branch `develop`.
- [x] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [x] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [x] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
