### PR TITLE
Feature/qas form view unsaved changes improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ## Não publicado
 ## BREAKING CHANGES
-- Anteriormente, o componente `QasFormView` não atualizava automaticamente o v-model após um evento de "submit" com sucesso, o que levava a alguns  problemas relacionados a não atualização de certos campos retornados da API. Para resolver isso, implementamos uma mudança para garantir que o `v-model` agora seja sempre atualizado com o resultado retornado pela API após um submit. Isso pode exigir testes adicionais para confirmar que o comportamento dos formulários estão alinhados com o esperado.
+- Anteriormente, o componente `QasFormView` não atualizava automaticamente o v-model após um evento de "submit" com sucesso, o que levava a alguns problemas relacionados a não atualização de certos campos retornados da API. Para resolver isso, implementamos uma mudança para garantir que o `v-model` agora seja sempre atualizado com o resultado retornado pela API após um submit. Isso pode exigir testes para confirmar que o comportamento dos formulários estão alinhados com o esperado.
 
 ### Adicionado
 - `QasTabsGenerator`: adicionado nova propriedade `use-route-tab` com o valor `false` por padrão. Essa propriedade serve para controlar se o componente deve utilizar o `q-route-tab` ou `q-tab` do Quasar.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+## BREAKING CHANGES
+- Anteriormente, o componente `QasFormView` não atualizava automaticamente o v-model após um evento de "submit" com sucesso, o que levava a alguns  problemas relacionados a não atualização de certos campos retornados da API. Para resolver isso, implementamos uma mudança para garantir que o `v-model` agora seja sempre atualizado com o resultado retornado pela API após um submit. Isso pode exigir testes adicionais para confirmar que o comportamento dos formulários estão alinhados com o esperado.
+
+### Corrigido
+- `QasFormView`: corrigido alguns problemas ao utilizar a propriedade `use-dialog-on-unsaved-changes` com o valor `true`.
+- `QasFormView`: corrigido problema ao alterar valores do formulário, salvar e o `v-model` do formulário ficar desatualizado em relação ao resultado retornado da API. Agora o `v-model` é sempre atualizado com o resultado retornado pela API após um submit.
+
 ## [3.12.0-beta.9] - 29-09-2023
 ### Adicionado
 - `QasNestedFields`: adicionado suporte para função de callback na propriedade `actions-menu-props`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ## BREAKING CHANGES
 - Anteriormente, o componente `QasFormView` não atualizava automaticamente o v-model após um evento de "submit" com sucesso, o que levava a alguns  problemas relacionados a não atualização de certos campos retornados da API. Para resolver isso, implementamos uma mudança para garantir que o `v-model` agora seja sempre atualizado com o resultado retornado pela API após um submit. Isso pode exigir testes adicionais para confirmar que o comportamento dos formulários estão alinhados com o esperado.
 
+### Adicionado
+- `QasTabsGenerator`: adicionado nova propriedade `use-route-tab` com o valor `false` por padrão. Essa propriedade serve para controlar se o componente deve utilizar o `q-route-tab` ou `q-tab` do Quasar.
+
 ### Corrigido
 - `QasFormView`: corrigido alguns problemas ao utilizar a propriedade `use-dialog-on-unsaved-changes` com o valor `true`.
 - `QasFormView`: corrigido problema ao alterar valores do formulário, salvar e o `v-model` do formulário ficar desatualizado em relação ao resultado retornado da API. Agora o `v-model` é sempre atualizado com o resultado retornado pela API após um submit.

--- a/docs/src/examples/QasTabsGenerator/RouteTab.vue
+++ b/docs/src/examples/QasTabsGenerator/RouteTab.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="container q-py-lg">
+    <qas-tabs-generator :tabs="tabs" use-route-tab />
+  </div>
+</template>
+
+<script>
+export default {
+  computed: {
+    tabs () {
+      return [
+        {
+          label: 'Tab 1',
+          value: 'tab1',
+          to: '/components/tabs-generator'
+        },
+        {
+          label: 'Tab 2',
+          value: 'tab2',
+          to: '/components/tabs-generator/tab-2'
+        },
+        {
+          label: 'Tab 3',
+          value: 'tab3',
+          to: '/components/tabs-generator/tab-3'
+        },
+        {
+          label: 'Tab 4',
+          value: 'tab4',
+          to: '/components/tabs-generator/tab-4'
+        },
+        {
+          label: 'Tab 5',
+          value: 'tab5',
+          to: '/components/tabs-generator/tab-5'
+        }
+      ]
+    }
+  }
+}
+</script>

