### PR TITLE
fix: numeric input docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasNumericInput`: corrigido docs onde acrescentavamos o atributo "entity" desnecessariamente.
+
 ## [3.13.0-beta.1] - 13-10-2023
 ### Corrigido
 - `QasInfiniteScroll`: corrigido problema do componente não resetar ao utilizar o método `refresh` em alguns cenários.

--- a/docs/src/examples/QasNumericInput/Basic.vue
+++ b/docs/src/examples/QasNumericInput/Basic.vue
@@ -1,19 +1,19 @@
 <template>
   <div class="container spaced">
     <div>
-      <qas-numeric-input v-model="integer" entity="test" label="integer" />
+      <qas-numeric-input v-model="integer" label="integer" />
       integer: {{ integer }}
     </div>
     <div class="q-my-lg">
-      <qas-numeric-input v-model="decimal" entity="test" label="decimal" mode="decimal" />
+      <qas-numeric-input v-model="decimal" label="decimal" mode="decimal" />
       decimal: {{ decimal }}
     </div>
     <div class="q-my-lg">
-      <qas-numeric-input v-model="percent" entity="test" label="percent" mode="percent" />
+      <qas-numeric-input v-model="percent" label="percent" mode="percent" />
       percent: {{ percent }}
     </div>
     <div class="q-my-lg">
-      <qas-numeric-input v-model="money" entity="test" label="money" mode="money" />
+      <qas-numeric-input v-model="money" label="money" mode="money" />
       money: {{ money }}
     </div>
   </div>

--- a/docs/src/examples/QasNumericInput/Negative.vue
+++ b/docs/src/examples/QasNumericInput/Negative.vue
@@ -1,19 +1,19 @@
 <template>
   <div class="container spaced">
     <div>
-      <qas-numeric-input v-model="integer" entity="test" label="integer" use-negative />
+      <qas-numeric-input v-model="integer" label="integer" use-negative />
       integer: {{ integer }}
     </div>
     <div class="q-my-lg">
-      <qas-numeric-input v-model="decimal" entity="test" label="decimal" mode="decimal" use-negative />
+      <qas-numeric-input v-model="decimal" label="decimal" mode="decimal" use-negative />
       decimal: {{ decimal }}
     </div>
     <div class="q-my-lg">
-      <qas-numeric-input v-model="percent" entity="test" label="percent" mode="percent" use-negative />
+      <qas-numeric-input v-model="percent" label="percent" mode="percent" use-negative />
       percent: {{ percent }}
     </div>
     <div class="q-my-lg">
-      <qas-numeric-input v-model="money" entity="test" label="money" mode="money" use-negative />
+      <qas-numeric-input v-model="money" label="money" mode="money" use-negative />
       money: {{ money }}
     </div>
   </div>


### PR DESCRIPTION
### Corrigido
- `QasNumericInput`: corrigido docs onde acrescentavamos o atributo "entity" desnecessariamente.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [ ] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
