### PR TITLE
feat(QasDelete): added redirect-route

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,7 +32,8 @@
     "QasActionsMenu",
     "QasTableGenerator",
     "QasDate",
-    "QasChartView"
+    "QasChartView",
+    "QasDelete"
   ],
   "cSpell.words": [
     "Breakline",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ## Não publicado
 ### Adicionado
 - `Delete.js`: adicionado parâmetro `redirectRoute`, onde há a possibilidade de passar uma rota onde será redirecionado após deletar o item.
-- `QasDelete`: adicionado props `redirectRoute` que será repassado para o plugin `Delete`.
+- `QasDelete`: adicionado prop `redirectRoute` que será repassado para o plugin `Delete`.
 
 ## [3.11.0-beta.7] - 14-07-2023
 ### Corrigido

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `Delete.js`: adicionado parâmetro `redirectRoute`, onde há a possibilidade de passar uma rota onde será redirecionado após deletar o item.
 - `QasDelete`: adicionado prop `redirectRoute` que será repassado para o plugin `Delete`.
 
+### Modificado
+`ui/src/css/utils/container.scss`: alterado espaçamento da classe `spaced`.
+`QasPageHeader`: alterado o valor do margin-bottom pra `lg`.
+
 ## [3.11.0-beta.7] - 14-07-2023
 ### Corrigido
 - `QasSelectList`: corrigido problema ao remover item do model quando `:emit-value="false"`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `Delete.js`: adicionado parâmetro `redirectRoute`, onde há a possibilidade de passar uma rota onde será redirecionado após deletar o item.
+- `QasDelete`: adicionado props `redirectRoute` que será repassado para o plugin `Delete`.
+
 ## [3.11.0-beta.7] - 14-07-2023
 ### Corrigido
 - `QasSelectList`: corrigido problema ao remover item do model quando `:emit-value="false"`.

--- a/docs/src/examples/Delete/Basic.vue
+++ b/docs/src/examples/Delete/Basic.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container spaced">
-    <qas-btn label="Deletar usuário" @click="$qas.delete({ deleteActionParams: { id: customId, entity: 'users' } })" />
+    <qas-btn label="Deletar usuário" @click="$qas.delete(deleteParams)" />
 
     <div class="q-mt-lg">
       user: <qas-debugger :inspect="[user]" />
@@ -23,6 +23,15 @@ export default {
 
     user () {
       return this.userById(this.customId)
+    },
+
+    deleteParams () {
+      return {
+        deleteActionParams: {
+          id: this.customId,
+          entity: 'users'
+        }
+      }
     }
   },
 

--- a/docs/src/examples/Delete/Basic.vue
+++ b/docs/src/examples/Delete/Basic.vue
@@ -31,6 +31,7 @@ export default {
           id: this.customId,
           entity: 'users'
         }
+        // redirectRoute: 'users' <- (Caso a intenção fosse redirecionar para a rota "users" após deletar.)
       }
     }
   },

--- a/docs/src/examples/Delete/DeleteWithRedirectRoute.vue
+++ b/docs/src/examples/Delete/DeleteWithRedirectRoute.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="container spaced">
+    <div>Exemplo com path</div>
+    <qas-btn label="Deletar usuário" @click="$qas.delete({ ...deleteParams, redirectRoute: '/' })" />
+
+    <div class="q-mt-lg">Exemplo com objeto</div>
+    <qas-btn label="Deletar usuário" @click="$qas.delete({...deleteParams, redirectRoute: { path: '/'} })" />
+
+    <div class="q-mt-lg">
+      user: <qas-debugger :inspect="[user]" />
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters, mapActions } from 'vuex'
+
+export default {
+  computed: {
+    ...mapGetters('users', {
+      userById: 'byId'
+    }),
+
+    customId () {
+      return '31362c39-2cb5-4fe2-982a-c270f88d2462'
+    },
+
+    user () {
+      return this.userById(this.customId)
+    },
+
+    deleteParams () {
+      return {
+        deleteActionParams: {
+          id: this.customId,
+          entity: 'users'
+        }
+      }
+    }
+  },
+
+  created () {
+    this.fetchSingle({ id: this.customId })
+  },
+
+  methods: {
+    ...mapActions('users', ['fetchSingle', 'destroy'])
+  }
+}
+</script>