--- a/docs/src/pages/components/tabs-generator.md
+++ b/docs/src/pages/components/tabs-generator.md
@@ -68,5 +68,19 @@ O uso recomendado da propriedade `tabs` é como array.
 <doc-example file="QasTabsGenerator/ExWithIcon" title="Tabs com ícone" />
 <doc-example file="QasTabsGenerator/ExWithStatus" title="Tabs com status" />
 <doc-example file="QasTabsGenerator/ExWithCounter" title="Tabs com contador na propriedade tabs" />
+
+:::tip
+Saiba mais sobre o funcionamento do `QRouteTab` na [documentação do Quasar](https://quasar.dev/vue-components/tabs#qroutetab-api)
+:::
+
+:::warning
+O exemplo abaixo não funcionará corretamente na documentação, devido a rota passada no `to` não existir.
+:::
+
+:::warning
+Ao usar o `QRouteTab` não é recomendado usar também um `v-model` (embora você ainda possa), porque a fonte da verdade para a tab ativa atual é determinada pela rota atual em vez do `v-model`. Cada `QRouteTab` torna-se “ativo” dependendo da rota do seu app e não devido ao `v-model`. Portanto, o valor inicial do `v-model` ou a alteração direta do `v-model` também não alterará a rota do seu app.
+:::
+<doc-example file="QasTabsGenerator/RouteTab" title="Tabs com QRouteTab" />
+
 <doc-example file="QasTabsGenerator/CustomSlotTab" title="Slot: tab-[nome-da-chave]" />
 <doc-example file="QasTabsGenerator/CustomSlotAfter" title="Slot: tab-after-[nome-da-chave]" />

--- a/ui/src/components/form-view/QasFormView.vue
+++ b/ui/src/components/form-view/QasFormView.vue
@@ -426,21 +426,28 @@ export default {
           payload
         })
 
+        const modelValue = {
+          ...this.modelValue,
+          ...response.data.result
+        }
+
         if (this.useDialogOnUnsavedChanges) {
-          this.cachedResult = extend(true, {}, this.modelValue)
+          this.cachedResult = extend(true, {}, modelValue)
         }
 
         this.mx_setErrors()
-        this.$emit('update:errors', this.mx_errors)
 
-        NotifySuccess(response.data.status.text || this.defaultNotifyMessages.success)
-        this.$emit('submit-success', response, this.modelValue)
+        this.$emit('update:errors', this.mx_errors)
+        this.$emit('update:modelValue', modelValue)
+        this.$emit('submit-success', response, modelValue)
 
         this.createSubmitSuccessEvent({ ...payload, entity: this.entity })
 
         this.$qas.logger.group(
           `QasFormView - submit -> resposta da action ${this.entity}/${this.mode}`, [response]
         )
