### PR TITLE
feat(QasDialog): added description component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasDialog`: possibilidade de passar a descrição como componente.
+
 ## [3.11.0-beta.11] - 01-08-2023
 ## BREAKING CHANGES
 - `QasSortable`: removido as props `sorted` e `list`, onde o a ordenação e as options será o próprio v-model.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ## Não publicado
 ### Adicionado
-- `QasDialog`: possibilidade de passar a descrição como componente.
+- `QasDialog`: possibilidade de passar a descrição como componente através da prop `description` de dentro do `card`.
 
 ### Corrigido
-- `Delete.js`: merge do `dialogProps` vindo por parâmetro na função, com os valores defaults.
+- `Delete.js`: merge do `dialogProps` vindo por parâmetro na função com os valores defaults.
 
 ### Modificado
 - `ui/src/css/components/button.scss`: modificado cor disabled de `grey-8` para `grey-6` nas variantes `secondary` e `tertiary` para seguir design system.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ### Adicionado
 - `QasDialog`: possibilidade de passar a descrição como componente.
 
+### Corrigido
+- `Delete.js`: merge do `dialogProps` vindo por parâmetro na função, com os valores defaults.
+
 ## [3.11.0-beta.11] - 01-08-2023
 ## BREAKING CHANGES
 - `QasSortable`: removido as props `sorted` e `list`, onde o a ordenação e as options será o próprio v-model.

--- a/docs/src/examples/Dialog/Basic.vue
+++ b/docs/src/examples/Dialog/Basic.vue
@@ -9,18 +9,16 @@
 import { Dialog } from 'asteroid'
 
 export default {
-  computed: {
-    dialogConfig () {
-      return {
-        card: {
-          title: 'Título do dialog',
-          description: 'Descrição do dialog.'
-        },
+  data () {
+    return {
+      card: {
+        title: 'Título do dialog',
+        description: 'Descrição do dialog.'
+      },
 
-        cancel: {
-          onClick () {
-            alert('Botão cancelar clicado!')
-          }
+      cancel: {
+        onClick () {
+          alert('Botão cancelar clicado!')
         }
       }
     }

--- a/docs/src/examples/Dialog/Basic.vue
+++ b/docs/src/examples/Dialog/Basic.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container spaced text-center">
+  <div class="column container spaced text-center">
     <qas-btn @click="$qas.dialog(dialogConfig)">Usando plugin com injeção</qas-btn>
     <qas-btn @click="Dialog(dialogConfig)">Usando plugin com import</qas-btn>
   </div>

--- a/docs/src/examples/Dialog/DescriptionComponent.vue
+++ b/docs/src/examples/Dialog/DescriptionComponent.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'DescriptionComponentTest'
+  name: 'DescriptionComponent'
 }
 </script>

--- a/docs/src/examples/Dialog/DescriptionComponent.vue
+++ b/docs/src/examples/Dialog/DescriptionComponent.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="flex items-center">
+    <div>Dialog com descrição <span class="text-bold">customizada</span> sendo um componente.</div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'DescriptionComponentTest'
+}
+</script>

--- a/docs/src/examples/Dialog/DialogWithDescriptionComponent.vue
+++ b/docs/src/examples/Dialog/DialogWithDescriptionComponent.vue
@@ -5,7 +5,6 @@
 </template>
 
 <script>
-import { Dialog } from 'asteroid'
 import DescriptionComponent from './DescriptionComponent'
 
 export default {
@@ -17,10 +16,6 @@ export default {
         }
       }
     }
-  },
-
-  methods: {
-    Dialog
   }
 }
 </script>

--- a/docs/src/examples/Dialog/DialogWithDescriptionComponent.vue
+++ b/docs/src/examples/Dialog/DialogWithDescriptionComponent.vue
@@ -8,9 +8,9 @@
 import DescriptionComponent from './DescriptionComponent'
 
 export default {
-  computed: {
-    dialogConfig () {
-      return {
+  data () {
+    return {
+      dialogConfig: {
         card: {
           description: DescriptionComponent
         }

--- a/docs/src/examples/Dialog/DialogWithDescriptionComponent.vue
+++ b/docs/src/examples/Dialog/DialogWithDescriptionComponent.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="container spaced text-center">
+    <qas-btn @click="$qas.dialog(dialogConfig)">Usando plugin com injeção</qas-btn>
+  </div>
+</template>
+
+<script>
+import { Dialog } from 'asteroid'
+import DescriptionComponent from './DescriptionComponent'
+
+export default {
+  computed: {
+    dialogConfig () {
+      return {
+        card: {
+          description: DescriptionComponent
+        }
+      }
+    }
+  },
+
+  methods: {
+    Dialog
+  }
+}
+</script>

--- a/docs/src/examples/Dialog/DialogWithDescriptionComponent.vue
+++ b/docs/src/examples/Dialog/DialogWithDescriptionComponent.vue
@@ -8,9 +8,9 @@
 import DescriptionComponent from './DescriptionComponent'
 
 export default {
-  data () {
-    return {
-      dialogConfig: {
+  computed: {
+    dialogConfig () {
+      return {
         card: {
           description: DescriptionComponent
         }

--- a/docs/src/examples/QasDialog/DescriptionComponent.vue
+++ b/docs/src/examples/QasDialog/DescriptionComponent.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'DescriptionComponentTest'
+  name: 'DescriptionComponent'
 }
 </script>

--- a/docs/src/examples/QasDialog/DescriptionComponent.vue
+++ b/docs/src/examples/QasDialog/DescriptionComponent.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="flex items-center">
+    <div>Dialog com descrição <span class="text-bold">customizada</span> sendo um componente.</div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'DescriptionComponentTest'
+}
+</script>

--- a/docs/src/examples/QasDialog/DialogWithDescriptionComponent.vue
+++ b/docs/src/examples/QasDialog/DialogWithDescriptionComponent.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="container q-py-lg">
+    <qas-btn @click="toggle">Abrir Dialog</qas-btn>
+
+    <qas-dialog v-model="isDialogOpened" v-bind="dialogProps" />
+  </div>
+</template>
+
+<script>
+import DescriptionComponent from './DescriptionComponent'
+
+export default {
+  data () {
+    return {
+      isDialogOpened: false
+    }
+  },
+
+  computed: {
+    dialogProps () {
+      return {
+        card: {
+          description: DescriptionComponent
+        }
+      }
+    }
+  },
+
+  methods: {
+    toggle () {
+      this.isDialogOpened = !this.isDialogOpened
+    }
+  }
+}
+</script>

--- a/docs/src/pages/components/dialog.md
+++ b/docs/src/pages/components/dialog.md
@@ -11,3 +11,10 @@ Componente de dialog.
 <doc-example file="QasDialog/Basic" title="Básico" />
 <doc-example file="QasDialog/ExWithActions" title="Com ações" />
 <doc-example file="QasDialog/ExWithSingleAction" title="Com uma única ação" />
+
+É possível passar um componente para a descrição, caso precise que a descrição seja diferente do padrão.
+
+:::warning
+Isso foi desenvolvido para utilizar em casos muitos específicos, não é recomendado o uso dessa funcionalidade com frequência.
+:::
+<doc-example file="QasDialog/DialogWithDescriptionComponent" title="Descrição sendo um componente" />

--- a/docs/src/pages/components/dialog.md
+++ b/docs/src/pages/components/dialog.md
@@ -16,5 +16,8 @@ Componente de dialog.
 
 :::warning
 Isso foi desenvolvido para utilizar em casos muitos específicos, não é recomendado o uso dessa funcionalidade com frequência.
+Um caso onde a exclusão desse item é de alto impacto, onde devemos ter informações a mais do que somente a descrição padrão.
+
+Exemplo: Tenho um item onde está vinculado a vários empreendimentos, e deverá ser exibido quais empreendimentos estão vinculados mostrando o impacto da exclusão do mesmo.
 :::
 <doc-example file="QasDialog/DialogWithDescriptionComponent" title="Descrição sendo um componente" />

--- a/docs/src/pages/plugins/dialog.md
+++ b/docs/src/pages/plugins/dialog.md
@@ -18,3 +18,10 @@ this.$qas.dialog('Deu certo!')
 ```
 
 <doc-example file="Dialog/Basic" title="Básico" />
