### PR TITLE
Changes in QasUploader and QasGalleryCard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasGalleryCard`: adicionado novas propriedades `errorMessage` e `errorIcon` para controlar conteúdo quando dar falha ao carregar imagem.
+- `QasGalleryCard`: adicionado novo slot `image-error-icon` para controle de ícone.
+
+### Modificado
+- `QasUploader`: propriedade `galleryCardProps` agora aceita callback function, para ter controle personalizado por card.
+- `QasGalleryCard`: modificado estilo de card para erro.
+
 ## [3.13.0-beta.5] - 01-11-2023
 ### Corrigido
 - `Notify`: alterado notify para aplicar estilos nos actions somente em NotifySuccess e NotifyError, uma vez que da forma anterior esta afetando todos os casos.

--- a/docs/src/examples/QasUploader/ExUploaderCardCallback.vue
+++ b/docs/src/examples/QasUploader/ExUploaderCardCallback.vue
@@ -1,0 +1,48 @@
+<template>
+  <q-form class="container spaced">
+    <qas-uploader v-model="model" v-bind="props" />
+    <qas-debugger :inspect="[model]" />
+  </q-form>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      model: [
+        'https://placehold.co/600x400/orange/white?text=img1',
+        'https://123placehold.co/600x400/red/white?text=img2',
+        'https://placehold.co/600x400/blue/white?text=img3',
+        'https://1234placehold.co/600x400/black/white?text=img4'
+      ]
+    }
+  },
+
+  computed: {
+    props () {
+      return {
+        addButtonLabel: 'Adicionar imagem',
+        entity: 'serviceOrders',
+        label: 'Meu uploader',
+        multiple: true,
+        galleryCardProps: this.galleryCardPropsFn
+      }
+    }
+  },
+
+  methods: {
+    galleryCardPropsFn ({ hasError }) {
+      return {
+        disable: hasError,
+
+        buttonProps: {
+          disable: hasError
+        },
+
+        errorIcon: 'sym_r_wifi_off',
+        errorMessage: 'Imagem indisponível.'
+      }
+    }
+  }
+}
+</script>

--- a/docs/src/pages/components/uploader.md
+++ b/docs/src/pages/components/uploader.md
@@ -10,6 +10,23 @@ Componente para upload com auto redimensionamento que implementa o "QField" e "Q
 Por hora, este componente não funciona na documentação e é preciso testar ele em algum projeto que tenha um bucket para upload.
 :::
 
+:::info
+##### Propriedade galleryCardProps
+
+A propriedade `galleryCardProps` pode ser usada como callback function, que vai retornar as seguintes informações:
+
+```js
+galleryCardPropsFn ({
+  hasError,
+  file: {
+    format,
+    name,
+    url
+  }
+})
+```
+:::
+
 :::tip
 O comportamento padrão do componente **QasUploader** é emitir/receber a `url` de upload do arquivo. Porém, ao utilizar a prop `useObjectModel` o componente começará a emitir/receber o valor como objeto.
 
@@ -29,6 +46,7 @@ O formato padrão do model de objeto é:
 <doc-example file="QasUploader/ExUploaderMultiple" title="Múltiplo" />
 <doc-example file="QasUploader/ExUploaderMultipleObjectModel" title="Múltiplo com useObjectModel" />
 <doc-example file="QasUploader/ExUploaderSingleObjectModel" title="Múltiplo com useObjectModel" />
+<doc-example file="QasUploader/ExUploaderCardCallback" title="Múltiplo com callback nos cards" />
 
 :::info
 - Para que o modo com grid funcione, é necessário utilizar a propriedade `useObjectModel` e que exista pelo menos a propriedade `fields` ou então o fields dentro de `gridGeneratorProps`.

--- a/ui/src/components/gallery-card/QasGalleryCard.vue
+++ b/ui/src/components/gallery-card/QasGalleryCard.vue
@@ -20,7 +20,21 @@
       <slot name="image">
         <q-img class="rounded-borders" height="100%" :src="card.url" v-bind="imageProps">
           <template #error>
-            <slot name="image-error" />
+            <div :class="errorClasses">
+              <div class="text-center">
+                <slot name="image-error-icon">
+                  <div v-if="errorIcon">
+                    <q-icon :name="errorIcon" size="sm" />
+                  </div>
+                </slot>
+
+                <slot name="image-error">
+                  <div>
+                    {{ errorMessage }}
+                  </div>
+                </slot>
+              </div>
+            </div>
           </template>
         </q-img>
       </slot>
@@ -51,6 +65,16 @@ export default {
 
     disable: {
       type: Boolean
+    },
+
+    errorIcon: {
+      type: String,
+      default: ''
+    },
+
+    errorMessage: {
+      type: String,
+      default: ''
     },
 
     gridGeneratorProps: {
@@ -108,6 +132,19 @@ export default {
         'text-grey-9': !this.disable,
         'q-mb-md': this.hasActions || this.card.name
       }
+    },
+
+    errorClasses () {
+      return [
+        'bg-grey-4',
+        'flex',
+        'full-height',
+        'full-width',
+        'items-center',
+        'justify-center',
+        'text-grey-9',
+        'text-subtitle2'
+      ]
     }
   }
 }

--- a/ui/src/components/gallery-card/QasGalleryCard.yml
+++ b/ui/src/components/gallery-card/QasGalleryCard.yml
@@ -9,6 +9,16 @@ props:
     default: {}
     type: Object
 
+  error-icon:
+    desc: Ícone que aparecerá quando uma imagem falhar ao carregar.
+    default: ''
+    type: String
+
+  error-message:
+    desc: Texto que aparecerá quando uma imagem falhar ao carregar.
+    default: ''
+    type: String
+
   card:
     desc: Informações do card, como name (nome) e url.
     default: {}
@@ -40,6 +50,9 @@ slots:
 
   image-error:
     desc: Slot para acessar o conteúdo da imagem quando existe algum erro com a imagem.
+
+  image-error-icon:
+    desc: Slot para acessar o conteúdo de ícone quando existe algum erro com a imagem.
 
   header:
     desc: Slot para acessar o conteúdo do cabeçalho.

--- a/ui/src/components/uploader/QasUploader.vue
+++ b/ui/src/components/uploader/QasUploader.vue
@@ -116,7 +116,7 @@ export default {
     },
 
     galleryCardProps: {
-      type: Object,
+      type: [Object, Function],
       default: () => ({})
     },
 

--- a/ui/src/components/uploader/private/PvUploaderGalleryCard.vue
+++ b/ui/src/components/uploader/private/PvUploaderGalleryCard.vue
@@ -1,28 +1,6 @@
 <template>
   <div>
     <qas-gallery-card v-bind="defaultGalleryCardProps">
-      <!-- este template é para quando existe um erro carregar uma imagem de um arquivo como PDF, DOCX. -->
-      <template #image-error>
-        <div class="text-uppercase" :class="errorClasses">
-          {{ fileType }}
-        </div>
-      </template>
-
-      <!-- este template é para quando existe um erro ao fazer um UPLOAD! -->
-      <template v-if="hasError" #image>
-        <div :class="errorClasses">
-          <div class="q-pa-sm text-center">
-            <div>
-              <q-icon name="sym_r_cancel" size="sm" />
-            </div>
-
-            <div class="q-mt-sm">
-              Falha ao carregar arquivo.
-            </div>
-          </div>
-        </div>
-      </template>
-
       <template v-if="hasGenerator" #bottom>
         <div>
           <qas-grid-generator v-if="hasGridGenerator" v-bind="defaultGridGeneratorProps" />
@@ -80,7 +58,7 @@ export default {
     },
 
     galleryCardProps: {
-      type: Object,
+      type: [Object, Function],
       default: () => ({})
     },
 
@@ -112,7 +90,8 @@ export default {
   data () {
     return {
       dialogValues: {},
-      showDialog: false
+      showDialog: false,
+      hasErrorOnUploadedFile: false
     }
   },
 
@@ -136,20 +115,66 @@ export default {
       }
     },
 
+    normalizedCardGalleryProps () {
+      const isFunction = typeof this.galleryCardProps === 'function'
+
+      const functionPayload = {
+        hasError: this.hasErrorOnUploadedFile,
+        file: this.file
+      }
+
+      return (isFunction ? this.galleryCardProps(functionPayload) : this.galleryCardProps) || {}
+    },
+
     defaultGalleryCardProps () {
-      const { list, buttonProps, ...actionsMenuProps } = this.galleryCardProps.actionsMenuProps || {}
+      const {
+        list,
+        imageProps,
+
+        buttonProps: btnProps,
+        errorMessage: error,
+        errorIcon: icon,
+
+        ...actionsMenuProps
+      } = this.normalizedCardGalleryProps
+
+      /**
+       * Quando hasError for "true", significa que é falha ao enviar a imagem ao servidor (upload), e nestes casos:
+       *
+       * buttonProps: deve sempre ser possível excluir a imagem, por isso o disable do botão é "false".
+       * errorMessage: o label do erro deve ser "Falha ao carregar arquivo."
+       * errorIcon: o ícone do erro deve ser "sym_r_cancel".
+       */
+      const buttonProps = this.hasError ? { ...btnProps, disable: false } : btnProps
+      const errorMessage = this.hasError ? 'Falha ao carregar arquivo.' : error || this.fileType
+      const errorIcon = this.hasError ? 'sym_r_cancel' : icon
 
       return {
-        ...this.galleryCardProps,
         disable: this.hasError,
 
+        ...this.normalizedCardGalleryProps,
+
+        errorIcon,
+        errorMessage,
+
+        imageProps: {
+          ...imageProps,
+
+          // callback para sinalizar que houve erro em arquivos já upados.
+          onError: () => {
+            this.hasErrorOnUploadedFile = true
+
+            this.galleryCardProps.imageProps?.onError?.()
+          }
+        },
+
         actionsMenuProps: {
+          ...actionsMenuProps,
+
           buttonProps: {
             disable: false,
             ...buttonProps
           },
-
-          ...actionsMenuProps,
 
           list: {
             ...(
@@ -216,21 +241,8 @@ export default {
       }
     },
 
-    errorClasses () {
-      return [
-        'bg-grey-4',
-        'flex',
-        'full-height',
-        'full-width',
-        'items-center',
-        'justify-center',
-        'text-grey-9',
-        'text-subtitle2'
-      ]
-    },
-
     fileName () {
-      return this.url.split('/').pop()
+      return this.url ? this.url.split('/').pop() : ''
     },
 
     fileType () {
@@ -259,6 +271,7 @@ export default {
 
     hasFormFields () {
       const { fields } = this.defaultFormGeneratorProps
+
       return !!Object.keys(fields).length
     },
 
@@ -288,7 +301,19 @@ export default {
     },
 
     normalizedModelValue () {
-      return this.useObjectModel && !this.hasError ? this.currentModelValue : this.file
+      return (
+        this.useObjectModel && !this.hasError
+          ? this.currentModelValue
+
+          /**
+           * Quando da erro ao enviar, a url não é enviada no model, desta forma para aparecer a imagem
+           * de "Falha ao enviar arquivo." é necessário que a "url" exista, então é criada uma url fake.
+           *
+           * Obs: esta URL fake é usada apenas para aparecer a imagem de "Falha ao enviar arquivo."
+           * e não é adicionada ao model.
+           */
+          : { url: this.url || 'error-on-upload-file', ...this.file }
+      )
     },
 
     url () {

--- a/ui/src/components/uploader/private/PvUploaderGalleryCard.vue
+++ b/ui/src/components/uploader/private/PvUploaderGalleryCard.vue
@@ -139,7 +139,7 @@ export default {
       } = this.normalizedCardGalleryProps
 
       /**
-       * Quando hasError for "true", significa que é falha ao enviar a imagem ao servidor (upload), e nestes casos:
+       * Quando hasError for "true", significa que é falha ao enviar o arquivo ao servidor (upload), e nestes casos:
        *
        * buttonProps: deve sempre ser possível excluir a imagem, por isso o disable do botão é "false".
        * errorMessage: o label do erro deve ser "Falha ao carregar arquivo."


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Adicionado
- `QasGalleryCard`: adicionado novas propriedades `errorMessage` e `errorIcon` para controlar conteúdo quando dar falha ao carregar imagem.
- `QasGalleryCard`: adicionado novo slot `image-error-icon` para controle de ícone.

### Modificado
- `QasUploader`: propriedade `galleryCardProps` agora aceita callback function, para ter controle personalizado por card.
- `QasGalleryCard`: modificado estilo de card para erro.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
