### PR TITLE
Fixed `search-filter.js`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `search-filter.js`: corrigido problema de quando as opções externas são setadas após o fetch interno de opções, que fazia que as opções externas sobrescreviam as opões interna erroneamente.
+
 ## [3.10.0-beta.3] - 12-05-2023
 ## BREAKING CHANGES
 - `QasFilters`: O componente irá filtrar somente campos com valores que sejam diferente de **null** ou **undefined**, caso contrário ao filtrar o campo irá ser removido da query.

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -45,7 +45,7 @@
     },
     "../ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.10.0-beta.2",
+      "version": "3.10.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/store-adapter": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6934,7 +6934,7 @@
     },
     "ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.10.0-beta.2",
+      "version": "3.10.0-beta.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/ui/src/mixins/search-filter.js
+++ b/ui/src/mixins/search-filter.js
@@ -272,7 +272,17 @@ export default {
       this.$watch(model, options => {
         if (!options?.length) return
 
-        this.mx_filteredOptions = [...options]
+        /*
+          * pode ser que as opções sejam inicializadas após o primeiro fetch de opções
+          * fazendo com que as opções sobrescreva as que vieram através do fetch, então é
+          * preciso tratar para nestes casos serem incrementadas ao invés de sobrescrever.
+        */
+        if (this.mx_fetchCount === 1) {
+          this.mx_filteredOptions.unshift(...options)
+        } else {
+          this.mx_filteredOptions = [...options]
+        }
+
         this.mx_cachedOptions = [...options]
       }, { immediate: true })
     }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Corrigido
- `search-filter.js`: corrigido problema de quando as opções externas são setadas após o fetch interno de opções, que fazia que as opções externas sobrescreviam as opões interna erroneamente.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [ ] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [x] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