+
+É possível passar um componente para a descrição, caso precise que a descrição seja diferente do padrão.
+
+:::warning
+Isso foi desenvolvido para utilizar em casos muitos específicos, não é recomendado o uso dessa funcionalidade com frequência.
+:::
+<doc-example file="Dialog/DialogWithDescriptionComponent" title="Descrição sendo um componente" />

--- a/docs/src/pages/plugins/dialog.md
+++ b/docs/src/pages/plugins/dialog.md
@@ -23,5 +23,8 @@ this.$qas.dialog('Deu certo!')
 
 :::warning
 Isso foi desenvolvido para utilizar em casos muitos específicos, não é recomendado o uso dessa funcionalidade com frequência.
+Um caso onde a exclusão desse item é de alto impacto, onde devemos ter informações a mais do que somente a descrição padrão.
+
+Exemplo: Tenho um item onde está vinculado a vários empreendimentos, e deverá ser exibido quais empreendimentos estão vinculados mostrando o impacto da exclusão do mesmo.
 :::
 <doc-example file="Dialog/DialogWithDescriptionComponent" title="Descrição sendo um componente" />

--- a/ui/src/components/dialog/QasDialog.vue
+++ b/ui/src/components/dialog/QasDialog.vue
@@ -14,7 +14,7 @@
       <section class="text-body1 text-grey-8">
         <component :is="componentTag" ref="form">
           <slot name="description">
