### PR TITLE
QasTextTruncate feature counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ### Adicionado
 - `QasTextTruncate`: adicionado propriedades `color` e `typography` para controlar estilo da fonte.
-- `QasTextTruncate` adicionado propriedades `useCounterMode`, `maxVisibleItem`, `list` e `useObjectList` para recurso de contador.
+- `QasTextTruncate` adicionado propriedades, `maxVisibleItem`, `list` e `useObjectList` para recurso de contador.
 
 ### Modificado
 - `QasTextTruncate`: modificado cor e tipografia do texto.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+## BREAKING CHANGES
+- `QasTextTruncate`: quebra visual por conta das alterações de estilos na fonte do texto, olhar todos lugares que utilizam o componente e caso necessário adaptar com as propriedades color e typography.
+
+### Adicionado
+- `QasTextTruncate`: adicionado propriedades `color` e `typography` para controlar estilo da fonte.
+- `QasTextTruncate` adicionado propriedades `useCounterMode`, `maxVisibleItem`, `list` e `useObjectList` para recurso de contador.
+
+### Modificado
+- `QasTextTruncate`: modificado cor e tipografia do texto.
+
 ## [3.11.0-beta.18] - 25-08-2023
 ### Adicionado
 - `QasFormGenerator`: adicionado possibilidade de passar uma descrição para o `fieldset`.

--- a/docs/src/examples/QasTextTruncate/WithCounter.vue
+++ b/docs/src/examples/QasTextTruncate/WithCounter.vue
@@ -1,12 +1,11 @@
 <template>
   <div class="container q-py-lg">
