### PR TITLE
Fix QasSelect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasSelect`: corrigido watcher que não removida classe e mantinha opções desabilitadas quando deveria estar habilitada.
+
 ## [3.12.0-beta.3] - 08-09-2023
 ### Corrigido
 - `boot/queryCache`: alterada a validação ao definir cache da query para corrigir erro, que, ao limpar os filtros e alterar de página não limpava o cache.

--- a/ui/src/components/select/QasSelect.vue
+++ b/ui/src/components/select/QasSelect.vue
@@ -178,6 +178,12 @@ export default {
       if (this.hasFuse) this.setFuse()
     },
 
+    mx_isFetching (value) {
+      if (!this.isPopupContentOpen || !this.useLazyLoading) return
+
+      this.togglePopupContentClass(value)
+    },
+
     options: {
       handler () {
         if (this.useLazyLoading && this.mx_hasFilteredOptions) return
@@ -193,7 +199,6 @@ export default {
 
   created () {
     this.setSearchMethod()
-    this.setIsFetchingWatcher()
   },
 
   methods: {
@@ -235,16 +240,6 @@ export default {
 
       if (this.mx_isFetching) {
         this.togglePopupContentClass(true)
-      }
-    },
-
-    setIsFetchingWatcher () {
-      if (this.useLazyLoading) {
-        this.$watch('mx_isFetching', value => {
-          if (!this.isPopupContentOpen) return
-
-          this.togglePopupContentClass(value)
-        })
       }
     },
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Corrigido
- `QasSelect`: corrigido watcher que não removida classe e mantinha opções desabilitadas quando deveria estar habilitada.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
