### PR TITLE
Changes in QasSearchBox/QasListView/QasSingleView/search-filter.js and added new component QasEmptyResultText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
+### Modificado
+- `QasSearchBox`: alterado default da prop `emptyResultText` para `Não há itens para serem exibidos.`
+- `QasSearchBox`: alterado estilo de quando não não há itens para serem exibidos.
+
 ### Corrigido
 - `QasSearchBox`: corrigido primeiro fetch quando existe `options` antes de finalizar o primeiro `fetch`.
 - `ui/src/mixins/search-filter.js`: corrigido duplicidade de opções quando acontece mais de requisição em paralelo pelas mudanças causadas no `lazyLoadingProps`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,23 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
+## BREAKING CHANGES
+- `QasSearchBox`: removido prop `emptyResultText` para manter sempre a mesma mensagem quando não encontra itens.
+
+### Adicionado
+- `QasEmptyResultText`: adicionado novo componente para resultados vazio.
+
 ### Modificado
 - `QasSearchBox`: alterado default da prop `emptyResultText` para `Não há itens para serem exibidos.`
 - `QasSearchBox`: alterado estilo de quando não não há itens para serem exibidos.
+- [`QasSearchBox`, `QasListView`, `QasSingleView`]: adicionado componente `QasEmptyResultText`.
 
 ### Corrigido
 - `QasSearchBox`: corrigido primeiro fetch quando existe `options` antes de finalizar o primeiro `fetch`.
 - `ui/src/mixins/search-filter.js`: corrigido duplicidade de opções quando acontece mais de requisição em paralelo pelas mudanças causadas no `lazyLoadingProps`.
+
+### Removido
+- `QasSearchBox`: removido prop `emptyResultText` para manter sempre a mesma mensagem quando não encontra itens.
 
 ## [3.10.0-beta.0] - 04-05-2023
 ## BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasSearchBox`: corrigido primeiro fetch quando existe `options` antes de finalizar o primeiro `fetch`.
+- `ui/src/mixins/search-filter.js`: corrigido duplicidade de opções quando acontece mais de requisição em paralelo pelas mudanças causadas no `lazyLoadingProps`.
+
 ## [3.10.0-beta.0] - 04-05-2023
 ## BREAKING CHANGES
 - `QasSelect`: removido props `labelKey` e `valueKey`, componente não aceita mais fazer conversão das chaves label/value, o backend deve sempre retornar no padrão correto, em **ultimo** caso, é possível utilizar o helper `getNormalizedOptions` para converter as opções antes de enviar para o componente, porém o componente não fica mais responsável por isto.

--- a/docs/src/assets/menu.js
+++ b/docs/src/assets/menu.js
@@ -117,6 +117,10 @@ module.exports = [
         path: '/components/dialog-router'
       },
       {
+        name: 'EmptyResultText',
+        path: '/components/empty-result-text'
+      },
+      {
         name: 'Field',
         path: '/components/field'
       },

--- a/docs/src/examples/QasEmptyResultText/Basic.vue
+++ b/docs/src/examples/QasEmptyResultText/Basic.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="container q-py-lg">
+    <qas-empty-result-text />
+  </div>
+</template>

--- a/docs/src/pages/components/empty-result-text.md
+++ b/docs/src/pages/components/empty-result-text.md
@@ -1,0 +1,11 @@
+---
+title: QasEmptyResultText
+---
+
+Componente de texto em casos de resultados vazio após filtros.
+
+<doc-api file="empty-result-text/QasEmptyResultText" name="QasEmptyResultText" />
+
+## Uso
+
+<doc-example file="QasEmptyResultText/Basic" title="Básico" />

--- a/ui/src/components/empty-result-text/QasEmptyResultText.vue
+++ b/ui/src/components/empty-result-text/QasEmptyResultText.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="text-body1 text-grey-8">
+    <slot>
+      {{ text }}
+    </slot>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'QasEmptyResultText',
+
+  props: {
+    text: {
+      default: 'Não há itens para serem exibidos.',
+      type: String
+    }
+  }
+}
+</script>

