### PR TITLE
Fixed QasAppUser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
-### Modificado
+### Corrigido
 - `QasAppUSer`: corrigido select de empresa quando o select possuía busca, que ao clicar no botão de limpar, não limpava e ainda tentava alterar o vinculo para um vinculo vazio.
 
 ## [3.13.0] - 27-12-2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `QasAppUSer`: corrigido select de empresa quando o select possuía busca, que ao clicar no botão de limpar, não limpava e ainda tentava alterar o vinculo para um vinculo vazio.
+
 ## [3.13.0] - 27-12-2023
 ## BREAKING CHANGES
 - Anteriormente, o componente `QasFormView` não atualizava automaticamente o v-model após um evento de "submit" com sucesso, o que levava a alguns problemas relacionados a não atualização de certos campos retornados da API. Para resolver isso, implementamos uma mudança para garantir que o `v-model` agora seja sempre atualizado com o resultado retornado pela API após um submit. Isso pode exigir testes para confirmar que o comportamento dos formulários estão alinhados com o esperado.

--- a/docs/src/examples/QasAppUser/Basic.vue
+++ b/docs/src/examples/QasAppUser/Basic.vue
@@ -25,6 +25,38 @@ export default {
             {
               label: 'Empresa 2',
               value: '2'
+            },
+            {
+              label: 'Empresa 3',
+              value: '3'
+            },
+            {
+              label: 'Empresa 4',
+              value: '4'
+            },
+            {
+              label: 'Empresa 5',
+              value: '5'
+            },
+            {
+              label: 'Empresa 6',
+              value: '6'
+            },
+            {
+              label: 'Empresa 7',
+              value: '7'
+            },
+            {
+              label: 'Empresa 8',
+              value: '8'
+            },
+            {
+              label: 'Empresa 9',
+              value: '9'
+            },
+            {
+              label: 'Empresa 10',
+              value: '10'
             }
           ],
 

--- a/ui/src/components/app-user/QasAppUser.vue
+++ b/ui/src/components/app-user/QasAppUser.vue
@@ -18,7 +18,7 @@
       </div>
     </div>
 
-    <q-menu class="shadow-2 text-grey-10" max-height="400px" v-bind="menuProps">
+    <q-menu class="shadow-2 text-grey-10" max-height="400px" v-bind="menuProps" @hide="onMenuHide">
       <div class="q-pb-sm q-pt-md q-px-md qas-app-user__menu">
         <qas-avatar class="q-mb-md" :image="user.photo" size="64px" :title="userName" />
 
@@ -30,7 +30,7 @@
           {{ user.email }}
         </div>
 
-        <qas-select v-if="hasCompaniesSelect" v-model="companiesModel" class="q-my-md" v-bind="defaultCompanyProps" data-cy="app-user-companies-select" @update:model-value="setCompanies" />
+        <qas-select v-if="hasCompaniesSelect" v-bind="defaultCompanyProps" v-model="companiesModel" class="q-my-md" data-cy="app-user-companies-select" @update:model-value="setCompanies" />
 
         <q-list class="q-mt-md">
           <q-item v-close-popup :active="false" class="qas-app-user__menu-item" clickable :to="user.to">
@@ -146,6 +146,8 @@ function signOut () {
 }
 
 async function setCompanies (value) {
+  if (!value) return
+
   loading.value = true
 
   try {
@@ -159,6 +161,12 @@ async function setCompanies (value) {
     NotifyError('Falha ao alterar vínculo.')
   } finally {
     loading.value = false
+  }
+}
+
+function onMenuHide () {
+  if (!companiesModel.value) {
+    companiesModel.value = props.companyProps.modelValue
   }
 }
 </script>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Modificado
- `QasAppUSer`: corrigido select de empresa quando o select possuía busca, que ao clicar no botão de limpar, não limpava e ainda tentava alterar o vinculo para um vinculo vazio.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
