### PR TITLE
QasTableGenerator new bg hover color and fix ErrorComponent background-color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,16 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+`QasTableGenerator`: alterado hover da cor de fundo da linha da tabela para a cor de background padrão.
+
+### Corrigido
+- `ErrorComponent`: corrigido problema na exibição da cor de fundo.
+
 ## [3.13.0-beta.17] - 19-12-2023
 ### Modificado
-- `QasAppBar.vue`: alterado `max-width` da logo para `115px`.
+- `QasAppBar`: alterado `max-width` da logo para `115px`.
 
 ## [3.13.0-beta.16] - 18-12-2023
 ## BREAKING CHANGE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ## Não publicado
 ### Modificado
-`QasTableGenerator`: alterado hover da cor de fundo da linha da tabela para a cor de background padrão.
+- `QasTableGenerator`: alterado hover da cor de fundo da linha da tabela para a cor de background padrão.
 
 ### Corrigido
 - `ErrorComponent`: corrigido problema na exibição da cor de fundo.

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -333,13 +333,17 @@ export default {
 
     td {
       @include set-typography($body1);
+
+      &:before {
+        transition: background-color var(--qas-generic-transition);
+      }
     }
 
     tr {
-      transition: background-color var(--qas-generic-transition);
-
       &:hover {
-        background-color: $grey-2;
+        td:before {
+          background-color: var(--qas-background-color);
+        }
       }
     }
 

--- a/ui/src/pages/ErrorComponent.vue
+++ b/ui/src/pages/ErrorComponent.vue
@@ -56,7 +56,6 @@ export default {
 
 <style lang="scss">
 .error-component {
-  background-color: var(--qas-background-color);
   min-height: 100vh;
   padding: var(--qas-spacing-3xl) 0;
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- (Remova este texto de descrição.) -->
### Modificado
- `QasTableGenerator`: alterado hover da cor de fundo da linha da tabela para a cor de background padrão.

### Corrigido
- `ErrorComponent`: corrigido problema na exibição da cor de fundo.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [x] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