--- a/ui/src/components/empty-result-text/QasEmptyResultText.yml
+++ b/ui/src/components/empty-result-text/QasEmptyResultText.yml
@@ -1,0 +1,14 @@
+type: component
+
+meta:
+  desc: Componente de texto em casos de resultados vazio após filtros.
+
+props:
+  text:
+    desc: Texto a ser exibido.
+    default: Não há itens para serem exibidos.
+    type: String
+
+slots:
+  default:
+    desc: Slot que substitui a propriedade "text".

--- a/ui/src/components/list-view/QasListView.vue
+++ b/ui/src/components/list-view/QasListView.vue
@@ -16,9 +16,7 @@
 
         <div v-else-if="!mx_isFetching">
           <slot name="empty-results">
-            <div class="q-my-lg text-body1 text-grey-7">
-              Não há itens para serem exibidos.
-            </div>
+            <qas-empty-result-text />
           </slot>
         </div>
 

--- a/ui/src/components/search-box/QasSearchBox.vue
+++ b/ui/src/components/search-box/QasSearchBox.vue
@@ -14,7 +14,7 @@
       </slot>
 
       <slot v-if="showEmptyResult" name="empty-result">
-        <qas-empty-result-text class="q-mt-md" v-bind="emptyResultTextProps" />
+        <qas-empty-result-text class="q-mt-md" />
       </slot>
 
       <q-inner-loading :showing="showInnerLoading">