+
+        NotifySuccess(response.data.status.text || this.defaultNotifyMessages.success)
       } catch (error) {
         const errors = error?.response?.data?.errors
         const message = error?.response?.data?.status?.text

--- a/ui/src/components/form-view/QasFormView.vue
+++ b/ui/src/components/form-view/QasFormView.vue
@@ -213,6 +213,10 @@ export default {
   watch: {
     isSubmitting (value) {
       this.$emit('update:submitting', value)
+    },
+
+    '$route.path' () {
+      this.ignoreRouterGuard = false
     }
   },
 

--- a/ui/src/components/form-view/QasFormView.vue
+++ b/ui/src/components/form-view/QasFormView.vue
@@ -436,8 +436,8 @@ export default {
         }
 
         this.mx_setErrors()
-
         this.$emit('update:errors', this.mx_errors)
+
         this.$emit('update:modelValue', modelValue)
         this.$emit('submit-success', response, this.modelValue)
 

--- a/ui/src/components/form-view/QasFormView.vue
+++ b/ui/src/components/form-view/QasFormView.vue
@@ -439,7 +439,7 @@ export default {
 
         this.$emit('update:errors', this.mx_errors)
         this.$emit('update:modelValue', modelValue)
-        this.$emit('submit-success', response, modelValue)
+        this.$emit('submit-success', response, this.modelValue)
 
         this.createSubmitSuccessEvent({ ...payload, entity: this.entity })
 

--- a/ui/src/components/form-view/QasFormView.vue
+++ b/ui/src/components/form-view/QasFormView.vue
@@ -374,10 +374,9 @@ export default {
       if (!this.ignoreKeysInUnsavedChanges.length) return
 
       this.ignoreKeysInUnsavedChanges.forEach(key => {
-        if (!firstValue) return
+        if (firstValue) delete firstValue[key]
 
-        delete firstValue[key]
-        delete secondValue[key]
+        if (secondValue) delete secondValue[key]
       })
     },
 
@@ -426,10 +425,7 @@ export default {
           payload
         })
 
-        const modelValue = {
-          ...this.modelValue,
-          ...response.data.result
-        }
+        const modelValue = { ...this.modelValue, ...response.data.result }
 
         if (this.useDialogOnUnsavedChanges) {
           this.cachedResult = extend(true, {}, modelValue)

--- a/ui/src/components/form-view/QasFormView.yml
+++ b/ui/src/components/form-view/QasFormView.yml
@@ -157,17 +157,21 @@ slots:
     desc: Slot para acessar o header.
 
 events:
-  '@fetch-success -> function(value)':
+  '@fetch-success -> function(response, modelValue)':
     desc: Dispara quando a action "fetchSingle" é executada com sucesso.
     params:
-      value:
+      response:
         desc: Retorna todos os dados "cru" respondido pelo fetch.
         type: Object
 
-  '@fetch-error -> function(value)':
+      modelValue:
+        desc: Retorna o model anterior ao fetch.
+        type: Object
+
+  '@fetch-error -> function(error)':
     desc: Dispara quando a action "fetchSingle" cai em uma exceção.
     params:
-      value:
+      error:
         desc: Retorna todos os dados "cru" respondido na exceção do fetch.
         type: Object
 
@@ -212,3 +216,23 @@ events:
       value:
         desc: Retorna se está ou não fazendo fetching de dados.
         type: Boolean
+
+  '@submit-success -> function(response, modelValue)':
+    desc: Dispara quando a action "submit" é executada com sucesso.
+    params:
+      response:
+        desc: Retorna todos os dados "cru" respondido pelo submit.
+        type: Object
+
+      modelValue:
+        desc: Retorna o model anterior ao submit.
+        type: Object
+
+  '@submit-error -> function(error)':
+    desc: Dispara quando a action "submit" cai em uma exceção.
+    params:
+      error:
+        desc: Retorna todos os dados "cru" respondido na exceção do submit.
+        type: Object
+
+

--- a/ui/src/components/tabs-generator/QasTabsGenerator.vue
+++ b/ui/src/components/tabs-generator/QasTabsGenerator.vue
@@ -2,7 +2,7 @@
   <div class="qas-tabs-generator">
     <q-tabs v-model="model" active-color="primary" align="left" :breakpoint="0" content-class="text-grey-8" dense inline-label left-icon="sym_r_chevron_left" outside-arrows right-icon="sym_r_chevron_right">
       <slot v-for="(tab, key) in formattedTabs" :item="tab" :name="`tab-${tab.value}`">
-        <q-tab :key="key" v-bind="getTabProps(tab)" class="text-body1" :name="tab.value" no-caps :ripple="false">
+        <component :is="tabComponent" :key="key" v-bind="getTabProps(tab)" class="text-body1" :name="tab.value">
           <slot :item="tab" :name="`tab-after-${tab.value}`">
             <q-icon v-if="tab.icon" :name="tab.icon" size="sm" />
 
@@ -12,7 +12,7 @@
               {{ getFormattedLabel(tab) }}
             </div>
           </slot>
-        </q-tab>
+        </component>
       </slot>
     </q-tabs>
   </div>
@@ -45,6 +45,10 @@ export default {
       default: () => ({}),
       required: true,
       type: [Object, Array]
+    },
+
+    useRouteTab: {
+      type: Boolean
     }
   },
 
@@ -77,6 +81,10 @@ export default {
 
         this.$emit('update:modelValue', value)
       }
+    },
+
+    tabComponent () {
+      return this.useRouteTab ? 'q-route-tab' : 'q-tab'
     }
   },
 
