### PR TITLE
Refactor QasCard to Composition API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `QasBtnDropdown`: alterado componente para Composition API.
+
 ## [3.13.0] - 27-12-2023
 ## BREAKING CHANGES
 - Anteriormente, o componente `QasFormView` não atualizava automaticamente o v-model após um evento de "submit" com sucesso, o que levava a alguns problemas relacionados a não atualização de certos campos retornados da API. Para resolver isso, implementamos uma mudança para garantir que o `v-model` agora seja sempre atualizado com o resultado retornado pela API após um submit. Isso pode exigir testes para confirmar que o comportamento dos formulários estão alinhados com o esperado.

--- a/ui/src/components/card/QasCard.vue
+++ b/ui/src/components/card/QasCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="col-12 col-lg-3 col-md-4 col-sm-6">
     <q-card class="border-radius-lg column full-height overflow-hidden" :class="cardClasses">
-      <header v-if="useHeader" class="overflow-hidden relative-position w-full">
+      <header v-if="props.useHeader" class="overflow-hidden relative-position w-full">
         <slot name="header">
           <q-carousel v-model="slideImage" animated class="cursor-pointer" height="205px" infinite :navigation="hasImages" navigation-icon="sym_r_fiber_manual_record" swipeable>
             <template #navigation-icon="{ active, btnProps, onClick }">
@@ -30,84 +30,66 @@
   </div>
 </template>
 
-<script>
-export default {
-  name: 'QasCard',
+<script setup>
+import { Spacing } from '../../enums/Spacing'
 
-  props: {
-    imagePosition: {
-      type: String,
-      default: 'center'
-    },
+import { ref, computed, useSlots } from 'vue'
 
-    gutter: {
-      type: String,
-      default: 'sm'
-    },
+defineOptions({ name: 'QasCard' })
 
-    images: {
-      default: () => [],
-      type: Array
-    },
-
-    outlined: {
-      type: Boolean
-    },
-
-    unelevated: {
-      type: Boolean
-    },
-
-    useHeader: {
-      type: Boolean
-    }
+const props = defineProps({
+  imagePosition: {
+    type: String,
+    default: 'center'
   },
 
-  data () {
-    return {
-      slideImage: 0
-    }
+  gutter: {
+    type: String,
+    default: Spacing.Sm,
+    validator: value => Object.values(Spacing).includes(value)
   },
 
-  computed: {
-    imagePositionClass () {
-      return `bg-position-${this.imagePosition}`
-    },
-
-    cardClasses () {
-      return {
-        'shadow-2': !this.unelevated,
-        'border-primary': this.outlined,
-        'no-shadow': this.outlined,
-        'bg-white': this.outlined
-      }
-    },
-
-    gutterClass () {
-      return `q-col-gutter-${this.gutter}`
-    },
-
-    hasActionsSlot () {
-      return !!this.$slots.actions
-    },
-
-    hasImages () {
-      return this.images.length > 1
-    },
-
-    imagesLength () {
-      return this.images?.length
-    },
-
-    imagesList () {
-      return this.imagesLength && this.images.slice(0, 3)
-    }
+  images: {
+    default: () => [],
+    type: Array
   },
 
-  methods: {
-    getNavigationIcon (active, { icon }) {
-      return active ? 'sym_r_radio_button_checked' : icon
-    }
+  outlined: {
+    type: Boolean
+  },
+
+  unelevated: {
+    type: Boolean
+  },
+
+  useHeader: {
+    type: Boolean
   }
+})
+
+const slots = useSlots()
+
+const slideImage = ref(0)
+
+const cardClasses = computed(() => {
+  return {
+    'shadow-2': !props.unelevated,
+    'border-primary': props.outlined,
+    'no-shadow': props.outlined,
+    'bg-white': props.outlined
+  }
+})
+
+const imagePositionClass = computed(() => `bg-position-${props.imagePosition}`)
+const gutterClass = computed(() => `q-col-gutter-${props.gutter}`)
+
+const hasActionsSlot = computed(() => !!slots.actions)
+const hasImages = computed(() => props.images.length > 1)
+
+const imagesLength = computed(() => props.images?.length)
+const imagesList = computed(() => imagesLength.value && props.images.slice(0, 3))
+
+function getNavigationIcon (active, { icon }) {
+  return active ? 'sym_r_radio_button_checked' : icon
 }
 </script>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Modificado
- `QasBtnDropdown`: alterado componente para Composition API.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
