### PR TITLE
fix: QasInput mask watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ### Corrigido
 - `QasInput`: corrigido problema causado na versão `3.11.0-beta.14` onde o watch `mask` não foi alterado para `currentMask`.
 
-### Removido
-- `QasInput`: removido computada `inputReference` que retornava o ref do `input`, pois seguindo a recomendação do Vue não é uma boa prática utilizar refs dentro de computadas, então foi movido a recuperação da ref para os métodos que à utilizam.
+### Modificado
+- `QasInput`: modificado computada `inputReference` que retornava o ref do `input` para ser um data. Pois seguindo a recomendação do Vue não é uma boa prática utilizar refs dentro de computadas.
 
 ## [3.11.0-beta.14] - 15-08-2023
 ### Adicionado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasDateTimeInput`: adicionado prop `datePopupProxyProps` para repassar props para o componente `QPopupProxy` do `QDate`.
 - `QasDateTimeInput`: adicionado prop `timePopupProxyProps` para repassar props para o componente `QPopupProxy` do `QTime`.
 
+### Corrigido
+- `QasInput`: corrigido problema causado na versão `3.11.0-beta.14` onde o watch `mask` não foi alterado para `currentMask`.
+
+### Removido
+- `QasInput`: removido computada `inputReference` que retornava o ref do `input`, pois seguindo a recomendação do Vue não é uma boa prática utilizar refs dentro de computadas, então foi movido a recuperação da ref para os métodos que à utilizam.
+- `QasInput`: removido computada `hasError` pois não estava sendo utilizada em nenhum local no componente.
+
 ## [3.11.0-beta.14] - 15-08-2023
 ### Adicionado
 - `QasActionsMenu`: adicionado `@click.stop.prevent` solucionando o problema de utilizar o componente em conjunto com o `QasTableGenerator`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ### Removido
 - `QasInput`: removido computada `inputReference` que retornava o ref do `input`, pois seguindo a recomendação do Vue não é uma boa prática utilizar refs dentro de computadas, então foi movido a recuperação da ref para os métodos que à utilizam.
-- `QasInput`: removido computada `hasError` pois não estava sendo utilizada em nenhum local no componente.
 
 ## [3.11.0-beta.14] - 15-08-2023
 ### Adicionado

--- a/ui/src/components/input/QasInput.vue
+++ b/ui/src/components/input/QasInput.vue
@@ -65,14 +65,6 @@ export default {
   },
 
   computed: {
-    hasError () {
-      return this.inputReference.hasError
-    },
-
-    inputReference () {
-      return this.$refs.input
-    },
-
     masks () {
       return {
         [Masks.CompanyDocument]: () => '##.###.###/####-##',
@@ -114,7 +106,7 @@ export default {
   },
 
   watch: {
-    mask (value) {
+    currentMask (value) {
       if (!value) return
 
       const input = this.getInput()
@@ -142,11 +134,11 @@ export default {
 
   methods: {
     focus () {
-      return this.inputReference.focus()
+      return this.$refs.input.focus()
     },
 
     resetValidation () {
-      return this.inputReference.resetValidation()
+      return this.$refs.input.resetValidation()
     },
 
     toggleMask (first, second) {
@@ -155,7 +147,7 @@ export default {
     },
 
     validate (value) {
-      return this.inputReference.validate(value)
+      return this.$refs.input.validate(value)
     },
 
     onPaste (event) {
@@ -171,7 +163,7 @@ export default {
     },
 
     getInput () {
-      return this.inputReference?.$el?.querySelector('input')
+      return this.$refs.input?.$el?.querySelector('input')
     },
 
     handleErrors () {

--- a/ui/src/components/input/QasInput.vue
+++ b/ui/src/components/input/QasInput.vue
@@ -60,13 +60,14 @@ export default {
   data () {
     return {
       errorData: false,
-      currentMask: ''
+      currentMask: '',
+      inputReference: null
     }
   },
 
   computed: {
     hasError () {
-      return this.$refs.input.hasError
+      return this.inputReference.hasError
     },
 
     masks () {
@@ -136,13 +137,17 @@ export default {
     }
   },
 
+  mounted () {
+    this.inputReference = this.$refs.input
+  },
+
   methods: {
     focus () {
-      return this.$refs.input.focus()
+      return this.inputReference.focus()
     },
 
     resetValidation () {
-      return this.$refs.input.resetValidation()
+      return this.inputReference.resetValidation()
     },
 
     toggleMask (first, second) {
@@ -151,7 +156,7 @@ export default {
     },
 
     validate (value) {
-      return this.$refs.input.validate(value)
+      return this.inputReference.validate(value)
     },
 
     onPaste (event) {
@@ -167,7 +172,7 @@ export default {
     },
 
     getInput () {
-      return this.$refs.input?.$el?.querySelector('input')
+      return this.inputReference?.$el?.querySelector('input')
     },
 
     handleErrors () {

--- a/ui/src/components/input/QasInput.vue
+++ b/ui/src/components/input/QasInput.vue
@@ -65,6 +65,10 @@ export default {
   },
 
   computed: {
+    hasError () {
+      return this.$refs.input.hasError
+    },
+
     masks () {
       return {
         [Masks.CompanyDocument]: () => '##.###.###/####-##',


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- (Remova este texto de descrição.) -->
### Corrigido
- `QasInput`: corrigido problema causado na versão `3.11.0-beta.14` onde o watch `mask` não foi alterado para `currentMask`.

### Removido
- `QasInput`: removido computada `inputReference` que retornava o ref do `input`, pois seguindo a recomendação do Vue não é uma boa prática utilizar refs dentro de computadas, então foi movido a recuperação da ref para os métodos que à utilizam.
- `QasInput`: removido computada `hasError` pois não estava sendo utilizada em nenhum local no componente.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [x] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [ ] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
