### PR TITLE
Changes in QasAlert

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,6 +38,7 @@
     "QasSortable"
   ],
   "cSpell.words": [
+    "breakline",
     "Breakline",
     "fawmi",
     "fontfaceobserver",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
+## BREAKING CHANGES
+### Removido
+- `QasAlert`: removido propriedades [`color`, `title`].
+- `QasAlert`: removido slot header.
+
 ### Adicionado
 - `QasNestedFields`: Adicionado suporte para função de callback na propriedade `disabled-rows`.
 - `QasAlert`: adicionado novas propriedades [`status`, `storageKey`, `usePersistentModelOnClose`].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ## Não publicado
 ### Adicionado
 - `QasNestedFields`: Adicionado suporte para função de callback na propriedade `disabled-rows`.
+- `QasAlert`: adicionado novas propriedades [`status`, `storageKey`, `usePersistentModelOnClose`].
+- `enums/Status`: adicionado novos enums para status.
+
+### Modificado
+- `QasAlert`: mudanças de layout e comportamento com componente.
+- `QasAlert`: modificado componente para composition API.
+- `QasAlert`: agora só é preciso passar um v-model caso realmente seja necessário.
+
+### Removido
+- `QasAlert`: removido propriedades [`color`, `title`].
+- `QasAlert`: removido slot header.
 
 ## [3.12.0-beta.4] - 11-09-2023
 ### Corrigido

--- a/docs/src/examples/QasAlert/Basic.vue
+++ b/docs/src/examples/QasAlert/Basic.vue
@@ -1,21 +1,5 @@
 <template>
   <div class="container q-py-lg">
-    <qas-alert v-model="model" color="negative" text="Aqui vai um pequeno texto para teste" title="Titulo de exemplo" />
-
-    <div>
-      model: {{ model }}
-    </div>
-
-    <qas-btn @click="model = !model">Mudar o model</qas-btn>
+    <qas-alert text="Pequeno texto para demonstração." />
   </div>
 </template>
-
-<script>
-export default {
-  data () {
-    return {
-      model: true
-    }
-  }
-}
-</script>

--- a/docs/src/examples/QasAlert/Basic.vue
+++ b/docs/src/examples/QasAlert/Basic.vue
@@ -1,5 +1,5 @@
 <template>
   <div class="container q-py-lg">
-    <qas-alert text="Pequeno texto para demonstração." />
+    <qas-alert text="Estamos passando por manutenção entre os dias 02/04 e 03/04. A estabilização do sistema está prevista para 03/04 às 15:00." />
   </div>
 </template>

--- a/docs/src/examples/QasAlert/ExAlertError.vue
+++ b/docs/src/examples/QasAlert/ExAlertError.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="container q-py-lg">
+    <qas-alert status="error" text="Pequeno texto para demonstração." />
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      model: false
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QasAlert/ExAlertModel.vue
+++ b/docs/src/examples/QasAlert/ExAlertModel.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="container q-py-lg">
+    <qas-alert v-model="model" text="Pequeno texto para demonstração." />
+
+    <div>
+      model: {{ model }}
+    </div>
+
+    <qas-btn @click="model = !model">Mudar o model</qas-btn>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      model: true
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QasAlert/ExAlertPersistent.vue
+++ b/docs/src/examples/QasAlert/ExAlertPersistent.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="container q-py-lg">
+    <qas-alert storage-key="my-alert-persistent" text="Pequeno texto para demonstração." use-persistent-model-on-close />
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      model: false
+    }
+  }
+}
+</script>

--- a/docs/src/pages/components/alert.md
+++ b/docs/src/pages/components/alert.md
@@ -6,7 +6,15 @@ Componente para abrir um menu de ação a partir de um botão, muito utilizado e
 
 <doc-api file="alert/QasAlert" name="QasAlert" />
 
+:::info
+A propriedade `status` por hora implementa apenas 2 status, eles são:
+- error
+- info
+:::
 
 ## Uso
 
 <doc-example file="QasAlert/Basic" title="Básico" />
+<doc-example file="QasAlert/ExAlertModel" title="Com model" />
+<doc-example file="QasAlert/ExAlertPersistent" title="Model persistente" />
+<doc-example file="QasAlert/ExAlertError" title="Status error" />

