### PR TITLE
Fixed single label in QasNestedFields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasNestedFields`: corrigido problemas referentes ao espaçamento do label quando é usado com `useSingleLabel`.
+
 ## [3.10.0-beta.4] - 17-05-2023
 ### Modificado
 - `QasDate`: adicionado a cor primaria na data de hoje.

--- a/docs/src/examples/QasNestedFields/Basic.vue
+++ b/docs/src/examples/QasNestedFields/Basic.vue
@@ -3,7 +3,7 @@
     <div class="full-width">
       <div class="q-mt-lg text-center">
         <div>
-          <qas-nested-fields v-model="model" class="full-width" :field="nested" :fields-props="fieldsProps" :form-columns="formColumns" :row-object="rowObject" />
+          <qas-nested-fields v-model="model" class="full-width" :field="nested" :fields-props="fieldsProps" :form-columns="formColumns" :row-object="rowObject" use-inline-action use-single-label />
         </div>
 
         <div class="q-my-lg">

--- a/docs/src/examples/QasNestedFields/ExSingleLabel.vue
+++ b/docs/src/examples/QasNestedFields/ExSingleLabel.vue
@@ -3,7 +3,7 @@
     <div class="full-width">
       <div class="q-mt-lg text-center">
         <div>
-          <qas-nested-fields v-model="model" class="full-width" :field="nested" :fields-props="fieldsProps" :form-columns="formColumns" :row-object="rowObject" />
+          <qas-nested-fields v-model="model" class="full-width" :field="nested" :fields-props="fieldsProps" :form-columns="formColumns" :row-object="rowObject" use-inline-actions use-single-label />
         </div>
 
         <div class="q-my-lg">

--- a/docs/src/pages/components/nested-fields.md
+++ b/docs/src/pages/components/nested-fields.md
@@ -66,6 +66,7 @@ A propriedade `useDestroyAlways` caso não seja repassada ao componente, assume 
 ## Uso
 
 <doc-example file="QasNestedFields/Basic" title="Básico" />
+<doc-example file="QasNestedFields/ExSingleLabel" title="Label única" />
 <doc-example file="QasNestedFields/StartsEmptyFalse" title="Começando com formulário" />
 <doc-example file="QasNestedFields/DisabledRows" title="Linhas desabilitadas" />
 <doc-example file="QasNestedFields/InlineActions" title="Propriedade useInlineActions" />

--- a/ui/src/components/nested-fields/QasNestedFields.vue
+++ b/ui/src/components/nested-fields/QasNestedFields.vue
@@ -1,14 +1,14 @@
 <template>
   <div :id="fieldName" class="qas-nested-fields">
     <div class="text-left">
-      <qas-label v-if="useSingleLabel" :label="fieldLabel" />
+      <qas-label v-if="useSingleLabel" :label="fieldLabel" margin="lg" />
     </div>
 
     <div ref="inputContent">
       <component :is="componentTag" v-bind="componentProps">
         <template v-for="(row, index) in nested" :key="`row-${index}`">
-          <div v-if="!row[destroyKey]" :id="`row-${index}`" class="full-width q-mt-md">
-            <header class="flex items-center q-py-md" :class="headerClasses">
+          <div v-if="!row[destroyKey]" :id="`row-${index}`" class="full-width q-mt-md qas-nested-fields__field-item">
+            <header v-if="hasHeader" class="flex items-center" :class="headerClasses">
               <qas-label v-if="!useSingleLabel" :label="getRowLabel(index)" />
               <qas-actions-menu v-if="hasBlockActions(row)" v-bind="actionsMenuProps" :list="getActionsList(index, row)" />
             </header>
@@ -290,8 +290,17 @@ export default {
       return this.useFirstInputButton && !this.nested.length
     },
 
+    hasHeader () {
+      return !this.useSingleLabel && !this.useInlineActions
+    },
+
     headerClasses () {
-      return this.useSingleLabel ? 'justify-end' : 'justify-between'
+      return {
+        'justify-end': this.useSingleLabel,
+        'justify-between': !this.useSingleLabel,
+        'q-pb-sm': this.useSingleLabel,
+        'q-pb-md': !this.useSingleLabel
+      }
     }
   },
 
@@ -462,6 +471,10 @@ export default {
 .qas-nested-fields {
   &__actions {
     height: 56px;
+  }
+
+  &__field-item + &__field-item {
+    margin-top: var(--qas-spacing-xl);
   }
 }
 </style>

--- a/ui/src/components/nested-fields/QasNestedFields.vue
+++ b/ui/src/components/nested-fields/QasNestedFields.vue
@@ -291,7 +291,7 @@ export default {
     },
 
     hasHeader () {
-      return !this.useSingleLabel && !this.useInlineActions
+      return !this.useInlineActions
     },
 
     headerClasses () {
@@ -299,7 +299,7 @@ export default {
         'justify-end': this.useSingleLabel,
         'justify-between': !this.useSingleLabel,
         'q-pb-sm': this.useSingleLabel,
-        'q-pb-md': !this.useSingleLabel
+        'q-pb-md': !this.useInlineActions
       }
     }
   },


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

### Corrigido
- `QasNestedFields`: corrigido problemas referentes ao espaçamento do label quando é usado com `useSingleLabel`.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
