### PR TITLE
Feature/qas sortable adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
+## BREAKING CHANGES
+- `QasSortable`: removido as props `sorted` e `list`, onde o a ordenação e as options será o próprio v-model.
+
+### Adicionado
+- `QasSortable`: adicionado v-model para o controle da ordenação.
+
+### Removido
+- `QasSortable`: removido as props `sorted` e `list`.
+
 ### Corrigido
 - `search-filter`: adicionado validação da prop `useLazyLoading` no watch do `lazyLoadingProps.params` para não fazer request quando ela for false.
 

--- a/ui/src/components/sortable/QasSortable.vue
+++ b/ui/src/components/sortable/QasSortable.vue
@@ -137,16 +137,16 @@ export default {
       const deleted = this.sortedList.splice(oldIndex, 1)
       this.sortedList.splice(newIndex, 0, deleted[0])
 
-      this.updateSortedModel()
+      this.updateModel()
 
       this.useSaveOnSort && this.replace()
     },
 
-    setSortedValue (value) {
-      this.sortedList = extend(true, [], value || this.modelValue)
+    setSortedValue () {
+      this.sortedList = extend(true, [], this.modelValue)
     },
 
-    updateSortedModel () {
+    updateModel () {
       this.$emit('update:modelValue', this.sortedList)
     }
   }

--- a/ui/src/components/sortable/QasSortable.vue
+++ b/ui/src/components/sortable/QasSortable.vue
@@ -1,5 +1,8 @@
 <template>
-  <component :is="tag" ref="sortableItems">
+  <component
+    :is="tag"
+    ref="sortableItems"
+  >
     <slot />
   </component>
 </template>
@@ -25,11 +28,6 @@ export default {
       type: Object
     },
 
-    list: {
-      default: () => [],
-      type: Array
-    },
-
     tag: {
       default: 'div',
       type: String
@@ -40,7 +38,7 @@ export default {
       type: String
     },
 
-    sorted: {
+    modelValue: {
       default: () => [],
       type: Array
     },
@@ -52,7 +50,7 @@ export default {
   },
 
   emits: [
-    'update:sorted',
+    'update:modelValue',
     'sort',
     'success',
     'error'
@@ -76,9 +74,9 @@ export default {
       this.sortable.options = { ...this.sortable.options, ...value }
     },
 
-    list: {
-      handler (value) {
-        this.setSortedValue(value)
+    modelValue: {
+      handler (newValues) {
+        this.sortedList = newValues
       },
 
       deep: true
@@ -139,16 +137,17 @@ export default {
       const deleted = this.sortedList.splice(oldIndex, 1)
       this.sortedList.splice(newIndex, 0, deleted[0])
 
+      this.updateSortedModel()
+
       this.useSaveOnSort && this.replace()
     },
 
     setSortedValue (value) {
-      this.sortedList = extend(true, [], value || this.list)
-      this.updateSortedModel()
+      this.sortedList = extend(true, [], value || this.modelValue)
     },
 
     updateSortedModel () {
-      return this.$emit('update:sorted', this.sortedList)
+      this.$emit('update:modelValue', this.sortedList)
     }
   }
 }

--- a/ui/src/components/sortable/QasSortable.vue
+++ b/ui/src/components/sortable/QasSortable.vue
@@ -1,8 +1,5 @@
 <template>
-  <component
-    :is="tag"
-    ref="sortableItems"
-  >
+  <component :is="tag" ref="sortableItems">
     <slot />
   </component>
 </template>

--- a/ui/src/components/sortable/QasSortable.yml
+++ b/ui/src/components/sortable/QasSortable.yml
@@ -17,7 +17,7 @@ props:
   model-value:
     desc: Model do componente onde será fornecido a lista, e ele será responsável pela ordenação.
     default: []
-    type: [Array]
+    type: Array
     examples: [v-model="fields"]
     model: true
 
@@ -62,4 +62,4 @@ events:
     params:
       values:
         desc: Novo valor do model.
-        type: [Array]
+        type: Array

--- a/ui/src/components/sortable/QasSortable.yml
+++ b/ui/src/components/sortable/QasSortable.yml
@@ -9,21 +9,16 @@ props:
     required: true
     type: String
 
-  list:
-    desc: Lista que vai ser reordenada.
-    default: []
-    type: Array
-
   sortable-options:
     desc: Opções do "sortablejs" (https://github.com/SortableJS/Sortable#options).
     default: { animation: 500 }
     type: Object
 
-  sorted:
-    desc: Model da lista reordenada
+  model-value:
+    desc: Model do componente onde será fornecido a lista, e ele será responsável pela ordenação.
     default: []
-    type: Array
-    examples: [v-model:sorted="fields"]
+    type: [Array]
+    examples: [v-model="fields"]
     model: true
 
   tag:
@@ -62,9 +57,9 @@ events:
         desc: fields.
         type: Object
 
-  '@update:sorted -> function(value)':
-    desc: Dispara no created e toda vez que a prop "list" muda, usado para o v-model:sorted.
+  '@update:model-value -> function(values)':
+    desc: Dispara quando o model-value altera, após acontecer uma ordenação.
     params:
-      value:
-        desc: Lista contendo nova ordenação.
-        type: Array
+      values:
+        desc: Novo valor do model.
+        type: [Array]


### PR DESCRIPTION
- Mudança no comportamento do componente, onde irá ter somente um v-model onde será ordenado.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
