### PR TITLE
Update QasAlert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `QasAlert`: adicionado classe `inline-block` para o elemento pegar somente o tamanho necessário e não 100% sempre.
+
 ## [3.12.0-beta.5] - 13-09-2023
 ## BREAKING CHANGES
 ### Removido

--- a/ui/src/components/alert/QasAlert.vue
+++ b/ui/src/components/alert/QasAlert.vue
@@ -1,23 +1,24 @@
 <template>
-  <div
-    v-if="show"
-    class="bg-dark flex justify-between no-wrap q-pa-md qas-alert relative-position"
-  >
-    <div class="qas-alert__border-left" :class="borderClass" />
+  <div v-if="show" class="inline-block">
+    <div
+      class="bg-dark flex justify-between no-wrap q-pa-md qas-alert relative-position"
+    >
+      <div class="qas-alert__border-left" :class="borderClass" />
 
-    <div class="text-body1 text-white">
-      <slot>
-        {{ text }}
-      </slot>
+      <div class="text-body1 text-white">
+        <slot>
+          {{ text }}
+        </slot>
+      </div>
+
+      <qas-btn
+        class="q-ml-xs qas-alert__close"
+        color="white"
+        icon="sym_r_close"
+        :use-hover-on-white-color="false"
+        @click="close"
+      />
     </div>
-
-    <qas-btn
-      class="q-ml-xs qas-alert__close"
-      color="white"
-      icon="sym_r_close"
-      :use-hover-on-white-color="false"
-      @click="close"
-    />
   </div>
 </template>
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Modificado
- `QasAlert`: adicionado classe `inline-block` para o elemento pegar somente o tamanho necessário e não 100% sempre.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
