### PR TITLE
QasDialog changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `api.js`: adicionado `provide` do axios por conta de composition components não terem acesso ao `globalProperties`.
 - `QasDialog`: adicionado novos eventos `@ok` que dispara toda vez que é clicado no botão "ok" ou quando useForm for true e o for clicado "enter" estando com foco em algum input (evento de submit).
 - `QasDialog`: adicionado novos eventos `@cancel` que dispara toda vez que é clicado no botão "cancel".
+- `QasAppUser`: adicionado 2 novos `data-cy`, `data-cy="app-user"` e `data-cy="app-user-companies-select"`.
 
 ### Corrigido
 - `QasFormView`: corrigido alguns problemas ao utilizar a propriedade `use-dialog-on-unsaved-changes` com o valor `true`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,15 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ### Adicionado
 - `QasTabsGenerator`: adicionado nova propriedade `use-route-tab` com o valor `false` por padrão. Essa propriedade serve para controlar se o componente deve utilizar o `q-route-tab` ou `q-tab` do Quasar.
+- `QasDialog`: adicionado novos eventos `@ok` que dispara toda vez que é clicado no botão "ok" ou quando useForm for true e o for clicado "enter" estando com foco em algum input (evento de submit).
+- `QasDialog`: adicionado novos eventos `@cancel` que dispara toda vez que é clicado no botão "cancel".
 
 ### Corrigido
 - `QasFormView`: corrigido alguns problemas ao utilizar a propriedade `use-dialog-on-unsaved-changes` com o valor `true`.
 - `QasFormView`: corrigido problema ao alterar valores do formulário, salvar e o `v-model` do formulário ficar desatualizado em relação ao resultado retornado da API. Agora o `v-model` é sempre atualizado com o resultado retornado pela API após um submit.
+
+### Modificado
+- `QasDialog`: agora a seção de `actions` foi movida para dentro do QForm, isto faz com que ao clicar enter, o botão deja disparado mesmo que não tenha sido clicado (quando useForm for true).
 
 ## [3.12.0] - 10-10-2023
 ## BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ### Corrigido
 - `QasFormView`: corrigido alguns problemas ao utilizar a propriedade `use-dialog-on-unsaved-changes` com o valor `true`.
 - `QasFormView`: corrigido problema ao alterar valores do formulário, salvar e o `v-model` do formulário ficar desatualizado em relação ao resultado retornado da API. Agora o `v-model` é sempre atualizado com o resultado retornado pela API após um submit.
+- `QasDialog`: corrigido bug que fazia que pagina recarregasse ao dar enter quando a prop useForm tinha o valor "true".
 
 ### Modificado
 - `QasDialog`: agora a seção de `actions` foi movida para dentro do QForm, isto faz com que ao clicar enter, o botão deja disparado mesmo que não tenha sido clicado (quando useForm for true).

--- a/docs/src/examples/QasDialog/ExDialogCancelAndOk.vue
+++ b/docs/src/examples/QasDialog/ExDialogCancelAndOk.vue
@@ -1,0 +1,72 @@
+<template>
+  <div class="container q-py-lg">
+    <qas-btn @click="toggle">Abrir Dialog</qas-btn>
+
+    <qas-dialog v-model="isDialogOpened" v-bind="dialogProps">
+      <template #description>
+        <qas-field v-model="description" :field="field" label="Descrição" />
+      </template>
+    </qas-dialog>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      isDialogOpened: false,
+      isLoading: false,
+      description: ''
+    }
+  },
+
+  computed: {
+    dialogProps () {
+      return {
+        useForm: true,
+
+        card: {
+          title: 'Título do dialog'
+        },
+
+        ok: {
+          label: 'Fechar',
+          loading: this.isLoading
+        },
+
+        onCancel: this.onCancel,
+        onOk: this.onOk
+      }
+    },
+
+    field () {
+      return {
+        name: 'description',
+        type: 'text',
+        label: 'Descrição'
+      }
+    }
+  },
+
+  methods: {
+    toggle () {
+      this.isDialogOpened = !this.isDialogOpened
+    },
+
+    onCancel () {
+      this.isDialogOpened = false
+      this.$qas.error('Evento cancel finalizado.')
+    },
+
+    onOk () {
+      this.isLoading = true
+
+      setTimeout(() => {
+        this.isLoading = false
+        this.isDialogOpened = false
+        this.$qas.success('Evento ok finalizado.')
+      }, 2000)
+    }
+  }
+}
+</script>

