### PR TITLE
Update useCache default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+## BREAKING CHANGE
+- `boot/query-cache.js`: modificado o valor padrão do `useCache`, antes todas rotas por default era `true`, agora, apenas rotas que contém a chave `name` e o name termine com a string `list` ou `List` terão `true` como padrão.
+
+### Modificado
+- `boot/query-cache.js`: modificado o valor padrão do `useCache`, antes todas rotas por default era `true`, agora, apenas rotas que contém a chave `name` e o name termine com a string `list` ou `List` terão `true` como padrão.
+
 ## [3.12.0-beta.6] - 13-09-2023
 ### Modificado
 - `QasAlert`: adicionado classe `inline-block` para o elemento pegar somente o tamanho necessário e não 100% sempre.

--- a/app-extension/src/boot/query-cache.js
+++ b/app-extension/src/boot/query-cache.js
@@ -5,8 +5,10 @@ const { addMany, findAll, clearAll } = useQueryCache()
 
 let isReplacingQuery = false
 
-function getDefaultUseCacheValue (route) {
-  return route.meta.useCache ?? true
+function getDefaultUseCacheValue (route = {}) {
+  const { name, meta } = route
+
+  return meta.useCache ?? name.toLowerCase?.().endsWith?.('list')
 }
 
 function getQueriesFromMatchedRoutes (matched, key) {

--- a/docs/src/pages/boot/query-cache.md
+++ b/docs/src/pages/boot/query-cache.md
@@ -9,11 +9,11 @@ Persistência das queries é habilitado por padrão e é o comportamento esperad
 O controle é feito pelo meta, sendo configurado nas rotas e podendo ter diferentes configurações por rota.
 
 :::info
-`useCache` é `true`, por default.
+`useCache` é `true`, para rotas com `name` que terminam com `list` | `List` por padrão.
 
 Os atributos que podem ser repassados para o meta, são:
 - `useCache: true | false`: responsável por habilitar a persistência de queries.
-- `excludes: string[]`: array de parâmetros que não devem ser persistidos. `page` é excluido por padrão.
+- `excludes: string[]`: array de parâmetros que não devem ser persistidos. `page` é excluído por padrão.
 - `includes: string[]`: array de parâmetros para ignorar parâmetros passados ao `excludes`.
 :::
 
@@ -39,20 +39,22 @@ const routes = [
       {
         path: '',
         name: 'Root',
+        meta: {
+          useCache: true // habilita o cache
+        },
         component: () => import('pages/IndexPage.vue'),
         redirect: { name: 'CustomersList' }
       },
       {
         path: 'customers',
-        name: 'CustomersList',
+        name: 'CustomersList', // habilitado cache por padrão por terminar com "List"
         component: () => import('pages/customers/CustomersList.vue'),
         meta: { includes: ['isActive'] } // a rota filho tem precedência sobre a rota pai, então "isActive" será persistido.
       },
       {
         path: 'customers/new',
-        name: 'CustomersCreate',
-        component: () => import('pages/customers/CustomersForm.vue'),
-        meta: { useCache: false } // a rota não irá persistir nenhum parâmetro.
+        name: 'CustomersCreate', // sem cache por padrão
+        component: () => import('pages/customers/CustomersForm.vue')
       },
     ]
   }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
## BREAKING CHANGE
- `boot/query-cache.js`: modificado o valor padrão do `useCache`, antes todas rotas por default era `true`, agora, apenas rotas que contém a chave `name` e o name termine com a string `list` ou `List` terão `true` como padrão.

### Modificado
- `boot/query-cache.js`: modificado o valor padrão do `useCache`, antes todas rotas por default era `true`, agora, apenas rotas que contém a chave `name` e o name termine com a string `list` ou `List` terão `true` como padrão.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [ ] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [x] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