@@ -92,8 +100,14 @@ export default {
     },
 
     getTabProps (tab) {
-      const { icon, label, ...payload } = tab
-      return payload
+      const { icon, label, ...tabProps } = tab
+
+      return {
+        ...tabProps,
+
+        noCaps: true,
+        ripple: false
+      }
     }
   }
 }

--- a/ui/src/components/tabs-generator/QasTabsGenerator.vue
+++ b/ui/src/components/tabs-generator/QasTabsGenerator.vue
@@ -2,7 +2,7 @@
   <div class="qas-tabs-generator">
     <q-tabs v-model="model" active-color="primary" align="left" :breakpoint="0" content-class="text-grey-8" dense inline-label left-icon="sym_r_chevron_left" outside-arrows right-icon="sym_r_chevron_right">
       <slot v-for="(tab, key) in formattedTabs" :item="tab" :name="`tab-${tab.value}`">
-        <component :is="tabComponent" :key="key" v-bind="getTabProps(tab)" class="text-body1" :name="tab.value">
+        <component :is="tabComponent" :key="key" v-bind="getTabProps(tab)" class="text-body1" :name="tab.value" no-caps :ripple="false">
           <slot :item="tab" :name="`tab-after-${tab.value}`">
             <q-icon v-if="tab.icon" :name="tab.icon" size="sm" />
 
@@ -100,14 +100,8 @@ export default {
     },
 
     getTabProps (tab) {
-      const { icon, label, ...tabProps } = tab
-
-      return {
-        ...tabProps,
-
-        noCaps: true,
-        ripple: false
-      }
+      const { icon, label, ...payload } = tab
+      return payload
     }
   }
 }

--- a/ui/src/components/tabs-generator/QasTabsGenerator.yml
+++ b/ui/src/components/tabs-generator/QasTabsGenerator.yml
@@ -24,6 +24,11 @@ props:
     type: [Object, Array]
     examples: ["{ tab1: 'tab1', tab2: 'tab2' }"]
 
+  useRouteTab:
+    desc: Quando "true" será utilizado o componente "QRouteTab" do Quasar (https://quasar.dev/vue-components/tabs#qroutetab-api).
+    default: false
+    type: Boolean
+
 slots:
   'tab-[nome-da-chave]':
     desc: Slot dinâmico gerado a partir das chave passada na prop "tabs", substitui todo o "q-tab".


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- (Remova este texto de descrição.) -->
## BREAKING CHANGES
- Anteriormente, o componente `QasFormView` não atualizava automaticamente o v-model após um evento de "submit" com sucesso, o que levava a alguns  problemas relacionados a não atualização de certos campos retornados da API. Para resolver isso, implementamos uma mudança para garantir que o `v-model` agora seja sempre atualizado com o resultado retornado pela API após um submit. Isso pode exigir testes adicionais para confirmar que o comportamento dos formulários estão alinhados com o esperado.

### Adicionado
- `QasTabsGenerator`: adicionado nova propriedade `use-route-tab` com o valor `false` por padrão. Essa propriedade serve para controlar se o componente deve utilizar o `q-route-tab` ou `q-tab` do Quasar.

### Corrigido
- `QasFormView`: corrigido alguns problemas ao utilizar a propriedade `use-dialog-on-unsaved-changes` com o valor `true`.
- `QasFormView`: corrigido problema ao alterar valores do formulário, salvar e o `v-model` do formulário ficar desatualizado em relação ao resultado retornado da API. Agora o `v-model` é sempre atualizado com o resultado retornado pela API após um submit.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