-            <component :is="descriptionComponent">{{ card.description }}</component>
+            <component :is="descriptionComponentTag">{{ card.description }}</component>
           </slot>
         </component>
       </section>
@@ -188,12 +188,12 @@ export default {
       }
     },
 
-    descriptionIsComponent () {
+    hasRenderFunction () {
       return typeof this.card.description?.render === 'function'
     },
 
-    descriptionComponent () {
-      return this.descriptionIsComponent ? this.card.description : 'div'
+    descriptionComponentTag () {
+      return this.hasRenderFunction ? this.card.description : 'div'
     }
   },
 

--- a/ui/src/components/dialog/QasDialog.vue
+++ b/ui/src/components/dialog/QasDialog.vue
@@ -14,7 +14,7 @@
       <section class="text-body1 text-grey-8">
         <component :is="componentTag" ref="form">
           <slot name="description">
-            <div v-if="card.description">{{ card.description }}</div>
+            <component :is="descriptionComponent">{{ card.description }}</component>
           </slot>
         </component>
       </section>
@@ -186,6 +186,14 @@ export default {
         useEqualWidth: this.hasAllActions,
         ...this.actionsProps
       }
+    },
+
+    descriptionIsComponent () {
+      return typeof this.card.description?.render === 'function'
+    },
+
+    descriptionComponent () {
+      return this.descriptionIsComponent ? this.card.description : 'div'
     }
   },
 

--- a/ui/src/components/label/QasLabel.yml
+++ b/ui/src/components/label/QasLabel.yml
@@ -19,6 +19,11 @@ props:
     type: String
     examples: [xs, sm, md, lg, xl]
 
+  color: 
+    desc: Cor da label.
+    default: grey-9
+    type: String
+
 slots:
   default:
     desc: Slot para acessar elemento do texto.

--- a/ui/src/components/label/QasLabel.yml
+++ b/ui/src/components/label/QasLabel.yml
@@ -19,7 +19,7 @@ props:
     type: String
     examples: [xs, sm, md, lg, xl]
 
-  color: 
+  color:
     desc: Cor da label.
     default: grey-9
     type: String

--- a/ui/src/plugins/delete/Delete.js
+++ b/ui/src/plugins/delete/Delete.js
@@ -18,23 +18,22 @@ export default function (config = {}) {
   } = config
 
   const { entity, id, url } = deleteActionParams
-  const { ok, card, ...dialogPropsRest } = dialogProps
 
   const defaultDialogProps = {
+    ...dialogProps,
+
     card: {
       description: 'Tem certeza que deseja excluir este item?',
 
-      ...card
+      ...dialogProps.card
     },
 
     ok: {
       label: 'Excluir',
       onClick: () => destroy.call(this),
 
-      ...ok
-    },
-
-    ...dialogPropsRest
+      ...dialogProps.ok
+    }
   }
 
   const defaultNotifyMessages = {

--- a/ui/src/plugins/delete/Delete.js
+++ b/ui/src/plugins/delete/Delete.js
@@ -37,8 +37,6 @@ export default function (config = {}) {
     ...dialogPropsRest
   }
 
-  console.log(defaultDialogProps, '<-- defaultDialogProps')
-
   const defaultNotifyMessages = {
     error: 'Não conseguimos excluir as informações. Por favor, tente novamente em alguns minutos.',
     success: 'Informações excluídas com sucesso.'

--- a/ui/src/plugins/delete/Delete.js
+++ b/ui/src/plugins/delete/Delete.js
@@ -18,14 +18,26 @@ export default function (config = {}) {
   } = config
 
   const { entity, id, url } = deleteActionParams
+  const { ok, card, ...dialogPropsRest } = dialogProps
 
   const defaultDialogProps = {
-    card: { description: 'Tem certeza que deseja excluir este item?' },
+    card: {
+      description: 'Tem certeza que deseja excluir este item?',
 
-    ok: { label: 'Excluir', onClick: () => destroy.call(this) },
+      ...card
+    },
 
-    ...dialogProps
+    ok: {
+      label: 'Excluir',
+      onClick: () => destroy.call(this),
+
+      ...ok
+    },
+
+    ...dialogPropsRest
   }
+
+  console.log(defaultDialogProps, '<-- defaultDialogProps')
 
   const defaultNotifyMessages = {
     error: 'Não conseguimos excluir as informações. Por favor, tente novamente em alguns minutos.',


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
### Adicionado
- `QasDialog`: possibilidade de passar a descrição como componente.

### Corrigido
- `Delete.js`: merge do `dialogProps` vindo por parâmetro na função, com os valores defaults.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [x] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
