### PR TITLE
QasFormGenerator: v-model changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+## BREAKING CHANGES
+- Como agora as mudanças do v-model do componente `QasFormGenerator` é refletida instantaneamente, pode ser que em alguns locais foi utilizado o `$nextTick` para recuperar o valor mais atualizado do model, porém, talvez agora não seja mais necessário.
+
+### Corrigido
+- `QasFormGenerator`: Corrigido problema de atualização do `v-model`, agora as mudanças realizadas nos valores do formulário são refletidas instantaneamente.
+
 ## [3.11.0-beta.3] - 26-06-2023
 ### Modificado
 - `QasLabel`: modificado default da prop `margin` para `md (16px)`.

--- a/ui/src/components/form-generator/QasFormGenerator.vue
+++ b/ui/src/components/form-generator/QasFormGenerator.vue
@@ -9,14 +9,14 @@
         <div :class="classes">
           <div v-for="(field, key) in fieldsetItem.fields.visible" :key="key" :class="getFieldClass({ index: key, fields: normalizedFields })">
             <slot :field="field" :name="`field-${field.name}`">
-              <qas-field :disable="isFieldDisabled(field)" v-bind="fieldsProps[field.name]" :error="errors[key]" :field="field" :model-value="modelValue[field.name]" @update:model-value="updateModelValue({ key: field.name, value: $event })" />
+              <qas-field v-bind="fieldsProps[field.name]" v-model="model[field.name]" :disable="isFieldDisabled(field)" :error="errors[key]" :field="field" />
             </slot>
           </div>
         </div>
 
         <div v-for="(field, key) in fieldsetItem.fields.hidden" :key="key">
           <slot :field="field" :name="`field-${field.name}`">
-            <qas-field :disable="isFieldDisabled(field)" v-bind="fieldsProps[field.name]" :field="field" :model-value="modelValue[field.name]" @update:model-value="updateModelValue({ key: field.name, value: $event })" />
+            <qas-field v-bind="fieldsProps[field.name]" v-model="model[field.name]" :disable="isFieldDisabled(field)" :field="field" />
           </slot>
         </div>
       </div>
@@ -79,6 +79,16 @@ const { classes, getFieldClass } = useGenerator({ props })
 const { fieldsetClasses, hasFieldset } = useFieldset({ props })
 
 // computed
+const model = computed({
+  get () {
+    return props.modelValue
+  },
+
+  set (value) {
+    emit('update:modelValue', value)
+  }
+})
+
 const groupedFields = computed(() => {
   const fields = { hidden: {}, visible: {} }
 
@@ -149,13 +159,6 @@ function getFieldType ({ type }) {
 
 function isFieldDisabled ({ disable }) {
   return disable || props.disable
-}
-
-function updateModelValue ({ key, value }) {
-  const models = { ...props.modelValue }
-  models[key] = value
-
-  emit('update:modelValue', models)
 }
 
 // composables


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- (Remova este texto de descrição.) -->
`QasFormGenerator`: Corrigido problema de atualização do `v-model`, agora as mudanças realizadas nos valores do formulário são refletidas instantaneamente.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