--- a/ui/src/components/alert/QasAlert.vue
+++ b/ui/src/components/alert/QasAlert.vue
@@ -5,14 +5,15 @@
   >
     <div class="qas-alert__border-left" :class="borderClass" />
 
-    <div class="qs-lh-lg text-body1 text-white">
+    <div class="text-body1 text-white">
       <slot>
         {{ text }}
       </slot>
     </div>
 
-    <div class="qas-alert__close">
+    <div>
       <qas-btn
+        class="q-ml-xs qas-alert__close"
         color="white"
         icon="sym_r_close"
         :use-hover-on-white-color="false"
@@ -106,11 +107,6 @@ function close () {
 
   &__close {
     top: calc(var(--qas-spacing-sm) * -1);
-
-    // TODO: rever com yan
-    .qas-btn .q-icon {
-      font-size: 1rem !important;
-    }
   }
 }
 </style>

--- a/ui/src/components/alert/QasAlert.vue
+++ b/ui/src/components/alert/QasAlert.vue
@@ -69,6 +69,7 @@ const colorByStatus = computed(() => {
   const status = Object.keys(Status).find(key => Status[key] === props.status)
   return StatusColor[status]
 })
+
 const borderClass = computed(() => `bg-${colorByStatus.value}`)
 
 const storageClosedKey = computed(() => `alert-${props.storageKey}-closed`)

--- a/ui/src/components/alert/QasAlert.vue
+++ b/ui/src/components/alert/QasAlert.vue
@@ -1,87 +1,116 @@
 <template>
-  <div v-if="model" class="bg-white q-pa-lg qas-alert relative-position rounded-borders" :class="classes">
-    <qas-btn class="absolute-top-right q-mr-md q-mt-sm" color="grey-9" icon="sym_r_close" variant="tertiary" @click="close" />
+  <div
+    v-if="show"
+    class="bg-dark flex justify-between no-wrap q-pa-md qas-alert relative-position"
+  >
+    <div class="qas-alert__border-left" :class="borderClass" />
 
-    <div class="q-gutter-md q-mr-lg">
-      <slot name="header">
-        <h5 v-if="title" class="text-bold text-h5" data-test="alert-title">{{ title }}</h5>
-      </slot>
-
+    <div class="qs-lh-lg text-body1 text-white">
       <slot>
-        <qas-breakline tag="p" :text="text" />
+        {{ text }}
       </slot>
+    </div>
+
+    <div class="qas-alert__close">
+      <qas-btn
+        color="white"
+        icon="sym_r_close"
+        :use-hover-on-white-color="false"
+        @click="close"
+      />
     </div>
   </div>
 </template>
 
-<script>
-import QasBreakline from '../breakline/QasBreakline.vue'
-import QasBtn from '../btn/QasBtn.vue'
+<script setup>
+import { LocalStorage } from 'quasar'
+import { Status, StatusColor } from '../../enums/Status'
+import { computed, watch, ref } from 'vue'
 