@@ -45,11 +45,6 @@ export default {
     emptyListHeight: {
       default: '100px',
       type: String
-    },
-
-    emptyResultTextProps: {
-      default: () => ({}),
-      type: Object
     },
 
     fuseOptions: {

--- a/ui/src/components/search-box/QasSearchBox.vue
+++ b/ui/src/components/search-box/QasSearchBox.vue
@@ -14,9 +14,7 @@
       </slot>
 
       <slot v-if="showEmptyResult" name="empty-result">
-        <div class="q-mt-sm text-body1 text-grey-8">
-          <div>{{ emptyResultText }}</div>
-        </div>
+        <qas-empty-result-text class="q-mt-md" v-bind="emptyResultTextProps" />
       </slot>
 
       <q-inner-loading :showing="showInnerLoading">
@@ -49,9 +47,9 @@ export default {
       type: String
     },
 
-    emptyResultText: {
-      default: 'Não há itens para serem exibidos.',
-      type: String
+    emptyResultTextProps: {
+      default: () => ({}),
+      type: Object
     },
 
     fuseOptions: {

--- a/ui/src/components/search-box/QasSearchBox.vue
+++ b/ui/src/components/search-box/QasSearchBox.vue
@@ -228,7 +228,9 @@ export default {
       // Se tiver erro no primeiro fetch, retorna o "done" na proxima.
       if (((this.mx_hasFetchError && !this.mx_hasFilteredOptions) || this.hasNoOptionsOnFirstFetch)) return done()
 
-      if (!this.mx_hasFilteredOptions && !this.mx_search) {
+      const canMakeFirstFetch = this.mx_fetchCount === 0 && this.mx_hasFilteredOptions
+
+      if ((!this.mx_hasFilteredOptions || canMakeFirstFetch) && !this.mx_search) {
         await this.mx_setFetchOptions()
         return done()
       }

--- a/ui/src/components/search-box/QasSearchBox.vue
+++ b/ui/src/components/search-box/QasSearchBox.vue
@@ -14,8 +14,7 @@
       </slot>
 
       <slot v-if="showEmptyResult" name="empty-result">
-        <div class="absolute-center text-center">
-          <q-icon class="q-mb-sm text-center" color="primary" name="sym_r_search" size="38px" />
+        <div class="q-mt-sm text-body1 text-grey-8">
           <div>{{ emptyResultText }}</div>
         </div>
       </slot>
@@ -51,7 +50,7 @@ export default {
     },
 
     emptyResultText: {
-      default: 'Não há resultados disponíveis.',
+      default: 'Não há itens para serem exibidos.',
       type: String
     },
 

--- a/ui/src/components/search-box/QasSearchBox.yml
+++ b/ui/src/components/search-box/QasSearchBox.yml
@@ -9,11 +9,6 @@ props:
     default: 100px
     type: String
 
-  empty-result-text:
-    desc: Define o texto dentro do box quando a lista está vazia.
-    default: Não há resultados disponíveis.
-    type: String
-
   entity:
     desc: Entidade enviada para a action "fetchFieldOptions" (usar somente quando "useLazyLoading" estiver habilitada).
     default: ''

--- a/ui/src/components/single-view/QasSingleView.vue
+++ b/ui/src/components/single-view/QasSingleView.vue
@@ -8,10 +8,7 @@
       <slot />
     </template>
 
-    <div v-else-if="!mx_isFetching" class="q-my-xl text-center">
-      <q-icon class="q-mb-sm text-center" color="grey-7" name="sym_r_search" size="38px" />
-      <div class="text-grey-7">Nenhum item encontrado.</div>
-    </div>
+    <qas-empty-result-text v-else-if="!mx_isFetching" class="q-my-xl" />
 
     <footer v-if="mx_hasFooterSlot">
       <slot name="footer" />

--- a/ui/src/mixins/search-filter.js
+++ b/ui/src/mixins/search-filter.js
@@ -102,14 +102,21 @@ export default {
 
       this.mx_fromSearch = !!search
 
-      await this.mx_setFetchOptions()
+      const options = await this.mx_fetchOptions()
+
+      this.mx_resetOptions()
+
+      this.mx_filteredOptions.push(...options)
 
       if (this.mx_cachedOptions.length && !search) this.mx_setInitialCachedOptions()
     },
 
-    mx_resetFilter (search) {
+    mx_resetOptions () {
       this.mx_filteredOptions = []
       this.mx_foundDuplicatedOptions = []
+    },
+
+    mx_resetFilter (search) {
       this.mx_search = search
       this.mx_pagination = {
         page: 1,

--- a/ui/src/vue-plugin.js
+++ b/ui/src/vue-plugin.js
@@ -19,6 +19,7 @@ import QasDebugger from './components/debugger/QasDebugger.vue'
 import QasDelete from './components/delete/QasDelete.vue'
 import QasDialog from './components/dialog/QasDialog.vue'
 import QasDialogRouter from './components/dialog-router/QasDialogRouter.vue'
+import QasEmptyResultText from './components/empty-result-text/QasEmptyResultText.vue'
 import QasField from './components/field/QasField.vue'
 import QasSearchInput from './components/search-input/QasSearchInput.vue'
 import QasFilters from './components/filters/QasFilters.vue'
@@ -101,6 +102,7 @@ function install (app) {
   app.component('QasDelete', QasDelete)
   app.component('QasDialog', QasDialog)
   app.component('QasDialogRouter', QasDialogRouter)
+  app.component('QasEmptyResultText', QasEmptyResultText)
   app.component('QasField', QasField)
   app.component('QasSearchInput', QasSearchInput)
   app.component('QasFilters', QasFilters)
@@ -184,6 +186,7 @@ export {
   QasDelete,
   QasDialog,
   QasDialogRouter,
+  QasEmptyResultText,
   QasField,
   QasSearchInput,
   QasFilters,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
## BREAKING CHANGES
- `QasSearchBox`: removido prop `emptyResultText` para manter sempre a mesma mensagem quando não encontra itens.

### Adicionado
- `QasEmptyResultText`: adicionado novo componente para resultados vazio.

### Modificado
- `QasSearchBox`: alterado default da prop `emptyResultText` para `Não há itens para serem exibidos.`
- `QasSearchBox`: alterado estilo de quando não não há itens para serem exibidos.
- [`QasSearchBox`, `QasListView`, `QasSingleView`]: adicionado componente `QasEmptyResultText`.

### Corrigido
- `QasSearchBox`: corrigido primeiro fetch quando existe `options` antes de finalizar o primeiro `fetch`.
- `ui/src/mixins/search-filter.js`: corrigido duplicidade de opções quando acontece mais de requisição em paralelo pelas mudanças causadas no `lazyLoadingProps`.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