--- a/docs/src/examples/QasDelete/DeleteWithRedirectRoute.vue
+++ b/docs/src/examples/QasDelete/DeleteWithRedirectRoute.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="container spaced">
+    <div>Exemplo com path</div>
+    <qas-delete v-model:deleting="isDeleting" :custom-id="customId" entity="users" label="Deletar este usuário" redirect-route="/" />
+
+    <div class="q-mt-lg">Exemplo com objeto</div>
+    <qas-delete v-model:deleting="isDeleting" :custom-id="customId" entity="users" label="Deletar este usuário" :redirect-route="{ path: '/' }" />
+
+    <!-- Remover este código -->
+    <div class="q-mt-lg">
+      user: <qas-debugger :inspect="[user]" />
+      isDeleting: {{ isDeleting }}
+    </div>
+  </div>
+</template>
+
+<script>
+// estes scripts tem a finalidade de utilização na documentação.
+import { mapGetters, mapActions } from 'vuex'
+
+export default {
+  data () {
+    return {
+      isDeleting: false
+    }
+  },
+
+  computed: {
+    ...mapGetters('users', {
+      userById: 'byId'
+    }),
+
+    customId () {
+      return '31362c39-2cb5-4fe2-982a-c270f88d2462'
+    },
+
+    user () {
+      return this.userById(this.customId)
+    }
+  },
+
+  created () {
+    this.fetchSingle({ id: this.customId })
+  },
+
+  methods: {
+    ...mapActions('users', ['fetchSingle'])
+  }
+}
+</script>

