### PR TITLE
Fix props usage in QasAppMenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasAppMenu`: corrigido props que estavam sendo usado como se estivesse em `Options API`.
+
 ## [3.13.0-beta.9] - 28-11-2023
 ## BREAKING CHANGE
 - `QasDialog`: ref `dialog` interno do componente alterado para `dialogRef`.

--- a/ui/src/components/app-menu/composables/use-app-menu-dropdown.js
+++ b/ui/src/components/app-menu/composables/use-app-menu-dropdown.js
@@ -4,7 +4,7 @@ import { computed, watch, ref } from 'vue'
 
 /**
  * @param {{
- *  props: { modules: [] },
+ *  props: { modules: [], title: string },
  *  onMenuUpdate: () => void
  * }} config
  */
@@ -19,7 +19,7 @@ export default function useAppMenuDropdown (config = {}) {
   const module = ref('')
 
   const defaultModules = computed(() => {
-    if (!isLocalDevelopment()) return this.modules
+    if (!isLocalDevelopment()) return props.modules
 
     const normalizedModules = [...props.modules]
 
@@ -31,7 +31,7 @@ export default function useAppMenuDropdown (config = {}) {
      * executado em desenvolvimento local.
      */
     normalizedModules.unshift({
-      label: `Localhost ${this.title ? `(${this.title})` : ''}`,
+      label: `Localhost ${props.title ? `(${props.title})` : ''}`,
       icon: 'sym_r_home',
       value
     })


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Corrigido
- `QasAppMenu`: corrigido props que estavam sendo usado como se estivesse em `Options API`.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