--- a/docs/src/pages/components/dialog.md
+++ b/docs/src/pages/components/dialog.md
@@ -6,9 +6,14 @@ Componente de dialog.
 
 <doc-api file="dialog/QasDialog" name="QasDialog" />
 
+:::info
+Recomendamos a utilização do evento `@ok|onOk` e `@cancel|onCancel` ao invés de utilizar diretamente o `onClick` na prop `ok` e `cancel`.
+:::
+
 ## Uso
 
 <doc-example file="QasDialog/Basic" title="Básico" />
+<doc-example file="QasDialog/ExDialogCancelAndOk" title="Eventos Ok e Cancel" />
 <doc-example file="QasDialog/ExWithActions" title="Com ações" />
 <doc-example file="QasDialog/ExWithSingleAction" title="Com uma única ação" />
 

--- a/ui/src/components/app-user/QasAppUser.vue
+++ b/ui/src/components/app-user/QasAppUser.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="cursor-pointer items-center no-wrap q-gutter-sm qas-app-user row">
+  <div class="cursor-pointer items-center no-wrap q-gutter-sm qas-app-user row" data-cy="app-user">
     <div class="relative-position">
       <qas-avatar :image="user.photo" :size="avatarSize" :title="userName" />
       <q-badge v-if="hasNotifications" color="red" floating>{{ notifications.count }}</q-badge>
@@ -17,7 +17,7 @@
         <div class="ellipsis qas-app-user__menu-name">{{ userName }}</div>
         <div class="ellipsis">{{ user.email }}</div>
 
-        <qas-select v-if="hasCompaniesSelect" v-model="companiesModel" class="q-my-md" label="Vínculo" :loading="loading" :options="companiesOptions" @update:model-value="setCompanies" />
+        <qas-select v-if="hasCompaniesSelect" v-model="companiesModel" class="q-my-md" data-cy="app-user-companies-select" label="Vínculo" :loading="loading" :options="companiesOptions" @update:model-value="setCompanies" />
 
         <q-list class="q-mt-md">
           <q-item v-close-popup :active="false" class="qas-app-user__menu-item" clickable :to="user.to">

--- a/ui/src/components/dialog/QasDialog.vue
+++ b/ui/src/components/dialog/QasDialog.vue
@@ -134,7 +134,7 @@ export default {
 
         ...this.ok,
 
-        // adiciona somente se não estiver usando useForm pois ai o controle ficará no submit
+        // adiciona somente se não estiver usando useForm pois o controle ficará no submit.
         ...(!this.useForm && { onClick: this.onOk })
       }
     },