--- a/docs/src/pages/components/delete.md
+++ b/docs/src/pages/components/delete.md
@@ -30,3 +30,6 @@ No exemplo abaixo estamos renderizando um `QasBtn` (que é o valor default da pr
 
 ## Uso
 <doc-example file="QasDelete/Basic" title="Básico" />
+
+Após ser deletado, será redirecionado para a home.
+<doc-example file="QasDelete/DeleteWithRedirectRoute" title="Utilizando o redirect-route" />

--- a/docs/src/pages/plugins/delete.md
+++ b/docs/src/pages/plugins/delete.md
@@ -69,3 +69,6 @@ this.$qas.delete({
 ```
 
 <doc-example file="Delete/Basic" title="Básico" />
+
+Após ser deletado, será redirecionado para a home.
+<doc-example file="Delete/DeleteWithRedirectRoute" title="Utilizando o redirect-route" />

--- a/docs/src/router/pages.js
+++ b/docs/src/router/pages.js
@@ -8,6 +8,7 @@ export default function () {
     const fileName = filePath.replace(/^.*[\\/]/, '')
 
     const path = filePath.replace(isIndex(fileName) ? /[^/]*$/ : /\.\w+$/, '')
+
     return { component: () => import(`../pages/${filePath}`), path }
   })
 }

--- a/ui/src/components/delete/QasDelete.vue
+++ b/ui/src/components/delete/QasDelete.vue
@@ -51,6 +51,11 @@ export default {
     useAutoDeleteRoute: {
       default: true,
       type: Boolean
+    },
+
+    redirectRoute: {
+      type: [Object, String],
+      default: ''
     }
   },
 
@@ -89,6 +94,8 @@ export default {
         dialogProps: this.dialogProps,
 
         useAutoDeleteRoute: this.useAutoDeleteRoute,
+
+        redirectRoute: this.redirectRoute,
 
         // callbacks
         onDelete: isDeleting => this.$emit('update:deleting', isDeleting),

--- a/ui/src/components/delete/QasDelete.yml
+++ b/ui/src/components/delete/QasDelete.yml
@@ -40,6 +40,10 @@ props:
     default: true
     type: Boolean
 
+  redirect-route:
+    desc: Espera receber um objeto de rota ou um path na qual vai ser redirecionado após o item ser deletado.
+    type: [String, Object]
+
 slots:
   default:
     desc: 'Slot para acessar dentro do componente.'

--- a/ui/src/components/page-header/QasPageHeader.vue
+++ b/ui/src/components/page-header/QasPageHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <q-toolbar class="justify-between q-mb-xl q-px-none qas-page-header">
+    <q-toolbar class="justify-between q-mb-lg q-px-none qas-page-header">
       <div class="ellipsis">
         <q-toolbar-title v-if="title" class="text-grey-9 text-h3">
           {{ title }}

--- a/ui/src/css/utils/container.scss
+++ b/ui/src/css/utils/container.scss
@@ -10,8 +10,8 @@
   width: calc(100% - 80px);
 
   &.spaced {
-    padding-bottom: 20px;
-    padding-top: 20px;
+    padding-bottom: var(--qas-spacing-md);
+    padding-top: var(--qas-spacing-md);
   }
 
   @media (max-width: $breakpoint-xs) {

--- a/ui/src/plugins/delete/Delete.js
+++ b/ui/src/plugins/delete/Delete.js
@@ -62,7 +62,7 @@ export default function (config = {}) {
 
       onDeleteSuccess(response)
 
-      redirectRoute && handleRedirectRoute(this)
+      redirectRoute && replaceRoute(this)
     } catch (error) {
       onDeleteError(error)
 
@@ -74,11 +74,12 @@ export default function (config = {}) {
     }
   }
 
-  function handleRedirectRoute (context) {
+  function replaceRoute (context) {
     const { $router } = context
 
-    const formattedRoute = typeof redirectRoute === 'string' ? { name: redirectRoute } : redirectRoute
+    const formattedRoute = typeof redirectRoute === 'string' ? { path: redirectRoute } : redirectRoute
 
+    console.log(formattedRoute, '<-- formattedRoute')
     $router.replace(formattedRoute)
   }
 

--- a/ui/src/plugins/delete/Delete.js
+++ b/ui/src/plugins/delete/Delete.js
@@ -79,7 +79,6 @@ export default function (config = {}) {
 
     const formattedRoute = typeof redirectRoute === 'string' ? { path: redirectRoute } : redirectRoute
 
-    console.log(formattedRoute, '<-- formattedRoute')
     $router.replace(formattedRoute)
   }
 

--- a/ui/src/plugins/delete/Delete.js
+++ b/ui/src/plugins/delete/Delete.js
@@ -8,6 +8,7 @@ export default function (config = {}) {
     dialogProps = {},
     deleteActionParams = {},
     useAutoDeleteRoute,
+    redirectRoute,
 
     // callbacks
     onDelete = () => {},
@@ -60,6 +61,8 @@ export default function (config = {}) {
       createDeleteSuccessEvent()
 
       onDeleteSuccess(response)
+
+      redirectRoute && handleRedirectRoute(this)
     } catch (error) {
       onDeleteError(error)
 
@@ -69,6 +72,14 @@ export default function (config = {}) {
 
       Loading.hide()
     }
+  }
+
+  function handleRedirectRoute (context) {
+    const { $router } = context
+
+    const formattedRoute = typeof redirectRoute === 'string' ? { name: redirectRoute } : redirectRoute
+
+    $router.replace(formattedRoute)
   }
 
   function getRoutesToBeDeletedById (routes = []) {

--- a/ui/src/plugins/delete/Delete.js
+++ b/ui/src/plugins/delete/Delete.js
@@ -77,9 +77,7 @@ export default function (config = {}) {
   function replaceRoute (context) {
     const { $router } = context
 
-    const formattedRoute = typeof redirectRoute === 'string' ? { path: redirectRoute } : redirectRoute
-
-    $router.replace(formattedRoute)
+    $router.replace(redirectRoute)
   }
 
   function getRoutesToBeDeletedById (routes = []) {

--- a/ui/src/plugins/delete/Delete.yml
+++ b/ui/src/plugins/delete/Delete.yml
@@ -69,3 +69,7 @@ inject:
                 desc: Objeto deleteActionParams enviado anteriormente como configuração do plugin Delete.
                 default: {}
                 examples: ["{ ..., deleteAction: params => useUsers.destroy(params) }"]
+
+          redirectRoute:
+            desc: Espera receber um objeto de rota ou um path na qual vai ser redirecionado após o item ser deletado.
+            type: [String, Object]


### PR DESCRIPTION
### Adicionado
- `Delete.js`: adicionado parâmetro `redirectRoute`, onde há a possibilidade de passar uma rota onde será redirecionado após deletar o item.
- `QasDelete`: adicionado props `redirectRoute` que será repassado para o plugin `Delete`.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [x] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