-export default {
-  name: 'QasAlert',
+defineOptions({ name: 'QasAlert' })
 
-  components: {
-    QasBreakline,
-    QasBtn
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: true
   },
 
-  props: {
-    modelValue: {
-      default: true,
-      type: Boolean
-    },
-
-    text: {
-      default: '',
-      type: String
-    },
-
-    color: {
-      type: String,
-      default: 'primary'
-    },
-
-    title: {
-      default: '',
-      type: String
-    }
+  text: {
+    type: String,
+    default: ''
   },
 
-  emits: ['update:modelValue'],
-
-  data () {
-    return {
-      model: true
-    }
+  storageKey: {
+    type: String,
+    default: ''
   },
 
-  computed: {
-    classes () {
-      return `text-${this.color}`
-    }
+  status: {
+    type: String,
+    default: Status.Info,
+    validator: value => Object.values(Status).includes(value)
   },
 
-  watch: {
-    modelValue: {
-      handler (value) {
-        this.model = value
-      },
-      immediate: true
-    }
-  },
-
-  methods: {
-    close () {
-      this.$emit('update:modelValue', false)
-    }
+  usePersistentModelOnClose: {
+    type: Boolean
   }
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const model = ref(props.modelValue)
+
+watch(() => props.modelValue, value => {
+  model.value = value
+})
+
+const colorByStatus = computed(() => {
+  const status = Object.keys(Status).find(key => Status[key] === props.status)
+  return StatusColor[status]
+})
+const borderClass = computed(() => `bg-${colorByStatus.value}`)
+
+const storageClosedKey = computed(() => `alert-${props.storageKey}-closed`)
+
+const isClosed = computed(() => {
+  return props.usePersistentModelOnClose && LocalStorage.getItem(storageClosedKey.value)
+})
+
+const show = computed(() => !isClosed.value && model.value)
+
+function close () {
+  if (props.usePersistentModelOnClose) {
+    LocalStorage.set(storageClosedKey.value, true)
+  }
+
+  model.value = false
+
+  emit('update:modelValue', model.value)
 }
+
 </script>
 
 <style lang="scss">
 .qas-alert {
-  border-style: solid;
-  border-width: 0 10px;
+  border-radius: var(--qas-generic-border-radius);
+
+  &__border-left {
+    border-radius: var(--qas-generic-border-radius) 0 0 var(--qas-generic-border-radius);
+    bottom: 0;
+    content: '';
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 4px;
+  }
+
+  &__close {
+    top: calc(var(--qas-spacing-sm) * -1);
+
+    // TODO: rever com yan
+    .qas-btn .q-icon {
+      font-size: 1rem !important;
+    }
+  }
 }
 </style>

--- a/ui/src/components/alert/QasAlert.yml
+++ b/ui/src/components/alert/QasAlert.yml
@@ -9,20 +9,26 @@ props:
     default: true
     type: Boolean
 
-  title:
-    desc: Título do componente.
-    type: String
-
   text:
     desc: Texto do componente.
     type: String
 
+  status:
+    desc: Status do alerta.
+    type: String
+    examples: ['error', 'info']
+
+  storage-key:
+    desc: Chave a ser salva no localStorage, necessário caso esteja usando mais de um QasAlert na aplicação e ambos estejam com a prop "use-persist-model-on-close" ativada.
+    type: String
+
+  use-persistent-model-on-close:
+    desc: Habilita salvar o model em localStorage ao fechar o alerta para não aparecer novamente.
+    type: Boolean
+
 slots:
   default:
     desc: 'Slot para acessar o conteúdo gerado pela prop "text"'
-
-  header:
-    desc: 'Slot para acessar o conteúdo gerado pela prop "title"'
 
 events:
   '@update:model-value -> function(value)':

--- a/ui/src/enums/Status.js
+++ b/ui/src/enums/Status.js
@@ -1,0 +1,33 @@
+/**
+ * Cores por status
+ *
+ * @property
+ * @name Spacing
+ * @readonly
+ * @enum
+ * @type {{
+ * Info: 'yellow-14',
+ * Error: 'red-14'
+ * }}
+*/
+export const StatusColor = {
+  Info: 'yellow-14',
+  Error: 'red-14'
+}
+
+/**
+ * Status
+ *
+ * @property
+ * @name Spacing
+ * @readonly
+ * @enum
+ * @type {{
+ * Info: 'info',
+ * Error: 'error'
+ * }}
+ */
+export const Status = {
+  Info: 'info',
+  Error: 'error'
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
## BREAKING CHANGES
### Removido
- `QasAlert`: removido propriedades [`color`, `title`].
- `QasAlert`: removido slot header.

### Adicionado
- `QasNestedFields`: Adicionado suporte para função de callback na propriedade `disabled-rows`.
- `QasAlert`: adicionado novas propriedades [`status`, `storageKey`, `usePersistentModelOnClose`].
- `enums/Status`: adicionado novos enums para status.

### Modificado
- `QasAlert`: mudanças de layout e comportamento com componente.
- `QasAlert`: modificado componente para composition API.
- `QasAlert`: agora só é preciso passar um v-model caso realmente seja necessário.

### Removido
- `QasAlert`: removido propriedades [`color`, `title`].
- `QasAlert`: removido slot header.


<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [x] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [x] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
