### PR TITLE
feat(QasSortable): fix watch list

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,7 +34,8 @@
     "QasDate",
     "QasChartView",
     "QasDelete",
-    "QasSelectList"
+    "QasSelectList",
+    "QasSortable"
   ],
   "cSpell.words": [
     "Breakline",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasSelectList`: nome de eventos alterados de `@added` para `@add` e `@removed` para `@remove`. 
 ### Corrigido
 - [`QasCopy`, `QasDelete`, `QasTreeGenerator`, `QasTruncate`]: alterado o `@click.stop` para `@click.stop.prevent` solucionando o problema de utilizar esses componentes em conjunto com o `QasTableGenerator`.
+- `QasSortable`: alterado watch da prop `list` para o deep, passando a ouvir quando dermos um `.push` ou `splice` no list.
+- `QasSortable`: removido método `sort` dentro do watch `list` na qual estava ordenando a lista quando não deveria ser ordenando.
 
 ### Adicionado
 - `QasSortable`: adicionado prop `useSaveOnSort` para não bater a API para salvar após fazer uma ordenação.

--- a/ui/src/components/sortable/QasSortable.vue
+++ b/ui/src/components/sortable/QasSortable.vue
@@ -76,9 +76,12 @@ export default {
       this.sortable.options = { ...this.sortable.options, ...value }
     },
 
-    list (value) {
-      this.setSortedValue(value)
-      this.sortable.sort(this.sortable.toArray())
+    list: {
+      handler (value) {
+        this.setSortedValue(value)
+      },
+
+      deep: true
     }
   },
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
- `QasSortable`: alterado watch da prop `list` para o deep, passando a ouvir quando dermos um `.push` ou `splice` no list.
- `QasSortable`: removido método `sort` dentro do watch `list` na qual estava ordenando a lista quando não deveria ser ordenando.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [ ] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