@@ -154,7 +154,7 @@ export default {
     componentProps () {
       /**
        * adiciona evento de submit caso useForm seja true,
-       * uma vez que somente o q-form possui este evento
+       * uma vez que somente o q-form possui este evento.
       */
       return {
         ...(this.useForm && { onSubmit: this.onSubmit })

--- a/ui/src/components/dialog/QasDialog.vue
+++ b/ui/src/components/dialog/QasDialog.vue
@@ -12,26 +12,26 @@
       </header>
 
       <section class="text-body1 text-grey-8">
-        <component :is="componentTag" ref="form">
+        <component :is="componentTag" ref="form" v-bind="componentProps">
           <slot name="description">
             <component :is="descriptionComponentTag">{{ card.description }}</component>
           </slot>
+
+          <div v-if="!isInfoDialog">
+            <slot name="actions">
+              <qas-actions v-bind="formattedActionsProps">
+                <template v-if="hasOk" #primary>
+                  <qas-btn ref="ok" v-close-popup="!useForm" class="full-width" variant="primary" v-bind="defaultOk" />
+                </template>
+
+                <template v-if="hasCancel" #secondary>
+                  <qas-btn v-close-popup class="full-width" v-bind="defaultCancel" variant="secondary" />
+                </template>
+              </qas-actions>
+            </slot>
+          </div>
         </component>
       </section>
-
-      <footer v-if="!isInfoDialog">
-        <slot name="actions">
-          <qas-actions v-bind="formattedActionsProps">
-            <template v-if="hasOk" #primary>
-              <qas-btn v-close-popup="!useForm" class="full-width" variant="primary" v-bind="defaultOk" @click="submitHandler" />
-            </template>
-
-            <template v-if="hasCancel" #secondary>
-              <qas-btn v-close-popup class="full-width" v-bind="defaultCancel" variant="secondary" />
-            </template>
-          </qas-actions>
-        </slot>
-      </footer>
     </div>
   </q-dialog>
 </template>
@@ -106,8 +106,13 @@ export default {
   },
 
   emits: [
+    // model
     'update:modelValue',
-    'validate'
+
+    // actions
+    'validate',
+    'ok',
+    'cancel'
   ],
 
   computed: {
@@ -115,7 +120,10 @@ export default {
       return {
         label: 'Cancelar',
         outline: true,
-        ...this.cancel
+
+        ...this.cancel,
+
+        onClick: this.onCancel
       }
     },
 
@@ -123,7 +131,11 @@ export default {
       return {
         label: 'Ok',
         type: this.ok?.type || this.useForm ? 'submit' : 'button',
-        ...this.ok
+
+        ...this.ok,
+
+        // adiciona somente se não estiver usando useForm pois ai o controle ficará no submit
+        ...(!this.useForm && { onClick: this.onOk })
       }
     },
 
@@ -137,6 +149,16 @@ export default {
 
     componentTag () {
       return this.useForm ? 'q-form' : 'div'
+    },
+
+    componentProps () {
+      /**
+       * adiciona evento de submit caso useForm seja true,
+       * uma vez que somente o q-form possui este evento
+      */
+      return {
+        ...(this.useForm && { onSubmit: this.onSubmit })
+      }
     },
 
     dialogProps () {
@@ -235,6 +257,31 @@ export default {
 
     updateModelValue (value) {
       this.$emit('update:modelValue', value)
+    },
+
+    onOk () {
+      this.ok?.onClick?.()
+      this.$emit('ok')
+    },
+
+    onCancel () {
+      this.cancel?.onClick?.()
+      this.$emit('cancel')
+    },
+
+    /**
+     * Sem este método, ao clicar enter com a prop useForm ativada a tela era recarregada,
+     * e a ação de click do botão não era chamada pois ele não esta dentro do form.
+    */
+    onSubmit (event) {
+      event.preventDefault()
+
+      this.$emit('ok')
+
+      if (this.hasOk) {
+        this.$refs.ok?.$el?.click?.()
+        this.submitHandler()
+      }
     }
   }
 }

--- a/ui/src/components/dialog/QasDialog.vue
+++ b/ui/src/components/dialog/QasDialog.vue
@@ -21,7 +21,7 @@
             <slot name="actions">
               <qas-actions v-bind="formattedActionsProps">
                 <template v-if="hasOk" #primary>
-                  <qas-btn ref="ok" v-close-popup="!useForm" class="full-width" variant="primary" v-bind="defaultOk" />
+                  <qas-btn v-close-popup="!useForm" class="full-width" variant="primary" v-bind="defaultOk" />
                 </template>
 
                 <template v-if="hasCancel" #secondary>
@@ -276,10 +276,8 @@ export default {
     onSubmit (event) {
       event.preventDefault()
 
-      this.$emit('ok')
-
       if (this.hasOk) {
-        this.$refs.ok?.$el?.click?.()
+        this.onOk()
         this.submitHandler()
       }
     }

--- a/ui/src/components/dialog/QasDialog.yml
+++ b/ui/src/components/dialog/QasDialog.yml
@@ -83,3 +83,10 @@ events:
       value:
         desc: Retorna se os campos passou ou não na validação
         type: Boolean
+
+  '@cancel: -> function ()':
+    desc: Dispara toda vez que é clicado no botão "cancel".
+
+  '@ok: -> function ()':
+    desc: Dispara toda vez que é clicado no botão "ok" ou quando useForm for true e o for clicado "enter" estando com foco em algum input (evento de submit).
+


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

### Adicionado
- `QasDialog`: adicionado novos eventos `@cancel` que dispara toda vez que é clicado no botão "cancel".

### Corrigido
- `QasDialog`: corrigido bug que fazia que pagina recarregasse ao dar enter quando a prop useForm tinha o valor "true".

### Modificado
- `QasDialog`: agora a seção de `actions` foi movida para dentro do QForm, isto faz com que ao clicar enter, o botão deja disparado mesmo que não tenha sido clicado (quando useForm for true).


<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
