### PR TITLE
Refactor QasActionsMenu component to Composition API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ### Modificado
 - `QasActions`: alterado componente para Composition API.
+- `QasActionsMenu`: alterado componente para Composition API.
 
 ## [3.13.0-beta.8] - 22-11-2023
 ## BREAKING CHANGE

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -40,13 +40,13 @@ const props = defineProps({
   },
 
   deleteLabel: {
-    type: String,
-    default: 'Excluir'
+    default: 'Excluir',
+    type: String
   },
 
   deleteIcon: {
-    type: String,
-    default: 'sym_r_delete'
+    default: 'sym_r_delete',
+    type: String
   },
 
   deleteProps: {
@@ -65,8 +65,8 @@ const props = defineProps({
   },
 
   splitName: {
-    type: String,
-    default: ''
+    default: '',
+    type: String
   },
 
   useLabel: {
@@ -84,7 +84,8 @@ const { deleteBtnProps, hasDelete } = useDelete()
 
 const fullList = computed(() => {
   return {
-    ...props.list, ...deleteBtnProps
+    ...props.list,
+    ...deleteBtnProps
   }
 })
 

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -22,193 +22,189 @@
   </div>
 </template>
 
-<script>
+<script setup>
 import QasBtn from '../btn/QasBtn.vue'
 import QasBtnDropdown from '../btn-dropdown/QasBtnDropdown.vue'
 
-export default {
-  name: 'QasActionsMenu',
+import Delete from '../../plugins/delete/Delete'
+import useScreen from '../../composables/use-screen'
 
-  components: {
-    QasBtn,
-    QasBtnDropdown
+import { computed } from 'vue'
+
+defineOptions({ name: 'QasActionsMenu' })
+
+const props = defineProps({
+  buttonProps: {
+    default: () => ({}),
+    type: Object
   },
 
-  props: {
+  deleteLabel: {
+    type: String,
+    default: 'Excluir'
+  },
+
+  deleteIcon: {
+    type: String,
+    default: 'sym_r_delete'
+  },
+
+  deleteProps: {
+    default: () => ({}),
+    type: Object
+  },
+
+  dropdownIcon: {
+    default: 'sym_r_more_vert',
+    type: String
+  },
+
+  list: {
+    default: () => ({}),
+    type: Object
+  },
+
+  splitName: {
+    type: String,
+    default: ''
+  },
+
+  useLabel: {
+    default: true,
+    type: Boolean
+  },
+
+  useTooltip: {
+    type: Boolean
+  }
+})
+
+const screen = useScreen()
+const { deleteBtnProps, hasDelete } = useDelete()
+
+const fullList = computed(() => {
+  return {
+    ...props.list, ...deleteBtnProps
+  }
+})
+
+const hasSplit = computed(() => !!props.splitName)
+
+// --------------------------------- actions -----------------------------------
+const actions = computed(() => {
+  const list = { ...fullList.value }
+
+  if (hasSplit.value && list[props.splitName] && isBtnDropdown.value) {
+    screen.isSmall
+      ? Object.assign(list, { [props.splitName]: list[props.splitName] })
+      : delete list[props.splitName]
+  }
+
+  return list
+})
+
+const hasActions = computed(() => !!Object.keys(actions.value).length)
+const firstItemKey = computed(() => Object.keys(actions.value)?.[0])
+
+// -------------------------------- tooltip ------------------------------------
+const tooltipLabel = computed(() => actions.value[firstItemKey.value]?.label)
+const hasTooltip = computed(() => {
+  return !isBtnDropdown.value && !props.useLabel && props.useTooltip
+})
+
+// --------------------------------- button ------------------------------------
+const defaultButtonProps = computed(() => {
+  const { label, variant, ...buttonProps } = props.buttonProps
+
+  return {
+    useHoverOnWhiteColor: true,
+    useLabelOnSmallScreen: false,
+    ...buttonProps
+  }
+})
+
+const btnDropdownProps = computed(() => {
+  const { icon, label } = fullList.value[props.splitName] || {}
+
+  const {
+    icon: defaultIcon,
+    ...defaultBtnProps
+  } = defaultButtonProps.value
+
+  return {
     buttonProps: {
-      default: () => ({}),
-      type: Object
+      ...(props.useLabel && { label: hasSplit.value ? label : 'Opções' }),
+      ...defaultBtnProps,
+      icon: icon || defaultIcon
     },
 
-    deleteLabel: {
-      type: String,
-      default: 'Excluir'
-    },
+    dropdownIcon: props.dropdownIcon,
+    useSplit: hasSplit.value,
 
-    deleteIcon: {
-      type: String,
-      default: 'sym_r_delete'
-    },
+    onClick: () => onClick(fullList.value[props.splitName])
+  }
+})
 
-    deleteProps: {
-      default: () => ({}),
-      type: Object
-    },
+const btnProps = computed(() => {
+  const { color, icon } = actions.value[firstItemKey.value] || {}
+  const { color: defaultColor, ...defaultBtnProps } = defaultButtonProps.value
 
-    dropdownIcon: {
-      default: 'sym_r_more_vert',
-      type: String
-    },
+  return {
+    color: color || defaultColor,
+    icon,
+    label: props.useLabel ? tooltipLabel.value : '',
+    onClick,
+    ...defaultBtnProps
+  }
+})
 
-    list: {
-      default: () => ({}),
-      type: Object
-    },
+const isBtnDropdown = computed(() => Object.keys(fullList.value || {}).length > 1)
 
-    splitName: {
-      type: String,
-      default: ''
-    },
+// -------------------------------- component ----------------------------------
+const component = computed(() => {
+  const is = isBtnDropdown.value ? QasBtnDropdown : QasBtn
 
-    useLabel: {
-      default: true,
-      type: Boolean
-    },
-
-    useTooltip: {
-      type: Boolean
+  return {
+    is,
+    props: {
+      ...(isBtnDropdown.value ? btnDropdownProps.value : btnProps.value),
+      ...(hasDelete.value && props.deleteProps)
     }
-  },
+  }
+})
 
-  computed: {
-    actions () {
-      const list = { ...this.fullList }
+// --------------------------------- methods -----------------------------------
+function onClick (item = {}) {
+  if (!isBtnDropdown.value) {
+    item = actions.value[firstItemKey.value]
+  }
 
-      if (this.hasSplit && list[this.splitName] && this.isBtnDropdown) {
-        this.isSmall
-          ? Object.assign(list, { [this.splitName]: list[this.splitName] })
-          : delete list[this.splitName]
+  if (typeof item.handler === 'function') {
+    const { handler, ...filtered } = item
+    item.handler(filtered)
+  }
+}
+
+// ------------------------------- composables ---------------------------------
+function useDelete () {
+  const deleteBtnProps = {}
+
+  const hasDelete = computed(() => !!Object.keys(props.deleteProps).length)
+
+  if (hasDelete.value) {
+    Object.assign(deleteBtnProps, {
+      delete: {
+        color: 'grey-9',
+        icon: props.deleteIcon,
+        label: props.deleteLabel,
+        handler: () => Delete(props.deleteProps)
       }
+    })
+  }
 
-      return list
-    },
-
-    fullList () {
-      return {
-        ...this.list,
-        ...(this.hasDelete && {
-          delete: {
-            color: 'grey-9',
-            icon: this.deleteIcon,
-            label: this.deleteLabel,
-            handler: () => this.$qas.delete(this.deleteProps)
-          }
-        })
-      }
-    },
-
-    component () {
-      const is = this.isBtnDropdown ? 'qas-btn-dropdown' : 'qas-btn'
-
-      return {
-        is,
-        props: {
-          ...(this.isBtnDropdown ? this.btnDropdownProps : this.btnProps),
-          ...(this.hasDelete && this.deleteProps)
-        }
-      }
-    },
-
-    firstItemKey () {
-      return Object.keys(this.actions)?.[0]
-    },
-
-    hasActions () {
-      return !!Object.keys(this.actions).length
-    },
-
-    hasDelete () {
-      return !!Object.keys(this.deleteProps).length
-    },
-
-    hasSplit () {
-      return !!this.splitName
-    },
-
-    isBtnDropdown () {
-      return Object.keys(this.fullList || {}).length > 1
-    },
-
-    hasTooltip () {
-      return !this.isBtnDropdown && !this.useLabel && this.useTooltip
-    },
-
-    tooltipLabel () {
-      return this.actions[this.firstItemKey]?.label
-    },
-
-    defaultButtonProps () {
-      const { label, variant, ...buttonProps } = this.buttonProps
-
-      return {
-        useHoverOnWhiteColor: true,
-        useLabelOnSmallScreen: false,
-        ...buttonProps
-      }
-    },
-
-    btnDropdownProps () {
-      const { icon, label } = this.fullList[this.splitName] || {}
-
-      const {
-        icon: defaultIcon,
-        ...defaultButtonProps
-      } = this.defaultButtonProps
-
-      return {
-        buttonProps: {
-          ...(this.useLabel && { label: this.hasSplit ? label : 'Opções' }),
-          ...defaultButtonProps,
-          icon: icon || defaultIcon
-        },
-
-        dropdownIcon: this.dropdownIcon,
-        useSplit: this.hasSplit,
-
-        // evento
-        onClick: () => this.onClick(this.fullList[this.splitName])
-      }
-    },
-
-    btnProps () {
-      const { color, icon } = this.actions[this.firstItemKey] || {}
-      const { color: defaultColor, ...defaultButtonProps } = this.defaultButtonProps
-
-      return {
-        color: color || defaultColor,
-        icon,
-        label: this.useLabel ? this.tooltipLabel : '',
-        onClick: this.onClick,
-        ...defaultButtonProps
-      }
-    },
-
-    isSmall () {
-      return this.$qas.screen.isSmall
-    }
-  },
-
-  methods: {
-    onClick (item = {}) {
-      if (!this.isBtnDropdown) {
-        item = this.actions[this.firstItemKey]
-      }
-
-      if (typeof item.handler === 'function') {
-        const { handler, ...filtered } = item
-        item.handler(filtered)
-      }
-    }
+  return {
+    deleteBtnProps,
+    hasDelete
   }
 }
 </script>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Modificado
- `QasActionsMenu`: alterado componente para Composition API.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
