### PR TITLE
Feature/empty result text nullish result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
+
+### Adicionado
+- `isEmpty.js`: adicionado novo helper para verificar se um valor é vazio (null, undefined ou '').
+
+### Modificado
+- [`QasGridGenerator`, `QasTableGenerator`]: modificado comportamento de exibição do valor do `empty-result-text`. Agora para o resultado de algum campo ser considerado vazio é necessário que o seu valor seja `null`, `undefined` ou `''`.
+
 ### Corrigido
 - `QasGridGenerator`: corrigido ordem de exibição dos `fields`.
 - `docs`: exibição dos componentes na documentação do `QasChartView` e `QasMaps`.

--- a/docs/src/assets/menu.js
+++ b/docs/src/assets/menu.js
@@ -395,6 +395,10 @@ module.exports = [
         path: '/helpers/images'
       },
       {
+        name: 'isEmpty',
+        path: '/helpers/is-empty'
+      },
+      {
         name: 'isLocalDevelopment',
         path: '/helpers/is-local-development'
       },

--- a/docs/src/pages/helpers/is-empty.md
+++ b/docs/src/pages/helpers/is-empty.md
@@ -1,0 +1,25 @@
+---
+title: isEmpty
+---
+
+Função para retornar se o valor passado por parâmetro é vazio. É considerado vazio os seguintes valores: `undefined`, `null` e `''`.
+
+```js
+isEmpty('')
+// Retorna: true
+
+isEmpty(undefined)
+// Retorna: true
+
+isEmpty(null)
+// Retorna: true
+
+isEmpty('John Doe')
+// Retorna: false
+
+isEmpty(0)
+// Retorna: false
+
+isEmpty(false)
+// Retorna: false
+```

--- a/docs/src/pages/helpers/is-empty.md
+++ b/docs/src/pages/helpers/is-empty.md
@@ -5,21 +5,21 @@ title: isEmpty
 Função para retornar se o valor passado por parâmetro é vazio. É considerado vazio os seguintes valores: `undefined`, `null` e `''`.
 
 ```js
-isEmpty('')
+isEmpty({ value: undefined })
 // Retorna: true
 
-isEmpty(undefined)
+isEmpty({ value: null })
 // Retorna: true
 
-isEmpty(null)
+isEmpty({ value: '' })
 // Retorna: true
 
-isEmpty('John Doe')
+isEmpty({ value: 'foo' })
 // Retorna: false
 
-isEmpty(0)
+isEmpty({ value: 0 })
 // Retorna: false
 
-isEmpty(false)
+isEmpty({ value: false })
 // Retorna: false
 ```

--- a/ui/src/components/grid-generator/QasGridGenerator.vue
+++ b/ui/src/components/grid-generator/QasGridGenerator.vue
@@ -20,7 +20,7 @@
 
 <script setup>
 import useGenerator, { baseProps } from '../../composables/private/use-generator'
-import { humanize } from '../../helpers/filters'
+import { isEmpty, humanize } from '../../helpers'
 import { isObject } from 'lodash-es'
 import { ref, computed, watch } from 'vue'
 
@@ -107,9 +107,12 @@ function getFieldsByResult () {
 
     if (!field.type) continue
 
+    const humanizedResult = humanize(field, result[key])
+    const formattedResult = isEmpty({ value: humanizedResult }) ? props.emptyResultText : humanizedResult
+
     fieldsByResult[key] = {
       ...field,
-      formattedResult: humanize(field, result[key]) || props.emptyResultText
+      formattedResult
     }
   }
 

--- a/ui/src/components/grid-generator/QasGridGenerator.yml
+++ b/ui/src/components/grid-generator/QasGridGenerator.yml
@@ -16,7 +16,7 @@ props:
     type: [Array, Object, String]
 
   empty-result-text:
-    desc: Se o resultado de algum campo for vazio, esta prop define qual será o valor padrão.
+    desc: Se o resultado de algum campo for vazio (null, undefined, ''), esta prop define qual será o valor padrão.
     default: '-'
     type: String
 

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -20,8 +20,7 @@
 
 <script>
 import { extend } from 'quasar'
-import { humanize } from '../../helpers/filters'
-import { setScrollOnGrab } from '../../helpers'
+import { isEmpty, humanize, setScrollOnGrab } from '../../helpers'
 
 export default {
   name: 'QasTableGenerator',
@@ -190,8 +189,11 @@ export default {
 
       const mappedResults = results.map((result, index) => {
         for (const key in result) {
+          const humanizedResult = humanize(this.fields[key], result[key])
+          const formattedResult = isEmpty({ value: humanizedResult }) ? this.emptyResultText : humanizedResult
+
           result.default = this.results[index]
-          result[key] = humanize(this.fields[key], result[key]) || this.emptyResultText
+          result[key] = formattedResult
         }
 
         return result

--- a/ui/src/components/table-generator/QasTableGenerator.yml
+++ b/ui/src/components/table-generator/QasTableGenerator.yml
@@ -10,7 +10,7 @@ props:
     type: Array
 
   empty-result-text:
-    desc: Quando uma célula da tabela está vazia, esta prop define qual será o valor padrão.
+    desc: Quando uma célula da tabela está vazia (null, undefined, ''), esta prop define qual será o valor padrão.
     default: '-'
     type: String
 

--- a/ui/src/helpers/index.js
+++ b/ui/src/helpers/index.js
@@ -13,6 +13,7 @@ export { default as getGreatestCommonDivisor } from './get-greatest-common-divis
 export { default as getNormalizedOptions } from './get-normalized-options.js'
 export { default as getSlotChildrenText } from './get-slot-children-text.js'
 export { default as handleProcess } from './handle-process.js'
+export { default as isEmpty } from './is-empty.js'
 export { default as isLocalDevelopment } from './is-local-development.js'
 export { default as promiseHandler } from './promise-handler.js'
 export { default as setScrollOnGrab } from './set-scroll-on-grab.js'

--- a/ui/src/helpers/is-empty.js
+++ b/ui/src/helpers/is-empty.js
@@ -1,0 +1,3 @@
+export default function ({ value }) {
+  return [null, undefined, ''].includes(value)
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- (Remova este texto de descrição.) -->
### Adicionado
- `isEmpty.js`: adicionado novo helper para verificar se um valor é vazio (null, undefined ou '').

### Modificado
- [`QasGridGenerator`, `QasTableGenerator`]: modificado comportamento de exibição do valor do `empty-result-text`. Agora para o resultado de algum campo ser considerado vazio é necessário que o seu valor seja `null`, `undefined` ou `''`.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [x] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
