### PR TITLE
Feature/qas nested fields actions menu support to callback fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ## Não publicado
 ### Adicionado
-- `QasNestedFields`: Adicionado suporte para função de callback na propriedade `actions-menu-props`.
+- `QasNestedFields`: adicionado suporte para função de callback na propriedade `actions-menu-props`.
+- `QasLabel`: adicionado nova propriedade `heading` para controlar a tipografia do texto.
 
 ### Modificado
 - `QasNestedFields`: modificado espaçamentos do componente.
+- `QasNestedFields`: modificado tamanho da fonte do label.
 
 ## [3.12.0-beta.8] - 13-09-2023
 ### Corrigido

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ## Não publicado
 ### Adicionado
 - `QasNestedFields`: adicionado suporte para função de callback na propriedade `actions-menu-props`.
-- `QasLabel`: adicionado nova propriedade `heading` para controlar a tipografia do texto.
+- `QasLabel`: adicionado nova propriedade `typography` para controlar a tipografia do texto.
 
 ### Modificado
 - `QasNestedFields`: modificado espaçamentos do componente.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasNestedFields`: Adicionado suporte para função de callback na propriedade `actions-menu-props`.
+
+### Modificado
+- `QasNestedFields`: modificado espaçamentos do componente.
+
 ## [3.12.0-beta.8] - 13-09-2023
 ### Corrigido
 - `boot/query-cache.js`: added optional chaining to route name.

--- a/docs/src/examples/QasNestedFields/ActionsMenuPropsFunction.vue
+++ b/docs/src/examples/QasNestedFields/ActionsMenuPropsFunction.vue
@@ -1,0 +1,95 @@
+<template>
+  <div class="container spaced">
+    <div class="full-width">
+      <div class="q-mt-lg text-center">
+        <div>
+          <qas-nested-fields v-model="model" :actions-menu-props="getActionsMenuProps" class="full-width" :field="nested" :form-columns="formColumns" :row-object="rowObject" :use-starts-empty="false" />
+        </div>
+
+        <div class="q-my-lg">
+          Model: <qas-debugger :inspect="[model]" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+const nested = {
+  name: 'nested',
+  type: 'nested',
+  label: 'Meu nested',
+  children: {
+    name: {
+      name: 'name',
+      type: 'text',
+      label: 'Nome'
+    },
+    email: {
+      name: 'email',
+      type: 'email',
+      label: 'E-mail'
+    },
+    cities: {
+      name: 'cities',
+      type: 'select',
+      options: [
+        {
+          label: 'Cidade 1',
+          value: 1
+        },
+        {
+          label: 'Cidade 2',
+          value: 2
+        },
+        {
+          label: 'Cidade 3',
+          value: 3
+        }
+      ]
+    }
+  }
+}
+
+export default {
+  data () {
+    return {
+      nested,
+      model: []
+    }
+  },
+
+  computed: {
+    rowObject () {
+      return {
+        name: '',
+        email: '',
+        cities: []
+      }
+    },
+
+    formColumns () {
+      return {
+        name: { col: 12 },
+        email: { col: 12 },
+        cities: { col: 12 }
+      }
+    }
+  },
+
+  methods: {
+    getActionsMenuProps ({ index, row, list }) {
+      return {
+        list: {
+          ...list,
+          visibility: {
+            icon: 'sym_r_visibility',
+            label: 'Visualizar',
+            handler: () => alert('Clicou em visualizar!')
+          }
+        }
+      }
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QasNestedFields/ActionsMenuPropsFunction.vue
+++ b/docs/src/examples/QasNestedFields/ActionsMenuPropsFunction.vue
@@ -20,6 +20,11 @@ const nested = {
   type: 'nested',
   label: 'Meu nested',
   children: {
+    status: {
+      name: 'status',
+      type: 'boolean',
+      label: 'Status'
+    },
     name: {
       name: 'name',
       type: 'text',
@@ -62,6 +67,7 @@ export default {
   computed: {
     rowObject () {
       return {
+        status: false,
         name: '',
         email: '',
         cities: []
@@ -70,6 +76,7 @@ export default {
 
     formColumns () {
       return {
+        status: { col: 2 },
         name: { col: 12 },
         email: { col: 12 },
         cities: { col: 12 }
@@ -80,13 +87,18 @@ export default {
   methods: {
     getActionsMenuProps ({ index, row, list }) {
       return {
+        splitName: row.status ? 'visibility' : '',
+
         list: {
-          ...list,
-          visibility: {
-            icon: 'sym_r_visibility',
-            label: 'Visualizar',
-            handler: () => alert('Clicou em visualizar!')
-          }
+          ...(row.status && {
+            visibility: {
+              icon: 'sym_r_visibility',
+              label: 'Visualizar',
+              handler: () => alert('Clicou em visualizar!')
+            }
+          }),
+
+          ...list
         }
       }
     }

--- a/docs/src/examples/QasNestedFields/ActionsMenuPropsObject.vue
+++ b/docs/src/examples/QasNestedFields/ActionsMenuPropsObject.vue
@@ -1,0 +1,92 @@
+<template>
+  <div class="container spaced">
+    <div class="full-width">
+      <div class="q-mt-lg text-center">
+        <div>
+          <qas-nested-fields v-model="model" :actions-menu-props="actionsMenuProps" class="full-width" :field="nested" :form-columns="formColumns" :row-object="rowObject" :use-starts-empty="false" />
+        </div>
+
+        <div class="q-my-lg">
+          Model: <qas-debugger :inspect="[model]" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+const nested = {
+  name: 'nested',
+  type: 'nested',
+  label: 'Meu nested',
+  children: {
+    name: {
+      name: 'name',
+      type: 'text',
+      label: 'Nome'
+    },
+    email: {
+      name: 'email',
+      type: 'email',
+      label: 'E-mail'
+    },
+    cities: {
+      name: 'cities',
+      type: 'select',
+      options: [
+        {
+          label: 'Cidade 1',
+          value: 1
+        },
+        {
+          label: 'Cidade 2',
+          value: 2
+        },
+        {
+          label: 'Cidade 3',
+          value: 3
+        }
+      ]
+    }
+  }
+}
+
+export default {
+  data () {
+    return {
+      nested,
+      model: []
+    }
+  },
+
+  computed: {
+    actionsMenuProps () {
+      return {
+        list: {
+          visibility: {
+            icon: 'sym_r_visibility',
+            label: 'Visualizar',
+            handler: () => alert('Clicou em visualizar!')
+          }
+        }
+      }
+    },
+
+    rowObject () {
+      return {
+        name: '',
+        email: '',
+        cities: []
+      }
+    },
+
+    formColumns () {
+      return {
+        name: { col: 12 },
+        email: { col: 12 },
+        cities: { col: 12 }
+      }
+    }
+  }
+}
+</script>

--- a/docs/src/pages/components/nested-fields.md
+++ b/docs/src/pages/components/nested-fields.md
@@ -70,6 +70,8 @@ A propriedade `useDestroyAlways` caso não seja repassada ao componente, assume 
 <doc-example file="QasNestedFields/StartsEmptyFalse" title="Começando com formulário" />
 <doc-example file="QasNestedFields/DisabledRowsArray" title="Linhas desabilitadas com um array de uuids" />
 <doc-example file="QasNestedFields/DisabledRowsFunction" title="Linhas desabilitadas com uma função de callback" />
+<doc-example file="QasNestedFields/ActionsMenuPropsObject" title="Propriedades do QasActionsMenu com objeto" />
+<doc-example file="QasNestedFields/ActionsMenuPropsFunction" title="Propriedades do QasActionsMenu com função de callback" />
 <doc-example file="QasNestedFields/InlineActions" title="Propriedade useInlineActions" />
 <doc-example file="QasNestedFields/SlotDynamic" title="Slot field-[nome-da-chave]" />
 <doc-example file="QasNestedFields/SlotFields" title="Slot fields" />

--- a/ui/src/components/label/QasLabel.vue
+++ b/ui/src/components/label/QasLabel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="text-h4" :class="classes">
+  <div :class="classes">
     <slot :label-with-suffix="formattedLabel">{{ formattedLabel }}</slot>
   </div>
 </template>
@@ -20,6 +20,16 @@ export default {
     count: {
       default: 0,
       type: [Number, String]
+    },
+
+    heading: {
+      default: 'h4',
+      type: String,
+      validator: value => {
+        const availableHeadings = ['h4', 'h5']
+
+        return availableHeadings.includes(value)
+      }
     },
 
     label: {
@@ -54,7 +64,8 @@ export default {
     classes () {
       return [
         `q-mb-${this.margin}`,
-        `text-${this.color}`
+        `text-${this.color}`,
+        `text-${this.heading}`
       ]
     }
   }

--- a/ui/src/components/label/QasLabel.vue
+++ b/ui/src/components/label/QasLabel.vue
@@ -22,16 +22,6 @@ export default {
       type: [Number, String]
     },
 
-    heading: {
-      default: 'h4',
-      type: String,
-      validator: value => {
-        const availableHeadings = ['h4', 'h5']
-
-        return availableHeadings.includes(value)
-      }
-    },
-
     label: {
       default: '',
       type: String
@@ -49,6 +39,16 @@ export default {
 
     required: {
       type: Boolean
+    },
+
+    typography: {
+      default: 'h4',
+      type: String,
+      validator: value => {
+        const availableTypography = ['h4', 'h5']
+
+        return availableTypography.includes(value)
+      }
     }
   },
 
@@ -65,7 +65,7 @@ export default {
       return [
         `q-mb-${this.margin}`,
         `text-${this.color}`,
-        `text-${this.heading}`
+        `text-${this.typography}`
       ]
     }
   }

--- a/ui/src/components/label/QasLabel.yml
+++ b/ui/src/components/label/QasLabel.yml
@@ -4,10 +4,21 @@ meta:
   desc: Componente para controlar textos que separam conteúdos, formatando com um sufixo quando existe um contador.
 
 props:
+  color:
+    desc: Cor do texto.
+    default: grey-9
+    type: String
+
   count:
     desc: Contador que vai ficar ao lado do texto.
     default: 0
     type: Number
+
+  heading:
+    desc: Controla qual a tipografia do texto.
+    default: h4
+    type: String
+    examples: [h4, h5]
 
   label:
     desc: Texto a ser exibido.
@@ -20,14 +31,9 @@ props:
     examples: [xs, sm, md, lg, xl]
 
   required:
-    desc: Controla label do campo, se for "true" adiciona sufixo "*".
+    desc: Controla se exibirá o sufixo "*" ao lado do texto.
     default: false
     type: Boolean
-
-  color:
-    desc: Cor da label.
-    default: grey-9
-    type: String
 
 slots:
   default:

--- a/ui/src/components/label/QasLabel.yml
+++ b/ui/src/components/label/QasLabel.yml
@@ -14,12 +14,6 @@ props:
     default: 0
     type: Number
 
-  heading:
-    desc: Controla qual a tipografia do texto.
-    default: h4
-    type: String
-    examples: [h4, h5]
-
   label:
     desc: Texto a ser exibido.
     type: String
@@ -34,6 +28,12 @@ props:
     desc: Controla se exibirá o sufixo "*" ao lado do texto.
     default: false
     type: Boolean
+
+  typography:
+    desc: Controla qual a tipografia do texto.
+    default: h4
+    type: String
+    examples: [h4, h5]
 
 slots:
   default:

--- a/ui/src/components/nested-fields/QasNestedFields.vue
+++ b/ui/src/components/nested-fields/QasNestedFields.vue
@@ -10,7 +10,7 @@
           <div v-if="!row[destroyKey]" :id="`row-${index}`" class="full-width q-mt-md qas-nested-fields__field-item">
             <header v-if="hasHeader" class="flex items-center q-pb-md" :class="headerClasses">
               <qas-label v-if="!useSingleLabel" :label="getRowLabel(index)" margin="none" />
-              <qas-actions-menu v-if="hasBlockActions(row)" v-bind="actionsMenuProps" :list="getActionsList(index, row)" />
+              <qas-actions-menu v-if="hasBlockActions(row)" v-bind="getActionsMenuProps(index, row)" />
             </header>
 
             <div ref="formGenerator" class="col-12 justify-between q-col-gutter-x-md row">
@@ -23,7 +23,7 @@
               </slot>
 
               <div v-if="hasInlineActions(row)" class="flex items-center qas-nested-fields__actions">
-                <qas-actions-menu v-bind="actionsMenuProps" :list="getActionsList(index, row)" />
+                <qas-actions-menu v-bind="getActionsMenuProps(index, row)" />
               </div>
             </div>
 
@@ -86,7 +86,7 @@ export default {
 
   props: {
     actionsMenuProps: {
-      type: Object,
+      type: [Object, Function],
       default: () => ({})
     },
 
@@ -327,7 +327,22 @@ export default {
   },
 
   methods: {
-    getActionsList (index, row) {
+    getActionsMenuProps (index, row) {
+      if (typeof this.actionsMenuProps === 'function') {
+        return this.actionsMenuProps({
+          index,
+          row,
+          list: this.getDefaultActionsMenuList(index, row)
+        })
+      }
+
+      return {
+        ...this.actionsMenuProps,
+        list: this.getActionsMenuList(index, row)
+      }
+    },
+
+    getDefaultActionsMenuList (index, row) {
       const list = {}
 
       if (this.useDuplicate) {
@@ -343,6 +358,12 @@ export default {
           handler: () => this.destroy(index, row)
         }
       }
+
+      return list
+    },
+
+    getActionsMenuList (index, row) {
+      const list = this.getDefaultActionsMenuList(index, row)
 
       for (const key in this.actionsMenuProps.list) {
         const { handler, ...content } = this.actionsMenuProps.list[key] || {}

--- a/ui/src/components/nested-fields/QasNestedFields.vue
+++ b/ui/src/components/nested-fields/QasNestedFields.vue
@@ -1,13 +1,13 @@
 <template>
   <div :id="fieldName" class="qas-nested-fields">
     <div v-if="useSingleLabel" class="text-left">
-      <qas-label :label="fieldLabel" margin="lg" />
+      <qas-label :label="fieldLabel" />
     </div>
 
     <div ref="inputContent">
       <component :is="componentTag" v-bind="componentProps">
         <template v-for="(row, index) in nested" :key="`row-${index}`">
-          <div v-if="!row[destroyKey]" :id="`row-${index}`" class="full-width q-mt-md qas-nested-fields__field-item">
+          <div v-if="!row[destroyKey]" :id="`row-${index}`" class="full-width qas-nested-fields__field-item">
             <header v-if="hasHeader" class="flex items-center q-pb-md" :class="headerClasses">
               <qas-label v-if="!useSingleLabel" :label="getRowLabel(index)" margin="none" />
               <qas-actions-menu v-if="hasBlockActions(row)" v-bind="getActionsMenuProps(index, row)" />
@@ -34,7 +34,7 @@
         </template>
       </component>
 
-      <div v-if="useAdd" class="q-mt-md">
+      <div v-if="useAdd">
         <slot :add="add" name="add-input">
           <div v-if="showAddFirstInputButton" class="text-left">
             <qas-btn class="q-px-sm" color="primary" variant="tertiary" @click="add()">{{ addFirstInputLabel }}</qas-btn>
@@ -492,6 +492,10 @@ export default {
 .qas-nested-fields {
   &__actions {
     height: 56px;
+  }
+
+  &__field-item {
+    margin-bottom: var(--qas-spacing-md);
   }
 
   &__field-item + &__field-item {

--- a/ui/src/components/nested-fields/QasNestedFields.vue
+++ b/ui/src/components/nested-fields/QasNestedFields.vue
@@ -1,7 +1,7 @@
 <template>
   <div :id="fieldName" class="qas-nested-fields">
     <div v-if="useSingleLabel" class="text-left">
-      <qas-label :label="fieldLabel" />
+      <qas-label heading="h5" :label="fieldLabel" />
     </div>
 
     <div ref="inputContent">
@@ -9,7 +9,7 @@
         <template v-for="(row, index) in nested" :key="`row-${index}`">
           <div v-if="!row[destroyKey]" :id="`row-${index}`" class="full-width qas-nested-fields__field-item">
             <header v-if="hasHeader" class="flex items-center q-pb-md" :class="headerClasses">
-              <qas-label v-if="!useSingleLabel" :label="getRowLabel(index)" margin="none" />
+              <qas-label v-if="!useSingleLabel" heading="h5" :label="getRowLabel(index)" margin="none" />
               <qas-actions-menu v-if="hasBlockActions(row)" v-bind="getActionsMenuProps(index, row)" />
             </header>
 

--- a/ui/src/components/nested-fields/QasNestedFields.vue
+++ b/ui/src/components/nested-fields/QasNestedFields.vue
@@ -1,7 +1,7 @@
 <template>
   <div :id="fieldName" class="qas-nested-fields">
     <div v-if="useSingleLabel" class="text-left">
-      <qas-label heading="h5" :label="fieldLabel" />
+      <qas-label :label="fieldLabel" typography="h5" />
     </div>
 
     <div ref="inputContent">
@@ -9,7 +9,7 @@
         <template v-for="(row, index) in nested" :key="`row-${index}`">
           <div v-if="!row[destroyKey]" :id="`row-${index}`" class="full-width qas-nested-fields__field-item">
             <header v-if="hasHeader" class="flex items-center q-pb-md" :class="headerClasses">
-              <qas-label v-if="!useSingleLabel" heading="h5" :label="getRowLabel(index)" margin="none" />
+              <qas-label v-if="!useSingleLabel" :label="getRowLabel(index)" margin="none" typography="h5" />
               <qas-actions-menu v-if="hasBlockActions(row)" v-bind="getActionsMenuProps(index, row)" />
             </header>
 

--- a/ui/src/components/nested-fields/QasNestedFields.yml
+++ b/ui/src/components/nested-fields/QasNestedFields.yml
@@ -5,9 +5,9 @@ meta:
 
 props:
   actions-menu-props:
-    desc: Repassa as propriedades para o componente QasActionsMenu.
+    desc: Repassa as propriedades para o componente QasActionsMenu. É possível passar um objeto com as propriedades ou uma função que recebe o 'index', 'row' e 'list' como parâmetro e retorna um objeto com as propriedades.
     default: {}
-    type: Object
+    type: [Object, Function]
 
   add-first-input-label:
     desc: Rótulo do input para adicionar o primeiro campo.


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- (Remova este texto de descrição.) -->
### Adicionado
- `QasNestedFields`: adicionado suporte para função de callback na propriedade `actions-menu-props`.
- `QasLabel`: adicionado nova propriedade `heading` para controlar a tipografia do texto.

### Modificado
- `QasNestedFields`: modificado espaçamentos do componente.
- `QasNestedFields`: modificado tamanho da fonte do label.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
