### PR TITLE
added default inputmode values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ### Adicionado
 - `QasActionsMenu`: adicionado `@click.stop.prevent` solucionando o problema de utilizar o componente em conjunto com o `QasTableGenerator`.
 - `QasInput`: adicionado `inputmode` default de acordo com máscaras e type email.
+- [`QasDateTimeInput`, `QasNumericInput`]: adicionado `inputmode="numeric"`.
+- `QasSearchInput`: adicionado `inputmode="search"`.
 
 ### Corrigido
 - `QasDialog`: validação para quando deverá renderizar a descrição como componente e não texto.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ## Não publicado
 ### Adicionado
 - `QasActionsMenu`: adicionado `@click.stop.prevent` solucionando o problema de utilizar o componente em conjunto com o `QasTableGenerator`.
+- `QasInput`: adicionado `inputmode` default de acordo com máscaras e type email.
 
 ### Corrigido
 - `QasDialog`: validação para quando deverá renderizar a descrição como componente e não texto.

--- a/docs/src/pages/components/input.md
+++ b/docs/src/pages/components/input.md
@@ -10,7 +10,8 @@ Componente para input que implementa o "QInput" repassando propriedades, slots e
 Neste componente é um "wrapper" do [QInput](https://quasar.dev/vue-components/input#introduction) o que significa que ele repassa todos os slots, eventos e propriedades.
 :::
 
-:::tip
+:::info
+##### mask
 Propriedade `mask` vem do `QInput` e serve para definir um máscara para o input, porem nosso componente implementa algumas mascaras pré-definidas, como:
 
 ```bash
@@ -22,6 +23,19 @@ Propriedade `mask` vem do `QInput` e serve para definir um máscara para o input
 ```
 
 Caso seja passado uma mask que não seja essas acima, será usado a que foi passada.
+
+##### inputmode
+
+É possível repassar propriedades nativas para o input, como inputmode, por padrão os inputs que possuem mascara default já possuem um inputmode default, assim como o input type `email`, porém é possível sobrescrever esse inputmode.
+
+```bash
+- company-document (CNPJ) -> numeric
+- document (CPF/CNPJ) -> numeric
+- personal-document (RG) -> numeric
+- phone (Telefone) -> tel
+- postal-code (CEP) -> numeric
+- email (TYPE E-MAIL) -> email
+```
 :::
 
 ## Uso

--- a/ui/src/components/date-time-input/QasDateTimeInput.vue
+++ b/ui/src/components/date-time-input/QasDateTimeInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <qas-input ref="input" v-bind="attributes" v-model="currentValue" :unmasked-value="false" @blur="validateDateTimeOnBlur" @focus="resetError" @update:model-value="updateModelValue">
+  <qas-input ref="input" v-bind="attributes" v-model="currentValue" inputmode="numeric" :unmasked-value="false" @blur="validateDateTimeOnBlur" @focus="resetError" @update:model-value="updateModelValue">
     <template #append>
       <qas-btn v-if="!useTimeOnly" color="grey-9" :disable="$attrs.readonly" icon="sym_r_event" variant="tertiary">
         <q-popup-proxy ref="dateProxy" transition-hide="scale" transition-show="scale">

--- a/ui/src/components/input/QasInput.yml
+++ b/ui/src/components/input/QasInput.yml
@@ -15,6 +15,12 @@ props:
     desc: Controla cor da borda do input.
     type: Boolean
 
+  mask:
+    desc: Máscara do input, é possível passar um slug de mascara ou um pattern personalizado.
+    type: String
+    default: ''
+    examples: [document, personal-document, company-document, phone, postal-code, '##/##/####']
+
   model-value:
     desc: Model do componente.
     type: [String, Input]

--- a/ui/src/components/numeric-input/QasNumericInput.vue
+++ b/ui/src/components/numeric-input/QasNumericInput.vue
@@ -1,7 +1,7 @@
 <template>
   <q-field :model-value="modelValue" outlined>
     <template #control="{ floatingLabel, id }">
-      <input v-show="floatingLabel" :id="id" ref="input" class="q-field__input" @blur="emitValue" @click="setSelect" @input="emitUpdateModel($event.target.value)">
+      <input v-show="floatingLabel" :id="id" ref="input" class="q-field__input" inputmode="numeric" @blur="emitValue" @click="setSelect" @input="emitUpdateModel($event.target.value)">
     </template>
   </q-field>
 </template>

--- a/ui/src/components/search-input/QasSearchInput.vue
+++ b/ui/src/components/search-input/QasSearchInput.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="qas-filter-input">
-    <qas-input ref="input" v-model="model" v-bind="$attrs" class="bg-white rounded-borders-sm" data-cy="search-input" :debounce="debounce" dense hide-bottom-space input-class="ellipsis text-grey-8" type="search">
+    <qas-input ref="input" v-model="model" v-bind="$attrs" class="bg-white rounded-borders-sm" data-cy="search-input" :debounce="debounce" dense hide-bottom-space input-class="ellipsis text-grey-8" inputmode="search" type="search">
       <template #prepend>
         <q-icon v-if="useSearchOnType" color="grey-8" name="sym_r_search" />
         <qas-btn v-else color="grey-9" icon="sym_r_search" variant="tertiary" @click="$emit('filter')" />


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

### Adicionado
- `QasInput`: adicionado `inputmode` default de acordo com máscaras e type email.
- [`QasDateTimeInput`, `QasNumericInput`]: adicionado `inputmode="numeric"`.
- `QasSearchInput`: adicionado `inputmode="search"`.


<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
