### PR TITLE
QasFilters no filters in context fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasFilters`: corrigido problema no método `updateValues`. O model interno de `filters` ficava desatualizado quando não tinha query na URL.
+
 ## [3.10.0-beta.4] - 17-05-2023
 ### Modificado
 - `QasDate`: adicionado a cor primaria na data de hoje.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ## Não publicado
 ### Corrigido
 - `QasFilters`: corrigido problema no método `updateValues`. O model interno de `filters` ficava desatualizado quando não tinha query na URL.
+- `QasFilters`: corrigido problema na checagem se há valores nos `fields` retornados da API, caso não viesse `fields` ocorria um erro no console ao recuperar o tamanho do objeto de `fields`.
 
 ## [3.10.0-beta.4] - 17-05-2023
 ### Modificado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ### Corrigido
 - `QasFilters`: corrigido problema no método `updateValues`. O model interno de `filters` ficava desatualizado quando não tinha query na URL.
 - `QasFilters`: corrigido problema na checagem se há valores nos `fields` retornados da API, caso não viesse `fields` ocorria um erro no console ao recuperar o tamanho do objeto de `fields`.
+- `QasFilters`: corrigido atualização do model `currentFilters` que emitia o evento de atualização antes da query ser atualizada com base no filtro realizado.
 
 ## [3.10.0-beta.4] - 17-05-2023
 ### Modificado

--- a/docs/src/examples/QasFilters/NoRouteUpdate.vue
+++ b/docs/src/examples/QasFilters/NoRouteUpdate.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="container spaced">
     <qas-filters v-model:currentFilters="currentFilters" :entity="entity" :use-update-route="false" />
+    Valor filtrado: <qas-debugger :inspect="[currentFilters]" />
   </div>
 </template>
 

--- a/ui/src/components/filters/QasFilters.vue
+++ b/ui/src/components/filters/QasFilters.vue
@@ -394,9 +394,9 @@ export default {
     },
 
     setFilters () {
-      const { filters } = this.mx_context
-
       this.filters = {}
+
+      const { filters } = this.mx_context
 
       for (const key in filters) {
         this.filters[key] = parseValue(this.normalizeValues(filters[key], this.fields[key]?.multiple))

--- a/ui/src/components/filters/QasFilters.vue
+++ b/ui/src/components/filters/QasFilters.vue
@@ -229,7 +229,7 @@ export default {
   },
 
   methods: {
-    clearFilters () {
+    async clearFilters () {
       const { filters } = this.mx_context
       const query = { ...this.$route.query }
       const activeFilters = {
@@ -254,8 +254,10 @@ export default {
       }
 
       this.hideFiltersMenu()
+
+      await this.updateRouteQuery(query)
+
       this.updateCurrentFilters()
-      this.updateRouteQuery(query)
     },
 
     clearSearch () {
@@ -302,7 +304,7 @@ export default {
       }
     },
 
-    filter (external) {
+    async filter (external) {
       const { filters, page, ...context } = this.mx_context
 
       const query = {
@@ -318,8 +320,10 @@ export default {
       }
 
       this.hideFiltersMenu()
+
+      await this.updateRouteQuery(query)
+
       this.updateCurrentFilters()
-      this.updateRouteQuery(query)
     },
 
     getChipValue (value) {
@@ -330,14 +334,15 @@ export default {
       this.$refs.filtersButton?.hideMenu()
     },
 
-    removeFilter ({ name }) {
+    async removeFilter ({ name }) {
       const query = { ...this.$route.query }
 
       delete query[name]
       delete this.filters[name]
 
+      await this.updateRouteQuery(query)
+
       this.updateCurrentFilters()
-      this.updateRouteQuery(query)
     },
 
     updateCurrentFilters () {
@@ -349,8 +354,8 @@ export default {
       this.$emit('update:currentFilters', this.currentFilters)
     },
 
-    updateRouteQuery (query) {
-      this.useUpdateRoute && this.$router.push({ query })
+    async updateRouteQuery (query) {
+      this.useUpdateRoute && await this.$router.push({ query })
     },
 
     updateValues () {

--- a/ui/src/components/filters/QasFilters.vue
+++ b/ui/src/components/filters/QasFilters.vue
@@ -355,12 +355,7 @@ export default {
 
     updateValues () {
       this.setSearch()
-
-      const { filters } = this.mx_context
-
-      for (const key in filters) {
-        this.filters[key] = parseValue(this.normalizeValues(filters[key], this.fields[key]?.multiple))
-      }
+      this.setFilters()
     },
 
     normalizeValues (value, isMultiple) {
@@ -396,6 +391,16 @@ export default {
     setSearch () {
       const { search } = this.mx_context
       this.search = search || ''
+    },
+
+    setFilters () {
+      const { filters } = this.mx_context
+
+      this.filters = {}
+
+      for (const key in filters) {
+        this.filters[key] = parseValue(this.normalizeValues(filters[key], this.fields[key]?.multiple))
+      }
     }
   }
 }

--- a/ui/src/components/filters/QasFilters.vue
+++ b/ui/src/components/filters/QasFilters.vue
@@ -368,7 +368,7 @@ export default {
       if (!this.useUpdateRoute) return
 
       const watchOnce = this.$watch('fields', values => {
-        if (Object.keys(values).length) {
+        if (Object.keys(values || {}).length) {
           this.updateValues()
           this.updateCurrentFilters()
           watchOnce()

--- a/ui/src/components/filters/QasFilters.yml
+++ b/ui/src/components/filters/QasFilters.yml
@@ -4,6 +4,13 @@ meta:
   desc: Componente para criação de filtros dinâmicos.
 
 props:
+  current-filters:
+    model: true
+    desc: Utilizado para recuperar os filtros realizados internamente.
+    default: {}
+    type: Object
+    examples: [v-model:currentFilters="currentFilters"]
+
   entity:
     desc: Entidade da store, por exemplo se tiver que trabalhar com modulo de usuários, teremos o model "users" na store, que vai ser nossa "entity".
     required: true


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- (Remova este texto de descrição.) -->
## Corrigido
- `QasFilters`: corrigido problema no método `updateValues`. O model interno de `filters` ficava desatualizado quando não tinha query na URL.
- `QasFilters`: corrigido problema na checagem se há valores nos `fields` retornados da API, caso não viesse `fields` ocorria um erro no console ao recuperar o tamanho do objeto de `fields`.
- `QasFilters`: corrigido atualização do model `currentFilters` que emitia o evento de atualização antes da query ser atualizada com base no filtro realizado.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
