### PR TITLE
Added QasEmptyResultText on QasUploader 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `QasUploader`: adicionado `QasEmptyResultText` para quando o modelValue do componente for vazio (também afeta o QasSignatureUploader).
+
 ## [3.10.0-beta.4] - 17-05-2023
 ### Modificado
 - `QasDate`: adicionado a cor primaria na data de hoje.

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -45,7 +45,7 @@
     },
     "../ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.10.0-beta.3",
+      "version": "3.10.0-beta.4",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/store-adapter": "^1.0.0",

--- a/docs/src/pages/start/develop.md
+++ b/docs/src/pages/start/develop.md
@@ -36,7 +36,7 @@ Primeiro, você precisa pegar o caminho relativo que se encontra o `asteroid` lo
 Dentro do seu projeto que está usando asteroid, no terminal, vá até `node_modules/@bildvitta/quasar-app-extension-asteroid`, e digite este comando:
 
 ```js
-npm add --dev file:~/Documents/bild/asteroid
+npm add file:~/Documents/bild/asteroid/ui
 ```
 
 Agora o `quasar-app-extension-asteroid` dentro do `node_modules` do seu projeto está redirecionado para o `ui/` do asteroid localmente.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6934,7 +6934,7 @@
     },
     "ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.10.0-beta.3",
+      "version": "3.10.0-beta.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/ui/src/components/uploader/QasUploader.vue
+++ b/ui/src/components/uploader/QasUploader.vue
@@ -24,10 +24,14 @@
       </template>
 
       <template #list="scope">
-        <div v-if="hasGalleryCardSection" class="q-col-gutter-lg q-mt-sm row">
+        <div v-if="hasGalleryCardSection(getFilesList(scope.files, scope))" class="q-col-gutter-lg q-mt-sm row">
           <div v-for="(file, key, index) in getFilesList(scope.files, scope)" :key="index" :class="columnClasses">
             <pv-uploader-gallery-card v-bind="getUploaderGalleryCardProps({ key, scope, file, index })" />
           </div>
+        </div>
+
+        <div v-else class="q-mt-md">
+          <qas-empty-result-text />
         </div>
       </template>
     </q-uploader>
@@ -268,12 +272,6 @@ export default {
       return this.$slots['custom-upload']
     },
 
-    hasGalleryCardSection () {
-      return (
-        (this.useObjectModel ? !!Object.keys(this.modelValue).length : !!this.modelValue?.length) || this.hasError
-      )
-    },
-
     hasHeaderSlot () {
       return this.$slots.header
     },
@@ -448,6 +446,10 @@ export default {
 
     handleSubmitSuccess ({ detail: { entity } }) {
       if (entity === this.entity) this.setSavedFiles()
+    },
+
+    hasGalleryCardSection (files) {
+      return Object.keys(files).length
     },
 
     isFailed (file) {

--- a/ui/src/components/uploader/QasUploader.vue
+++ b/ui/src/components/uploader/QasUploader.vue
@@ -30,7 +30,7 @@
           </div>
         </div>
 
-        <div v-else class="q-mt-md">
+        <div v-else class="q-mt-lg">
           <qas-empty-result-text />
         </div>
       </template>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

### Modificado
- `QasUploader`: adicionado `QasEmptyResultText` para quando o modelValue do componente for vazio (também afeta o QasSignatureUploader).

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
