### PR TITLE
Fix issues with QasDialog and plugins/Dialog.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasDialog`: corrigido problema de não emitir o evento `@hide`.
+- `plugins/Dialog.js`: corrigido problema de não retornar a instância do dialog.
+
 ## [3.13.0-beta.13] - 07-12-2023
 ### Adicionado
 - `vue-plugin.js`: Adicionado provider `qas`.

--- a/ui/src/components/dialog/QasDialog.vue
+++ b/ui/src/components/dialog/QasDialog.vue
@@ -125,7 +125,7 @@ const screen = useScreen()
 const slots = useSlots()
 
 // usado para o plugin
-const { dialogRef } = useDialogPluginComponent()
+const { dialogRef, onDialogHide } = useDialogPluginComponent()
 
 // QForm template
 const form = ref(null)
@@ -139,7 +139,9 @@ const { descriptionComponent, mainComponent } = useDynamicComponents({ ...compos
 const dialogProps = computed(() => {
   return {
     ...(!props.usePlugin && { modelValue: props.modelValue }),
-    ...attrs
+    ...attrs,
+
+    onHide: onDialogHide
   }
 })
 

--- a/ui/src/plugins/dialog/Dialog.js
+++ b/ui/src/plugins/dialog/Dialog.js
@@ -7,7 +7,7 @@ import QasDialog from '../../components/dialog/QasDialog.vue'
  * @example Dialog({ card: { title: 'Esse é o meu titulo!' } })
  */
 export default (componentProps = {}) => {
-  Dialog.create({
+  return Dialog.create({
     component: QasDialog,
     componentProps: { ...componentProps, usePlugin: true }
   })


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- (Remova este texto de descrição.) -->
### Corrigido
- `QasDialog`: corrigido problema de não emitir o evento `@hide`.
- `plugins/Dialog.js`: corrigido problema de não retornar a instância do dialog.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [x] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
