### PR TITLE
Uploader changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasUploader`: adicionado propriedade `useUrlPath` para dar possibilidade de salvar base64 no model ao invés de uma url externa (uso offline).
+- `QasUploader`: adicionado propriedade `uploadCredentialsParams` para repassar parâmetros para o endpoint `upload-credentials`.
+
 ## [3.12.0-beta.9] - 29-09-2023
 ### Adicionado
 - `QasNestedFields`: adicionado suporte para função de callback na propriedade `actions-menu-props`.

--- a/ui/src/components/uploader/QasUploader.vue
+++ b/ui/src/components/uploader/QasUploader.vue
@@ -154,6 +154,11 @@ export default {
       type: Number
     },
 
+    uploadCredentialsParams: {
+      type: Object,
+      default: () => ({})
+    },
+
     uploading: {
       type: Boolean
     },
@@ -170,6 +175,11 @@ export default {
     useResize: {
       default: true,
       type: Boolean
+    },
+
+    useUrlPath: {
+      type: Boolean,
+      default: true
     }
   },
 
@@ -366,7 +376,8 @@ export default {
       try {
         const { data } = await this.$axios.post('/upload-credentials/', {
           entity: this.entity,
-          filename
+          filename,
+          ...this.uploadCredentialsParams
         })
 
         return data
@@ -377,7 +388,7 @@ export default {
       uploadedFiles = uploadedFiles.map((file, indexToDelete) => {
         return {
           isUploaded: true,
-          url: file.xhr ? file.xhr.responseURL.split('?').shift() : '',
+          url: file.xhr ? this.getURLValue(file.xhr) : '',
           name: file.name,
           indexToDelete,
           isFailed: this.isFailed(file)
@@ -419,6 +430,16 @@ export default {
 
     getFileName (value) {
       return value.split('/').pop()
+    },
+
+    /**
+     * Caso useUrlPath seja true, retorna de responseURL, senão tenta retornar o response
+     * que pode ser um base64, caso não tenha o response, retorna a responseURL.
+    */
+    getURLValue (xhr) {
+      const responseURL = xhr.responseURL.split('?').shift()
+
+      return this.useUrlPath ? responseURL : (xhr.response || responseURL)
     },
 
     getModelValue (index) {
@@ -571,7 +592,7 @@ export default {
     uploaded (response) {
       this.hasError = false
 
-      const fullPath = response.xhr.responseURL.split('?').shift()
+      const fullPath = this.getURLValue(response.xhr)
 
       const objectValue = {
         format: response.files[0].type,

--- a/ui/src/components/uploader/QasUploader.yml
+++ b/ui/src/components/uploader/QasUploader.yml
@@ -33,7 +33,7 @@ props:
       'image/webp',
       'image/jpg'
     ]
-  
+
   columns:
     desc: Seta as colunas (grid cols), valor default depende se o componente é múltiplo ou não.
     default:
@@ -118,6 +118,11 @@ props:
     default: 1280
     type: Number
 
+  upload-credentials-params:
+    desc: Parâmetros enviados para a API do `/upload-credentials/`.
+    default: {}
+    type: Object
+
   uploading:
     desc: Model que retorna se o componente está fazendo algum upload.
     type: Boolean
@@ -136,6 +141,11 @@ props:
 
   use-resize:
     desc: Controla se o componente vai fazer o redimensionamento antes de upar as imagens.
+    default: true
+    type: Boolean
+
+  use-url-path:
+    desc: Controla se o componente vai salvar o path url no model ou por exemplo um base64.
     default: true
     type: Boolean
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Adicionado
- `QasUploader`: adicionado propriedade `useUrlPath` para dar possibilidade de salvar base64 no model ao invés de uma url externa (uso offline).
- `QasUploader`: adicionado propriedade `uploadCredentialsParams` para repassar parâmetros para o endpoint `upload-credentials`.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
