### PR TITLE
Bugfix/fix-breadcrumb-history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
-### Corrigido
-- `QasPageHeader`: corrigido o problema de pegar a rota errada do histórico.
-- `use-history`: corrigido o método `addRoute` que adicionava a rota apenas se última rota tivesse nome diferente, não diferenciando as queries. Agora valida com base no `fullPath`, considerando as queries da rota.
+## BREAKING CHANGE
+- `QasPageHeader`: removido a query dos breadcrumb. Utilize `use-query-cache` se precisar manter a query.
+
+### Removido
+- `QasPageHeader`: removido a `query` dos breadcrumb.
 
 ### Modificado
 - `use-history`: alterado a forma de pegar o último index. Agora utiliza o método `at(-1)`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,10 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ## Não publicado
 ## BREAKING CHANGE
-- `QasPageHeader`: removido a query dos breadcrumb. Utilize `use-query-cache` se precisar manter a query.
+- `QasPageHeader`: removido a query dos breadcrumb. Utilize `useCache: true` no meta das rotas onde precisar persistir a query.
 
 ### Removido
-- `QasPageHeader`: removido a `query` dos breadcrumb.
-
-### Modificado
-- `use-history`: alterado a forma de pegar o último index. Agora utiliza o método `at(-1)`;
+- `QasPageHeader`: removido a query dos links do breadcrumb.
 
 ## [3.13.0-beta.14] - 07-12-2023
 ### Corrigido

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasPageHeader`: corrigido o problema de pegar a rota errada do histórico.
+- `use-history`: corrigido o método `addRoute` que adicionava a rota apenas se última rota tivesse nome diferente, não diferenciando as queries. Agora valida com base no `fullPath`, considerando as queries da rota.
+
+### Modificado
+- `use-history`: alterado a forma de pegar o último index. Agora utiliza o método `at(-1)`;
+
 ## [3.13.0-beta.14] - 07-12-2023
 ### Corrigido
 - `QasDialog`: corrigido problema de não emitir o evento `@hide`.

--- a/ui/src/components/page-header/QasPageHeader.vue
+++ b/ui/src/components/page-header/QasPageHeader.vue
@@ -31,7 +31,7 @@ import { castArray } from 'lodash-es'
 import { useHistory } from '../../composables'
 import { createMetaMixin } from 'quasar'
 
-const { history } = useHistory()
+const { history, hasPreviousRoute } = useHistory()
 
 export default {
   name: 'QasPageHeader',
@@ -94,10 +94,9 @@ export default {
           item.route = { name: item.routeName }
         }
 
-        const historyList = history.list
+        if (hasPreviousRoute.value && item?.route?.name) {
+          const previous = history.list.findLast(({ name }) => name === item.route.name)
 
-        if (historyList.length && item?.route?.name) {
-          const previous = historyList.find(history => history.name === item.route.name)
           item.route.query = previous ? previous.query : null
         }
 

--- a/ui/src/components/page-header/QasPageHeader.vue
+++ b/ui/src/components/page-header/QasPageHeader.vue
@@ -28,10 +28,7 @@
 import QasHeaderActions from '../header-actions/QasHeaderActions.vue'
 
 import { castArray } from 'lodash-es'
-import { useHistory } from '../../composables'
 import { createMetaMixin } from 'quasar'
-
-const { history, hasPreviousRoute } = useHistory()
 
 export default {
   name: 'QasPageHeader',
@@ -92,12 +89,6 @@ export default {
 
         if (!item.route && item.routeName) {
           item.route = { name: item.routeName }
-        }
-
-        if (hasPreviousRoute.value && item?.route?.name) {
-          const previous = history.list.findLast(({ name }) => name === item.route.name)
-
-          item.route.query = previous ? previous.query : null
         }
 
         return item

--- a/ui/src/composables/use-history.js
+++ b/ui/src/composables/use-history.js
@@ -17,7 +17,7 @@ export default function () {
 
   function addRoute (route) {
     const lastRoute = history.list?.at(-1)
-    const routeExistsInList = lastRoute?.fullPath === route.fullPath
+    const routeExistsInList = lastRoute?.name === route.name
 
     if (routeExistsInList) return
 

--- a/ui/src/composables/use-history.js
+++ b/ui/src/composables/use-history.js
@@ -1,5 +1,4 @@
 import { reactive, computed } from 'vue'
-import { findLastIndex } from 'lodash-es'
 
 const history = reactive({ list: [] })
 
@@ -7,17 +6,18 @@ export default function () {
   const hasPreviousRoute = computed(() => history.list.length > 1)
 
   function getPreviousRoute (currentRoute) {
-    const index = findLastIndex(history.list, item => item.name === currentRoute.name)
+    const index = history.list.findLastIndex(item => item.name === currentRoute.name)
 
     if (~index) {
       history.list.splice(index, 1)
     }
 
-    return history.list[history.list.length - 1]
+    return history.list.at(-1)
   }
 
   function addRoute (route) {
-    const routeExistsInList = history.list?.[history.list?.length - 1]?.name === route.name
+    const lastRoute = history.list?.at(-1)
+    const routeExistsInList = lastRoute?.fullPath === route.fullPath
 
     if (routeExistsInList) return
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- (Remova este texto de descrição.) -->
Remove as queries dos breadcrumbs, pois não são mais necessárias.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [x] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [x] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [ ] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
