### PR TITLE
Changes in QasLabel and field.scss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `QasLabel`: modificado default da prop `margin` para `md (16px)`.
+- `QasLabel`: modificado tipografia para `text-h4`.
+
+### Corrigido
+- `ui/src/css/components/field.scss`: corrigido seletor de classe que estava deixando com cor no lugar errado.
+
 ## [3.11.0-beta.2] - 23-06-2023
 ### Modificado
 - `QasAvatar`: adicionado nova cor `grey-4` na propriedade `color`.

--- a/ui/src/components/label/QasLabel.vue
+++ b/ui/src/components/label/QasLabel.vue
@@ -1,11 +1,12 @@
 <template>
-  <div class="text-subtitle1" :class="classes">
+  <div class="text-h4" :class="classes">
     <slot :label-with-suffix="labelWithSuffix">{{ labelWithSuffix }}</slot>
   </div>
 </template>
 
 <script>
 import { addCounterSuffix } from '../../helpers'
+import { Spacing } from '../../enums/Spacing'
 
 export default {
   name: 'QasLabel',
@@ -22,12 +23,12 @@ export default {
     },
 
     margin: {
-      default: 'sm',
+      default: Spacing.Md,
       type: String,
       validator: value => {
-        const marginList = ['none', 'auto', 'xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl']
+        const availableSpacings = Object.values(Spacing)
 
-        return marginList.includes(value)
+        return availableSpacings.includes(value)
       }
     },
 

--- a/ui/src/css/components/field.scss
+++ b/ui/src/css/components/field.scss
@@ -1,4 +1,4 @@
-.q-field--outlined .q-field__inner {
+.q-field--outlined .q-field__control {
   background-color: white;
   border-radius: $generic-border-radius;
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Modificado
- `QasLabel`: modificado default da prop `margin` para `md (16px)`.
- `QasLabel`: modificado tipografia para `text-h4`.

### Corrigido
- `ui/src/css/components/field.scss`: corrigido seletor de classe que estava deixando com cor no lugar errado.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [x] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