-    <qas-text-truncate class="text-negative" dialog-title="Aqui está meu título!" :list="list" :max-visible-item="3" use-counter-mode />
+    <qas-text-truncate class="text-negative" dialog-title="Aqui está meu título!" :list="list" :max-visible-item="3" />
   </div>
 </template>
 
 <script>
 export default {
-
   computed: {
     list () {
       return [

--- a/docs/src/examples/QasTextTruncate/WithCounter.vue
+++ b/docs/src/examples/QasTextTruncate/WithCounter.vue
@@ -10,7 +10,7 @@ export default {
   computed: {
     list () {
       return [
-        'Primeiro item com um texto bem grande',
+        'Primeiro item',
         'Segundo item',
         'Terceiro item',
         'Quarto item',

--- a/docs/src/examples/QasTextTruncate/WithCounter.vue
+++ b/docs/src/examples/QasTextTruncate/WithCounter.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container q-py-lg">
-    <qas-text-truncate dialog-title="Aqui está meu título!" :list="list" use-counter-mode />
+    <qas-text-truncate class="text-negative" dialog-title="Aqui está meu título!" :list="list" :max-visible-item="3" use-counter-mode />
   </div>
 </template>
 
@@ -10,7 +10,7 @@ export default {
   computed: {
     list () {
       return [
-        'Primeiro item com um texto bem grande que vai ser cortado e vai aparecer um botão para ver mais',
+        'Primeiro item com um texto bem grande',
         'Segundo item',
         'Terceiro item',
         'Quarto item',

--- a/docs/src/examples/QasTextTruncate/WithCounter.vue
+++ b/docs/src/examples/QasTextTruncate/WithCounter.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="container q-py-lg">
+    <qas-text-truncate dialog-title="Aqui está meu título!" :list="list" use-counter-mode />
+  </div>
+</template>
+
+<script>
+export default {
+
+  computed: {
+    list () {
+      return [
+        'Primeiro item com um texto bem grande que vai ser cortado e vai aparecer um botão para ver mais',
+        'Segundo item',
+        'Terceiro item',
+        'Quarto item',
+        'Quinto item',
+        'Sexto item'
+      ]
+    }
+  }
+}
+</script>

--- a/docs/src/pages/components/text-truncate.md
+++ b/docs/src/pages/components/text-truncate.md
@@ -10,6 +10,8 @@ Trunca um texto baseado no tamanho do elemento pai e adiciona um rotulo "ver mai
 
 <doc-example file="QasTextTruncate/Basic" title="Básico" />
 
+<doc-example file="QasTextTruncate/WithCounter" title="Com contador" />
+
 :::warning
 Quando for utilizar por slot, não pode haver nenhum elemento englobando o texto.
 :::

--- a/ui/src/components/text-truncate/QasTextTruncate.vue
+++ b/ui/src/components/text-truncate/QasTextTruncate.vue
@@ -9,7 +9,7 @@
     </div>
 
     <qas-dialog v-model="show" v-bind="defaultProps" aria-label="Diálogo de texto completo" role="dialog">
-      <template v-if="props.useCounterMode" #description>
+      <template v-if="isCounterMode" #description>
         <div class="q-col-gutter-y-md row">
           <div
             v-for="(item, index) in normalizedList"
@@ -115,6 +115,7 @@ const {
   buttonLabel,
   displayText,
   hasButton,
+  isCounterMode,
   normalizedList
 } = useTemplate()
 
@@ -222,22 +223,25 @@ function useTemplate () {
     normalizedCounterText
   } = useCounter()
 
+  const isCounterMode = computed(() => !!props.list.length)
+
   const hasButton = computed(() => {
-    return props.useCounterMode ? normalizedList.value.length > props.maxVisibleItem : isTruncated.value
+    return isCounterMode.value ? normalizedList.value.length > props.maxVisibleItem : isTruncated.value
   })
 
   const displayText = computed(() => {
-    return props.useCounterMode ? normalizedCounterText.value : props.text
+    return isCounterMode.value ? normalizedCounterText.value : props.text
   })
 
   const buttonLabel = computed(() => {
-    return props.useCounterMode ? counterLabel.value : props.seeMoreLabel
+    return isCounterMode.value ? counterLabel.value : props.seeMoreLabel
   })
 
   return {
+    buttonLabel,
     displayText,
     hasButton,
-    buttonLabel,
+    isCounterMode,
     normalizedList
   }
 }

--- a/ui/src/components/text-truncate/QasTextTruncate.vue
+++ b/ui/src/components/text-truncate/QasTextTruncate.vue
@@ -87,10 +87,6 @@ const props = defineProps({
 
   useObjectList: {
     type: Boolean
-  },
-
-  useCounterMode: {
-    type: Boolean
   }
 })
 

--- a/ui/src/components/text-truncate/QasTextTruncate.yml
+++ b/ui/src/components/text-truncate/QasTextTruncate.yml
@@ -24,7 +24,7 @@ props:
     default: 0
 
   max-visible-item:
-    desc: Quantidade de itens a serem exibidos fora do dialog (uso junto ao useCounterMode).
+    desc: Quantidade de itens a serem exibidos fora do dialog (uso junto a prop list).
     type: Number
     default: 0
 
@@ -43,16 +43,12 @@ props:
     type: String
 
   list:
-    desc: Lista de itens a serem exibidos (uso junto ao useCounterMode).
+    desc: Lista de itens a serem exibidos (uso junto a prop list).
     default: []
     type: Array
 
-  use-counter-mode:
-    desc: Habilita o modo de contador.
-    type: Boolean
-
   use-object-list:
-    desc: Utiliza a propriedade "list" como array de objeto contendo label (uso junto ao useCounterMode).
+    desc: Utiliza a propriedade "list" como array de objeto contendo label (uso junto a prop list).
     type: Boolean
 
 slots:

--- a/ui/src/components/text-truncate/QasTextTruncate.yml
+++ b/ui/src/components/text-truncate/QasTextTruncate.yml
@@ -4,6 +4,11 @@ meta:
   desc: Trunca um texto baseado no tamanho do elemento pai e adiciona um rotulo "ver mais" que quando clicado mostra um dialog com o texto original completo (sem ser truncado).
 
 props:
+  color:
+    desc: Cor do texto.
+    type: String
+    default: grey-8
+
   dialog-props:
     desc: Repassa todas props e eventos para o componente `QasDialog`.
     type: Object
@@ -18,6 +23,11 @@ props:
     type: Number
     default: 0
 
+  max-visible-item:
+    desc: Quantidade de itens a serem exibidos fora do dialog (uso junto ao useCounterMode).
+    type: Number
+    default: 0
+
   see-more-label:
     desc: Texto que vai aparecer para ser clicado quando o texto original for truncado.
     type: String
@@ -26,6 +36,24 @@ props:
   text:
     desc: Texto a ser truncado.
     type: String
+
+  typography:
+    desc: Tipografia.
+    default: body1
+    type: String
+
+  list:
+    desc: Lista de itens a serem exibidos (uso junto ao useCounterMode).
+    default: []
+    type: Array
+
+  use-counter-mode:
+    desc: Habilita o modo de contador.
+    type: Boolean
+
+  use-object-list:
+    desc: Utiliza a propriedade "list" como array de objeto contendo label (uso junto ao useCounterMode).
+    type: Boolean
 
 slots:
   default:


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
## BREAKING CHANGES
- `QasTextTruncate`: quebra visual por conta das alterações de estilos na fonte do texto, olhar todos lugares que utilizam o componente e caso necessário adaptar com as propriedades color e typography.

### Adicionado
- `QasTextTruncate`: adicionado propriedades `color` e `typography` para controlar estilo da fonte.
- `QasTextTruncate` adicionado propriedades `useCounterMode`, `maxVisibleItem`, `list` e `useObjectList` para recurso de contador.


<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
