### PR TITLE
Fix gutter issue and update QasActions to Composition API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasActions`: corrigido computada `defaultGutter` que sempre retornava `md` ou `lg`, ignorando a prop `gutter`.
 
 ### Modificado
-- `QasActions`: Alterado componente para Composition API.
+- `QasActions`: alterado componente para Composition API.
 
 ## [3.13.0-beta.8] - 22-11-2023
 ## BREAKING CHANGE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasActions`: corrigido computada `defaultGutter` que sempre retornava `md` ou `lg`, ignorando a prop `gutter`.
+
+### Modificado
+- `QasActions`: Alterado componente para Composition API.
+
 ## [3.13.0-beta.8] - 22-11-2023
 ## BREAKING CHANGE
 - `plugins/Logger`: removido plugin de log, uma vez que o mesmo estava poluindo muito o console, alterado para a lib `debug`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
+### Adicionado
+- `enums/Align`: adicionado novo enum `FlexAlign` para alinhamentos.
+
 ### Corrigido
 - `QasActions`: corrigido computada `defaultGutter` que sempre retornava `md` ou `lg`, ignorando a prop `gutter`.
 

--- a/ui/src/components/actions/QasActions.vue
+++ b/ui/src/components/actions/QasActions.vue
@@ -10,58 +10,65 @@
   </div>
 </template>
 
-<script>
-export default {
-  name: 'QasActions',
+<script setup>
+import useScreen from '../../composables/use-screen'
+import { FlexAlign } from '../../enums/Align'
+import { Spacing } from '../../enums/Spacing'
 
-  props: {
-    align: {
-      default: 'end',
-      type: String,
-      validator: value => ['start', 'around', 'between', 'center', 'end'].includes(value)
-    },
+import { computed, useSlots } from 'vue'
 
-    gutter: {
-      default: '',
-      type: String,
-      validator: value => !value || ['xs', 'sm', 'md', 'lg', 'xl'].includes(value)
-    },
+defineOptions({ name: 'QasActions' })
 
-    useFullWidth: {
-      type: Boolean
-    },
-
-    useEqualWidth: {
-      type: Boolean
-    }
+const props = defineProps({
+  align: {
+    default: FlexAlign.End,
+    type: String,
+    validator: value => Object.values(FlexAlign).includes(value)
   },
 
-  computed: {
-    classes () {
-      return [
-        `justify-${this.align}`,
-        `q-col-gutter-${this.defaultGutter}`,
-        (this.$qas.screen.isSmall || this.useFullWidth) ? 'column reverse' : 'row'
-      ]
-    },
+  gutter: {
+    default: '',
+    type: String,
+    validator: value => !value || Object.values(Spacing).includes(value)
+  },
 
-    defaultGutter () {
-      return this.gutter || this.$qas.screen.isSmall ? 'md' : 'lg'
-    },
+  useFullWidth: {
+    type: Boolean
+  },
 
-    columnClasses () {
-      if (this.useEqualWidth) return 'col-12 col-sm-6'
-
-      return this.useFullWidth ? 'col-12' : 'col-12 col-sm-auto'
-    },
-
-    hasPrimarySlot () {
-      return !!this.$slots.primary
-    },
-
-    hasSecondarySlot () {
-      return !!this.$slots.secondary
-    }
+  useEqualWidth: {
+    type: Boolean
   }
-}
+})
+
+const slots = useSlots()
+const screen = useScreen()
+
+const defaultGutter = computed(() => {
+  return props.gutter || (screen.isSmall ? 'md' : 'lg')
+})
+
+const classes = computed(() => {
+  const isSmallOrFullWidth = screen.isSmall || props.useFullWidth
+
+  return [
+    // alinhamento
+    `justify-${props.align}`,
+
+    // espaçamento
+    `q-col-gutter-${defaultGutter.value}`,
+
+    // disposição
+    isSmallOrFullWidth ? 'column reverse' : 'row'
+  ]
+})
+
+const columnClasses = computed(() => {
+  if (props.useEqualWidth) return 'col-12 col-sm-6'
+
+  return props.useFullWidth ? 'col-12' : 'col-12 col-sm-auto'
+})
+
+const hasPrimarySlot = computed(() => !!slots.primary)
+const hasSecondarySlot = computed(() => !!slots.secondary)
 </script>

--- a/ui/src/enums/Align.js
+++ b/ui/src/enums/Align.js
@@ -1,0 +1,7 @@
+export const FlexAlign = {
+  Start: 'start',
+  End: 'end',
+  Center: 'center',
+  Around: 'around',
+  Between: 'between'
+}


### PR DESCRIPTION
Composition API

<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Adicionado
- `enums/Align`: adicionado novo enum `FlexAlign` para alinhamentos.

### Corrigido
- `QasActions`: corrigido computada `defaultGutter` que sempre retornava `md` ou `lg`, ignorando a prop `gutter`.

### Modificado
- `QasActions`: Alterado componente para Composition API.


<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [ ] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
