### PR TITLE
Feature/qas sortable prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- [`QasCopy`, `QasDelete`, `QasTreeGenerator`, `QasTruncate`]: alterado o `@click.stop` para `@click.stop.prevent` para melhor funcionamento.
+
+### Adicionado
+- `QasSortable`: adicionado prop `useSaveOnSort` para não bater a API ao fazer uma ordenação.
+
 ## [3.11.0-beta.9] - 25-07-2023
 ### Corrigido
 - `QasFilters`: Corrigido problema de merge entre os `fields` iniciais e a propriedade `fieldsProps` na computada `activeFilters`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,14 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
-### Modificado
-- [`QasCopy`, `QasDelete`, `QasTreeGenerator`, `QasTruncate`]: alterado o `@click.stop` para `@click.stop.prevent` para melhor funcionamento.
+### Corrigido
+- [`QasCopy`, `QasDelete`, `QasTreeGenerator`, `QasTruncate`]: alterado o `@click.stop` para `@click.stop.prevent` solucionando o problema de utilizar esses componentes em conjunto com o `QasTableGenerator`.
 
 ### Adicionado
-- `QasSortable`: adicionado prop `useSaveOnSort` para não bater a API ao fazer uma ordenação.
+- `QasSortable`: adicionado prop `useSaveOnSort` para não bater a API para salvar após fazer uma ordenação.
+
+### Removido
+- `QasSortable`: removido `required` da prop `entity`.
 
 ## [3.11.0-beta.9] - 25-07-2023
 ### Corrigido

--- a/ui/src/components/copy/QasCopy.vue
+++ b/ui/src/components/copy/QasCopy.vue
@@ -2,7 +2,7 @@
   <span>
     <slot>{{ text }}</slot>
 
-    <qas-btn class="q-ml-xs" color="primary" :icon="icon" :loading="isLoading" variant="tertiary" @click.stop="copy">
+    <qas-btn class="q-ml-xs" color="primary" :icon="icon" :loading="isLoading" variant="tertiary" @click.stop.prevent="copy">
       <q-tooltip>Copiar</q-tooltip>
     </qas-btn>
   </span>

--- a/ui/src/components/delete/QasDelete.vue
+++ b/ui/src/components/delete/QasDelete.vue
@@ -1,5 +1,5 @@
 <template>
-  <component v-bind="attributes" :is="tag" @click.stop="onDelete">
+  <component v-bind="attributes" :is="tag" @click.stop.prevent="onDelete">
     <template v-for="(_, name) in $slots" #[name]="context">
       <slot :name="name" v-bind="context || {}" />
     </template>

--- a/ui/src/components/sortable/QasSortable.vue
+++ b/ui/src/components/sortable/QasSortable.vue
@@ -17,7 +17,6 @@ export default {
   props: {
     entity: {
       default: '',
-      required: true,
       type: String
     },
 
@@ -44,6 +43,11 @@ export default {
     sorted: {
       default: () => [],
       type: Array
+    },
+
+    useSaveOnSort: {
+      type: Boolean,
+      default: true
     }
   },
 
@@ -132,7 +136,7 @@ export default {
       const deleted = this.sortedList.splice(oldIndex, 1)
       this.sortedList.splice(newIndex, 0, deleted[0])
 
-      this.replace()
+      this.useSaveOnSort && this.replace()
     },
 
     setSortedValue (value) {

--- a/ui/src/components/sortable/QasSortable.yml
+++ b/ui/src/components/sortable/QasSortable.yml
@@ -35,6 +35,11 @@ props:
     desc: Parâmetro enviado para a action "replace".
     type: String
 
+  use-save-on-sort:
+    desc: Controla se deve bater a API após fazer uma ordenação.
+    type: Boolean
+    default: true
+
 slots:
   default:
     desc: Slot para adicionar os items que serão reordenados.

--- a/ui/src/components/sortable/QasSortable.yml
+++ b/ui/src/components/sortable/QasSortable.yml
@@ -36,7 +36,7 @@ props:
     type: String
 
   use-save-on-sort:
-    desc: Controla se deve bater a API após fazer uma ordenação.
+    desc: Controla se deve bater a API para salvar após fazer uma ordenação.
     type: Boolean
     default: true
 

--- a/ui/src/components/text-truncate/QasTextTruncate.vue
+++ b/ui/src/components/text-truncate/QasTextTruncate.vue
@@ -5,7 +5,7 @@
         <slot>{{ text }}</slot>
       </div>
 
-      <div v-if="isTruncated" class="cursor-pointer text-primary" @click.stop="toggle">
+      <div v-if="isTruncated" class="cursor-pointer text-primary" @click.stop.prevent="toggle">
         {{ seeMoreLabel }}
       </div>
     </div>

--- a/ui/src/components/tree-generator/QasTreeGenerator.vue
+++ b/ui/src/components/tree-generator/QasTreeGenerator.vue
@@ -9,7 +9,7 @@
 
           <span v-if="hasMenuButton(node)" class="q-ml-sm">
             <!-- TODO: rever para o uso QasActionsMenu -->
-            <qas-btn color="grey-9" icon="sym_r_more_vert" variant="tertiary" @click.stop>
+            <qas-btn color="grey-9" icon="sym_r_more_vert" variant="tertiary" @click.stop.prevent>
               <q-menu auto-close>
                 <q-list separator>
                   <q-item v-if="useAddButton" v-ripple class="qas-tree-generator__item" clickable @click="handleTreeFormDialog(node, true, tree)">


### PR DESCRIPTION
### Modificado
- [`QasCopy`, `QasDelete`, `QasTreeGenerator`, `QasTruncate`]: alterado o `@click.stop` para `@click.stop.prevent` para melhor funcionamento.

### Adicionado
- `QasSortable`: adicionado prop `useSaveOnSort` para não bater a API ao fazer uma ordenação.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
