### PR TITLE
Feature/lazy loading props watcher fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,13 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `search-filter`: corrigido problema com filtros relacionados onde as opções cacheadas (opções iniciais) não eram limpas após mudança dos parâmetros da URL de lazy loading.
+- `search-filter`: corrigido problema com filtros relacionados que estavam sendo disparados o evento para buscar novas opções sem necessariamente ter alterado os parâmetros da URL de lazy loading.
+
 ## [3.10.0-beta.6] - 30-05-2023
-### corrigido
+### Corrigido
 - `QasNestedFields`: corrigido espaçamento das labels.
 
 ## [3.10.0-beta.5] - 30-05-2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
+### Modificado
+- `QasSelect`: modificado comportamento para selects do tipo lazy loading para não ser possível selecionar uma opção quando o componente estiver buscando por novas opções.
+
 ### Corrigido
 - `search-filter`: corrigido problema com filtros relacionados onde as opções cacheadas (opções iniciais) não eram limpas após mudança dos parâmetros da URL de lazy loading.
 - `search-filter`: corrigido problema com filtros relacionados que estavam sendo disparados o evento para buscar novas opções sem necessariamente ter alterado os parâmetros da URL de lazy loading.

--- a/ui/src/components/search-box/QasSearchBox.vue
+++ b/ui/src/components/search-box/QasSearchBox.vue
@@ -27,7 +27,7 @@
 <script>
 import { QInfiniteScroll } from 'quasar'
 import Fuse from 'fuse.js'
-
+import fuseConfig from '../../shared/fuse-config'
 import QasBox from '../box/QasBox.vue'
 import { searchFilterMixin } from '../../mixins'
 
@@ -139,8 +139,7 @@ export default {
 
     defaultFuseOptions () {
       return {
-        ignoreLocation: true,
-
+        ...fuseConfig,
         ...this.fuseOptions
       }
     },

--- a/ui/src/components/search-box/QasSearchBox.yml
+++ b/ui/src/components/search-box/QasSearchBox.yml
@@ -29,7 +29,7 @@ props:
     examples: ["{ keys: ['label'] }"]
     default:
       ignoreLocation: true
-      threshold: 0.6
+      threshold: 0.4
 
   height:
     desc: Define altura do box quando a lista não está vazia.

--- a/ui/src/components/select/QasSelect.vue
+++ b/ui/src/components/select/QasSelect.vue
@@ -71,7 +71,7 @@ export default {
     }
   },
 
-  emits: ['popup-hide', 'popup-show', 'update:modelValue'],
+  emits: ['popup-hide', 'popup-show', 'update:modelValue', 'virtual-scroll'],
 
   data () {
     return {
@@ -219,16 +219,16 @@ export default {
       this.$emit('popup-show')
 
       if (this.mx_isFetching) {
-        this.togglePopupContentClass()
+        this.togglePopupContentClass(true)
       }
     },
 
     setIsFetchingWatcher () {
       if (this.useLazyLoading) {
         this.$watch('mx_isFetching', value => {
-          if (!this.isPopupContentOpen || value) return
+          if (!this.isPopupContentOpen) return
 
-          this.togglePopupContentClass()
+          this.togglePopupContentClass(value)
         })
       }
     },
@@ -245,13 +245,13 @@ export default {
       if (this.hasFuse) this.setFuse()
     },
 
-    async togglePopupContentClass () {
+    async togglePopupContentClass (force) {
       await this.$nextTick()
 
       const popupContentElement = document.querySelector(`.${this.popupContentClass}`)
 
       if (popupContentElement) {
-        popupContentElement.classList.toggle('qas-select__is-fetching')
+        popupContentElement.classList.toggle('qas-select__is-fetching', force)
       }
     }
   }

--- a/ui/src/components/select/QasSelect.yml
+++ b/ui/src/components/select/QasSelect.yml
@@ -27,7 +27,7 @@ props:
     default:
       ignoreLocation: true
       keys: [label, value]
-      threshold: 0.6
+      threshold: 0.4
 
   label-key:
     desc: O componente internamente espera receber na propriedade "options" um array de objeto contendo "label" e "value", caso o seu objeto não tenha "label" mas um "name" por exemplo, você pode definir esta prop "label-key" como "name".

--- a/ui/src/mixins/search-filter.js
+++ b/ui/src/mixins/search-filter.js
@@ -77,26 +77,19 @@ export default {
 
     mx_hasFilteredOptions () {
       return !!this.mx_filteredOptions.length
-    },
-
-    mx_isMultiple () {
-      return this.$attrs.multiple || this.$attrs.multiple === ''
     }
   },
 
   watch: {
     'lazyLoadingProps.params': {
       handler (newParams, oldParams) {
-        const hasNewParams = Object.values(newParams).some(value => value)
-        const hasOldParams = Object.values(oldParams).some(value => value)
-        const isEqualParams = isEqual(newParams, oldParams)
-
-        if ((!hasNewParams && !hasOldParams) || isEqualParams) return
+        if (isEqual(newParams, oldParams)) return
 
         this.mx_cachedOptions = []
+
         this.mx_filterOptionsByStore('')
 
-        this.$emit('update:modelValue', this.mx_isMultiple ? [] : '')
+        this.$emit('update:modelValue', undefined)
       }
     }
   },

--- a/ui/src/mixins/search-filter.js
+++ b/ui/src/mixins/search-filter.js
@@ -124,7 +124,8 @@ export default {
       }
     },
 
-    async mx_onVirtualScroll ({ index, ref }) {
+    async mx_onVirtualScroll (details) {
+      const { index, ref } = details
       const lastIndex = this.mx_filteredOptions.length - 1
 
       if (index === lastIndex && this.mx_canFetchOptions()) {
@@ -135,6 +136,8 @@ export default {
           ref.refresh(lastIndex)
         })
       }
+
+      this.$emit('virtual-scroll', details)
     },
 
     async mx_loadMoreOptions () {

--- a/ui/src/mixins/search-filter.js
+++ b/ui/src/mixins/search-filter.js
@@ -85,10 +85,15 @@ export default {
   },
 
   watch: {
-    lazyLoadingProps: {
-      handler (value, oldValue) {
-        if (isEqual(value, oldValue)) return
+    'lazyLoadingProps.params': {
+      handler (newParams, oldParams) {
+        const hasNewParams = Object.values(newParams).some(value => value)
+        const hasOldParams = Object.values(oldParams).some(value => value)
+        const isEqualParams = isEqual(newParams, oldParams)
 
+        if ((!hasNewParams && !hasOldParams) || isEqualParams) return
+
+        this.mx_cachedOptions = []
         this.mx_filterOptionsByStore('')
 
         this.$emit('update:modelValue', this.mx_isMultiple ? [] : '')

--- a/ui/src/shared/fuse-config.js
+++ b/ui/src/shared/fuse-config.js
@@ -1,0 +1,4 @@
+export default {
+  ignoreLocation: true,
+  threshold: 0.4
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- (Remova este texto de descrição.) -->
### Corrigido
- `search-filter`: corrigido problema com filtros relacionados onde as opções cacheadas (opções iniciais) não eram limpas após mudança dos parâmetros da URL de lazy loading.
- `search-filter`: corrigido problema com filtros relacionados que estavam sendo disparados o evento para buscar novas opções sem necessariamente ter alterado os parâmetros da URL de lazy loading.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [ ] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [ ] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
