### PR TITLE
QasAppUser Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+## BREAKING CHANGES
+- `QasAppUser`: removido propriedades `companiesOptions` e `currentCompany` em favor de utilizar a nova propriedade `companyProps`.
+
+### Adicionado
+- `QasAppUser`: adicionado nova propriedade `companyProps` que repassa todas as props para o select de vínculos.
+
+### Removido
+- `QasAppUser`: removido propriedades `companiesOptions` e `currentCompany` em favor de utilizar a nova propriedade `companyProps`.
+
 ## [3.13.0-beta.2] - 19-10-2023
 ### Adicionado
 - `helpers/promiseHandler`: adicionado nova opção `loadingConfig` para personalizar o loading.

--- a/docs/src/examples/QasAppBar/Basic.vue
+++ b/docs/src/examples/QasAppBar/Basic.vue
@@ -15,18 +15,21 @@ export default {
   computed: {
     appUserProps () {
       return {
-        companiesOptions: [
-          {
-            label: 'Empresa 1',
-            value: '1'
-          },
-          {
-            label: 'Empresa 2',
-            value: '2'
-          }
-        ],
+        companyProps: {
+          options: [
+            {
+              label: 'Empresa 1',
+              value: '1'
+            },
+            {
+              label: 'Empresa 2',
+              value: '2'
+            }
+          ],
 
-        currentCompany: '1',
+          modelValue: '1'
+        },
+
         user
       }
     }

--- a/docs/src/examples/QasAppMenu/Basic.vue
+++ b/docs/src/examples/QasAppMenu/Basic.vue
@@ -62,18 +62,21 @@ export default {
         miniBrand: 'https://placehold.co/40x40',
         modules,
         appUserProps: {
-          companiesOptions: [
-            {
-              label: 'Empresa 1',
-              value: '1'
-            },
-            {
-              label: 'Empresa 2',
-              value: '2'
-            }
-          ],
+          companyProps: {
+            options: [
+              {
+                label: 'Empresa 1',
+                value: '1'
+              },
+              {
+                label: 'Empresa 2',
+                value: '2'
+              }
+            ],
 
-          currentCompany: '1',
+            modelValue: '1'
+          },
+
           user
         },
         title: 'Documentação',

--- a/docs/src/examples/QasAppUser/Basic.vue
+++ b/docs/src/examples/QasAppUser/Basic.vue
@@ -16,17 +16,20 @@ export default {
     props () {
       return {
         user,
-        companiesOptions: [
-          {
-            label: 'Empresa 1',
-            value: '1'
-          },
-          {
-            label: 'Empresa 2',
-            value: '2'
-          }
-        ],
-        currentCompany: '1'
+        companyProps: {
+          options: [
+            {
+              label: 'Empresa 1',
+              value: '1'
+            },
+            {
+              label: 'Empresa 2',
+              value: '2'
+            }
+          ],
+
+          modelValue: '2'
+        }
       }
     }
   }

--- a/docs/src/examples/QasLayout/Basic.vue
+++ b/docs/src/examples/QasLayout/Basic.vue
@@ -75,18 +75,21 @@ export default {
     appBarProps () {
       return {
         appUserProps: {
-          companiesOptions: [
-            {
-              label: 'Empresa 1',
-              value: '1'
-            },
-            {
-              label: 'Empresa 2',
-              value: '2'
-            }
-          ],
+          companyProps: {
+            options: [
+              {
+                label: 'Empresa 1',
+                value: '1'
+              },
+              {
+                label: 'Empresa 2',
+                value: '2'
+              }
+            ],
 
-          currentCompany: '1',
+            modelValue: '1'
+          },
+
           user
         },
         title: 'QasLayout'

--- a/docs/src/pages/components/app-user.md
+++ b/docs/src/pages/components/app-user.md
@@ -7,7 +7,7 @@ Componente utilizado no `QasAppBar` e `QasAppMenu` para exibir o nome do usuári
 <doc-api file="app-user/QasAppUser" name="QasAppUser" />
 
 :::info
-A funcionalidade de troca de vínculo de empresa é ativada quando existe mais de 1 opção na prop `companiesOptions`, é executado uma API com o seguinte endpoint:
+A funcionalidade de troca de vínculo de empresa é ativada quando existe mais de 1 opção na prop `companyProps.options`, é executado uma API com o seguinte endpoint:
 
 `PATCH -> users/me`
 

--- a/ui/src/components/app-user/QasAppUser.vue
+++ b/ui/src/components/app-user/QasAppUser.vue
@@ -17,7 +17,7 @@
         <div class="ellipsis qas-app-user__menu-name">{{ userName }}</div>
         <div class="ellipsis">{{ user.email }}</div>
 
-        <qas-select v-if="hasCompaniesSelect" v-model="companiesModel" class="q-my-md" data-cy="app-user-companies-select" label="Vínculo" :loading="loading" :options="companiesOptions" @update:model-value="setCompanies" />
+        <qas-select v-if="hasCompaniesSelect" v-model="companiesModel" class="q-my-md" data-cy="app-user-companies-select" :loading="loading" v-bind="defaultCompanyProps" @update:model-value="setCompanies" />
 
         <q-list class="q-mt-md">
           <q-item v-close-popup :active="false" class="qas-app-user__menu-item" clickable :to="user.to">
@@ -69,14 +69,9 @@ export default {
       type: String
     },
 
-    companiesOptions: {
-      type: Array,
-      default: () => []
-    },
-
-    currentCompany: {
-      type: String,
-      default: ''
+    companyProps: {
+      default: () => ({}),
+      type: Object
     },
 
     menuProps: {
@@ -106,6 +101,15 @@ export default {
   },
 
   computed: {
+    defaultCompanyProps () {
+      return {
+        ...this.companyProps,
+
+        // não é possível alterar o label.
+        label: 'Vínculo'
+      }
+    },
+
     hasNotifications () {
       return !!Object.keys(this.notifications).length
     },
@@ -115,12 +119,12 @@ export default {
     },
 
     hasCompaniesSelect () {
-      return !!this.companiesOptions.length
+      return !!this.companyProps.options?.length
     }
   },
 
   watch: {
-    currentCompany: {
+    'companyProps.modelValue': {
       handler (value) {
         this.companiesModel = value
       },
@@ -144,7 +148,8 @@ export default {
 
         setTimeout(() => location.reload(), 1500)
       } catch {
-        this.companiesModel = this.currentCompany
+        this.companiesModel = this.companyProps.modelValue
+
         this.$qas.error('Falha ao alterar vínculo.')
       } finally {
         this.loading = false

--- a/ui/src/components/app-user/QasAppUser.vue
+++ b/ui/src/components/app-user/QasAppUser.vue
@@ -17,7 +17,7 @@
         <div class="ellipsis qas-app-user__menu-name">{{ userName }}</div>
         <div class="ellipsis">{{ user.email }}</div>
 
-        <qas-select v-if="hasCompaniesSelect" v-model="companiesModel" class="q-my-md" data-cy="app-user-companies-select" :loading="loading" v-bind="defaultCompanyProps" @update:model-value="setCompanies" />
+        <qas-select v-if="hasCompaniesSelect" v-model="companiesModel" class="q-my-md" v-bind="defaultCompanyProps" @update:model-value="setCompanies" />
 
         <q-list class="q-mt-md">
           <q-item v-close-popup :active="false" class="qas-app-user__menu-item" clickable :to="user.to">
@@ -103,6 +103,9 @@ export default {
   computed: {
     defaultCompanyProps () {
       return {
+        dataCy: 'app-user-companies-select',
+        loading: this.loading,
+
         ...this.companyProps,
 
         // não é possível alterar o label.

--- a/ui/src/components/app-user/QasAppUser.yml
+++ b/ui/src/components/app-user/QasAppUser.yml
@@ -10,7 +10,7 @@ props:
     type: String
 
   company-props:
-    desc: Repassa props pro QSelect de vínculo de empresas (não é possível alterar o label).
+    desc: Repassa props pro QasSelect de vínculo de empresas (não é possível alterar o label).
     default: {}
     type: Object
 

--- a/ui/src/components/app-user/QasAppUser.yml
+++ b/ui/src/components/app-user/QasAppUser.yml
@@ -9,15 +9,10 @@ props:
     default: 36px
     type: String
 
-  companies-options:
-    desc: Opções para o select de vínculo de empresas.
-    default: []
-    type: Array
-
-  current-company:
-    desc: Empresa atual vinculada
-    default: ''
-    type: String
+  company-props:
+    desc: Repassa props pro QSelect de vínculo de empresas (não é possível alterar o label).
+    default: {}
+    type: Object
 
   menu-props:
     desc: Repassa props pro QMenu.


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
## BREAKING CHANGES
- `QasAppUser`: removido propriedades `companiesOptions` e `currentCompany` em favor de utilizar a nova propriedade `companyProps`.

### Adicionado
- `QasAppUser`: adicionado nova propriedade `companyProps` que repassa todas as props para o select de vínculos.

### Removido
- `QasAppUser`: removido propriedades `companiesOptions` e `currentCompany` em favor de utilizar a nova propriedade `companyProps`.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [x] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
