### PR TITLE
Changes in QasFormView and QasAppUser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,14 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ## Não publicado
 ## BREAKING CHANGES
 - `QasFormView`: modificação do `data-cy` dos botões de "Salvar" e "Voltar" do formulário. Veja mais detalhes na seção "Modificado" abaixo.
+- `QasAppUser`: alterado `dataCy` para `data-cy`.
 
 ### Adicionado
 - `QasDialog`: adicionado `data-cy` em algumas seções do componente. Como, por exemplo: título, descrição, botões, etc.
+- `QasFormView`: adicionado nova propriedade `useNotifySuccess` para controlar quando mostrar a notificação de sucesso (utilizar somente em casos muito específicos, olhar documentação).
+
+### Corrigido
+- `QasAppUser`: alterado `dataCy` para `data-cy`.
 
 ### Modificado
 - `QasFormView`: modificado `data-cy` do botão de "Salvar" para `data-cy="form-view-submit-btn-[entity]"`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ## Não publicado
 ## BREAKING CHANGES
 - `QasFormView`: modificação do `data-cy` dos botões de "Salvar" e "Voltar" do formulário. Veja mais detalhes na seção "Modificado" abaixo.
-- `QasAppUser`: alterado `dataCy` para `data-cy`.
 
 ### Adicionado
 - `QasDialog`: adicionado `data-cy` em algumas seções do componente. Como, por exemplo: título, descrição, botões, etc.

--- a/docs/src/pages/components/form-view.md
+++ b/docs/src/pages/components/form-view.md
@@ -6,6 +6,11 @@ Componente para C.R.U.D. responsável pela pela criação (Create) e edição (U
 
 <doc-api file="form-view/QasFormView" name="QasFormView" />
 
+:::danger
+###### Propriedade "useNotifySuccess"
+Desative as notificações de sucesso apenas em situações particulares, como, por exemplo, em um 'stepper' no qual não é apropriado mostrar uma notificação de sucesso enquanto o processo ainda não atingiu a etapa final.
+:::
+
 :::warning
 Este componente depende do `Vuex`, utiliza módulos com actions, state e getters para manipular/recuperar os dados. Por exemplo, para você utilizar em uma entidade de show de usuários, você **deve** ter um modulo de `users` e dentro de dele ter os seguinte requisitos:
 - state: list.

--- a/ui/src/components/app-user/QasAppUser.vue
+++ b/ui/src/components/app-user/QasAppUser.vue
@@ -17,7 +17,7 @@
         <div class="ellipsis qas-app-user__menu-name">{{ userName }}</div>
         <div class="ellipsis">{{ user.email }}</div>
 
-        <qas-select v-if="hasCompaniesSelect" v-model="companiesModel" class="q-my-md" v-bind="defaultCompanyProps" @update:model-value="setCompanies" />
+        <qas-select v-if="hasCompaniesSelect" v-model="companiesModel" class="q-my-md" v-bind="defaultCompanyProps" data-cy="app-user-companies-select" @update:model-value="setCompanies" />
 
         <q-list class="q-mt-md">
           <q-item v-close-popup :active="false" class="qas-app-user__menu-item" clickable :to="user.to">
@@ -103,7 +103,6 @@ export default {
   computed: {
     defaultCompanyProps () {
       return {
-        dataCy: 'app-user-companies-select',
         loading: this.loading,
 
         ...this.companyProps,

--- a/ui/src/components/app-user/QasAppUser.yml
+++ b/ui/src/components/app-user/QasAppUser.yml
@@ -47,3 +47,7 @@ selectors:
   app-user:
     desc: Seletor do componente.
     examples: ['data-cy="app-user"']
+
+  app-user-companies-select:
+    desc: Seletor do select de vínculos de empresas.
+    examples: ['data-cy="app-user-companies-select"']

--- a/ui/src/components/form-view/QasFormView.vue
+++ b/ui/src/components/form-view/QasFormView.vue
@@ -57,6 +57,11 @@ export default {
   mixins: [viewMixin],
 
   props: {
+    beforeSubmit: {
+      default: null,
+      type: Function
+    },
+
     cancelButtonLabel: {
       default: 'Voltar',
       type: String
@@ -125,14 +130,14 @@ export default {
       type: Boolean
     },
 
+    useNotifySuccess: {
+      type: Boolean,
+      default: true
+    },
+
     useSubmitButton: {
       default: true,
       type: Boolean
-    },
-
-    beforeSubmit: {
-      default: null,
-      type: Function
     }
   },
 
@@ -447,7 +452,9 @@ export default {
           `QasFormView - submit -> resposta da action ${this.entity}/${this.mode}`, [response]
         )
 
-        NotifySuccess(response.data.status.text || this.defaultNotifyMessages.success)
+        if (this.useNotifySuccess) {
+          NotifySuccess(response.data.status.text || this.defaultNotifyMessages.success)
+        }
       } catch (error) {
         const errors = error?.response?.data?.errors
         const message = error?.response?.data?.status?.text

--- a/ui/src/components/form-view/QasFormView.yml
+++ b/ui/src/components/form-view/QasFormView.yml
@@ -138,6 +138,11 @@ props:
     default: true
     type: Boolean
 
+  use-notify-success:
+    desc: Controla se vai ter ou não notificação de sucesso ao finalizar o submit.
+    default: true
+    type: Boolean
+
   use-submit-button:
     desc: Controla se vai ter ou não botão de submit.
     default: true


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
## BREAKING CHANGES
- `QasAppUser`: alterado `dataCy` para `data-cy`.

### Adicionado
- `QasFormView`: adicionado nova propriedade `useNotifySuccess` para controlar quando mostrar a notificação de sucesso (utilizar somente em casos muito específicos, olhar documentação).

### Corrigido
- `QasAppUser`: alterado `dataCy` para `data-cy`.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
