### PR TITLE
Refactor QasDate to Composition API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `QasDate`: alterado componente para Composition API.
+
+### Removido
+- `QasDate`: removido propriedade `useUnmaskEvents`, uma vez que ela não era utilizada para nada dentro do componente.
+
 ## [3.14.0-beta.0] - 03-01-2024
 ### Corrigido
 - `QasAppUSer`: corrigido select de empresa quando o select possuía busca, que ao clicar no botão de limpar, não limpava e ainda tentava alterar o vinculo para um vinculo vazio.

--- a/docs/src/examples/QasDate/ExDateEvents.vue
+++ b/docs/src/examples/QasDate/ExDateEvents.vue
@@ -43,6 +43,14 @@ export default {
         {
           date: '2023-07-04',
           counter: 2
+        },
+        {
+          date: '2023-12-31',
+          counter: 2
+        },
+        {
+          date: '2024-01-01',
+          counter: 2
         }
       ]
     }

--- a/ui/src/components/date/QasDate.vue
+++ b/ui/src/components/date/QasDate.vue
@@ -7,7 +7,6 @@
 </template>
 
 <script setup>
-/* eslint-disable no-console */
 import { date as asteroidDate } from '../../helpers/filters'
 import { MaskOptions } from './enums/DateMaskOptions'
 
@@ -82,11 +81,10 @@ const currentDate = ref({})
 const dateObserver = ref(undefined)
 
 onMounted(() => {
-  console.log('TCL: MOUNTED: parentDate.value', parentDate.value)
   dateElement.value = parentDate.value?.$el
 
   // muda estilo da navegação
-  setNewNavigatorDisplay('OnMounted')
+  setNewNavigatorDisplay()
 
   // observa as mudanças no DOM do QDate > .q-date__content
   setObserveDate()
@@ -261,18 +259,26 @@ function getStatusDay ({ currentDay, index }) {
   return status
 }
 
-function getNormalizedYear ({ isNext, isPrevious, month, year }) {
-  if (isPrevious && month === 1) return year - 1
+function isJanuary (month) {
+  return month === 1
+}
 
-  if (isNext && month === 12) return year + 1
+function isDecember (month) {
+  return month === 12
+}
+
+function getNormalizedYear ({ isNext, isPrevious, month, year }) {
+  if (isPrevious && isJanuary(month)) return year - 1
+
+  if (isNext && isDecember(month)) return year + 1
 
   return year
 }
 
 function getNormalizedMonth ({ month, isPrevious, isNext }) {
-  if (isPrevious) return month === 1 ? (month = 12) : month - 1
+  if (isPrevious) return isJanuary(month) ? (month = 12) : month - 1
 
-  if (isNext) return month === 12 ? (month = 1) : month + 1
+  if (isNext) return isDecember(month) ? (month = 1) : month + 1
 
   return month
 }
@@ -375,9 +381,7 @@ function setEvents ({ year, month }) {
   })
 }
 
-function setNewNavigatorDisplay (from) {
-  console.log('TCL: setNewNavigatorDisplay -> from', from)
-  console.log('TCL: setNewNavigatorDisplay -> dateElement', dateElement)
+function setNewNavigatorDisplay () {
   const navigationElement = dateElement.value.querySelector('.q-date__navigation')
   const navigationChildren = navigationElement?.children || []
 
@@ -430,7 +434,7 @@ function onNavigation (date) {
 
   setCurrentDate(date)
 
-  nextTick(() => setNewNavigatorDisplay('onNavigation, nextTick'))
+  nextTick(() => setNewNavigatorDisplay())
 }
 </script>
 

--- a/ui/src/components/date/QasDate.vue
+++ b/ui/src/components/date/QasDate.vue
@@ -94,10 +94,11 @@ onUnmounted(() => dateObserver.value.disconnect())
 
 const dateElement = computed(() => parentDate.value?.$el)
 
-const styles = computed(() => (props.width && { width: props.width }))
 const classes = computed(() => {
   return ['qas-date', 'shadow-2', { 'qas-date--inative': props.useInactiveDates }]
 })
+
+const styles = computed(() => (props.width && { width: props.width }))
 
 const normalizedOptions = computed(() => {
   return props.useUnmaskOptions ? getUnmaskedList(props.options) : props.options

--- a/ui/src/components/date/QasDate.vue
+++ b/ui/src/components/date/QasDate.vue
@@ -73,11 +73,16 @@ const emits = defineEmits(['update:modelValue', 'navigation'])
 
 const attrs = useAttrs()
 
-const currentDate = ref({})
+// template refs
 const parentDate = ref(null)
+const dateElement = ref(null)
+
+const currentDate = ref({})
 const dateObserver = ref(undefined)
 
 onMounted(() => {
+  dateElement.value = parentDate.value?.$el
+
   // muda estilo da navegação
   setNewNavigatorDisplay('OnMounted')
 
@@ -92,8 +97,6 @@ onMounted(() => {
 })
 
 onUnmounted(() => dateObserver.value.disconnect())
-
-const dateElement = computed(() => parentDate.value?.$el)
 
 const classes = computed(() => {
   return ['qas-date', 'shadow-2', { 'qas-date--inative': props.useInactiveDates }]

--- a/ui/src/components/date/QasDate.vue
+++ b/ui/src/components/date/QasDate.vue
@@ -6,6 +6,7 @@
 </template>
 
 <script setup>
+/* eslint-disable no-console */
 import { date as asteroidDate } from '../../helpers/filters'
 import { MaskOptions } from './enums/DateMaskOptions'
 
@@ -78,7 +79,7 @@ const dateObserver = ref(undefined)
 
 onMounted(() => {
   // muda estilo da navegação
-  setNewNavigatorDisplay()
+  setNewNavigatorDisplay('OnMounted')
 
   // observa as mudanças no DOM do QDate > .q-date__content
   setObserveDate()
@@ -370,7 +371,9 @@ function setEvents ({ year, month }) {
   })
 }
 
-function setNewNavigatorDisplay () {
+function setNewNavigatorDisplay (from) {
+  console.log('TCL: setNewNavigatorDisplay -> from', from)
+  console.log('TCL: setNewNavigatorDisplay -> dateElement', dateElement)
   const navigationElement = dateElement.value.querySelector('.q-date__navigation')
   const navigationChildren = navigationElement?.children || []
 
@@ -423,7 +426,7 @@ function onNavigation (date) {
 
   setCurrentDate(date)
 
-  nextTick(() => setNewNavigatorDisplay())
+  nextTick(() => setNewNavigatorDisplay('onNavigation, nextTick'))
 }
 </script>
 

--- a/ui/src/components/date/QasDate.vue
+++ b/ui/src/components/date/QasDate.vue
@@ -1,7 +1,8 @@
 <template>
   <q-date
-    v-model="model"
     v-bind="attributes"
+    ref="parentDate"
+    v-model="model"
   />
 </template>
 
@@ -124,7 +125,6 @@ const attributes = computed(() => {
     minimal: true,
     multiple: props.multiple,
     options: normalizedOptions.value,
-    ref: 'parentDate',
     style: styles.value,
     textColor: 'white',
 

--- a/ui/src/components/date/QasDate.vue
+++ b/ui/src/components/date/QasDate.vue
@@ -81,6 +81,7 @@ const currentDate = ref({})
 const dateObserver = ref(undefined)
 
 onMounted(() => {
+  console.log('TCL: MOUNTED: parentDate.value', parentDate.value)
   dateElement.value = parentDate.value?.$el
 
   // muda estilo da navegação

--- a/ui/src/components/date/QasDate.vue
+++ b/ui/src/components/date/QasDate.vue
@@ -5,475 +5,424 @@
   />
 </template>
 
-<script>
-import { date } from 'quasar'
+<script setup>
 import { date as asteroidDate } from '../../helpers/filters'
+import { MaskOptions } from './enums/DateMaskOptions'
 
-const MaskOptions = {
-  Dash: 'YYYY-MM-DD',
-  Slash: 'YYYY/MM/DD',
-  SlashPtBR: 'DD/MM/YYYY',
-  SlashDateAndHourPtBR: 'DD/MM/YYYY HH:mm'
+import { date } from 'quasar'
+import { ref, computed, onMounted, onUnmounted, watch, useAttrs, nextTick } from 'vue'
+
+defineOptions({
+  name: 'QasDate',
+  inheritAttrs: false
+})
+
+const props = defineProps({
+  events: {
+    type: [Array, Function],
+    default: () => []
+  },
+
+  eventColor: {
+    type: [String, Function],
+    default: ''
+  },
+
+  mask: {
+    type: String,
+    default: MaskOptions.Dash,
+    validator: value => Object.values(MaskOptions).includes(value)
+  },
+
+  modelValue: {
+    type: [String, Array],
+    default: ''
+  },
+
+  multiple: {
+    type: Boolean
+  },
+
+  options: {
+    type: [Array, Function],
+    default: undefined
+  },
+
+  useIso: {
+    type: Boolean
+  },
+
+  useInactiveDates: {
+    default: true,
+    type: Boolean
+  },
+
+  useUnmaskOptions: {
+    default: true,
+    type: Boolean
+  },
+
+  width: {
+    type: String,
+    default: ''
+  }
+})
+
+const emits = defineEmits(['update:modelValue', 'navigation'])
+
+const attrs = useAttrs()
+
+const currentDate = ref({})
+const parentDate = ref(null)
+const dateObserver = ref(undefined)
+
+onMounted(() => {
+  // muda estilo da navegação
+  setNewNavigatorDisplay()
+
+  // observa as mudanças no DOM do QDate > .q-date__content
+  setObserveDate()
+
+  // seta data atual de acordo com a view do mês atual
+  setCurrentDate()
+
+  // seta os eventos, ativos e inativos
+  setEvents(currentDate.value)
+})
+
+onUnmounted(() => dateObserver.value.disconnect())
+
+const dateElement = computed(() => parentDate.value?.$el)
+
+const styles = computed(() => (props.width && { width: props.width }))
+const classes = computed(() => {
+  return ['qas-date', 'shadow-2', { 'qas-date--inative': props.useInactiveDates }]
+})
+
+const normalizedOptions = computed(() => {
+  return props.useUnmaskOptions ? getUnmaskedList(props.options) : props.options
+})
+
+const attributes = computed(() => {
+  const {
+    color,
+    minimal,
+    textColor,
+    ...restAttrs
+  } = attrs
+
+  return {
+    class: classes.value,
+    color: 'primary',
+    mask: props.mask,
+    minimal: true,
+    multiple: props.multiple,
+    options: normalizedOptions.value,
+    ref: 'parentDate',
+    style: styles.value,
+    textColor: 'white',
+
+    // events
+    onNavigation,
+
+    ...restAttrs
+  }
+})
+
+const model = computed({
+  get () {
+    return props.modelValue
+  },
+
+  set (value) {
+    emits('update:modelValue', props.useIso ? getISODate(value) : value)
+  }
+})
+
+const hasModelValue = computed(() => props.multiple ? !!props.modelValue.length : !!props.modelValue)
+
+const isEventColorCallback = computed(() => typeof props.eventColor === 'function')
+const isEventsCallback = computed(() => typeof props.events === 'function')
+
+watch(() => props.events, () => setEvents(currentDate.value))
+
+// functions
+function createActiveEventElement (dayElement, eventElement) {
+  const buttonElement = dayElement.querySelector('.q-btn__content')
+
+  buttonElement?.appendChild?.(eventElement)
 }
 
-export default {
-  name: 'QasDate',
+function createCounterInactiveEventElement (dayElement, eventElement) {
+  const spanElement = document.createElement('span')
+  const [child] = dayElement.children
 
-  inheritAttrs: false,
+  spanElement.setAttribute('data-event', true)
+  dayElement.setAttribute('data-has-inactive-event', true)
 
-  props: {
-    events: {
-      type: [Array, Function],
-      default: () => []
-    },
+  spanElement.classList.add('flex', 'items-center', 'justify-center', 'text-center')
 
-    eventColor: {
-      type: [String, Function],
-      default: ''
-    },
+  child.setAttribute('data-day-content', child.textContent)
 
-    mask: {
-      type: String,
-      default: MaskOptions.Dash,
-      validator: value => Object.values(MaskOptions).includes(value)
-    },
+  spanElement.appendChild(child)
+  spanElement.appendChild(eventElement)
+  dayElement.appendChild(spanElement)
+}
 
-    modelValue: {
-      type: [String, Array],
-      default: ''
-    },
+function createPointerEventElement (isInactive, currentColor, eventElement) {
+  const eventPointerElement = document.createElement('div')
 
-    multiple: {
-      type: Boolean
-    },
+  eventPointerElement.classList.add(
+    'qas-date__event-pointer',
+    `bg-${isInactive ? 'grey-4' : currentColor || 'primary'}`
+  )
 
-    options: {
-      type: [Array, Function],
-      default: undefined
-    },
+  eventElement.appendChild(eventPointerElement)
+}
 
-    useIso: {
-      type: Boolean
-    },
+function getCurrentColor (date, color) {
+  return (isEventColorCallback.value ? props.eventColor(date) : props.eventColor) || color
+}
 
-    useInactiveDates: {
-      default: true,
-      type: Boolean
-    },
+function getUnmaskedList (list) {
+  const invalidTypes = ['function', 'undefined']
 
-    useUnmaskEvents: {
-      default: true,
-      type: Boolean
-    },
+  return invalidTypes.includes(typeof list)
+    ? list
+    : list.map(item => asteroidDate(item, 'yyyy/MM/dd'))
+}
 
-    useUnmaskOptions: {
-      default: true,
-      type: Boolean
-    },
-
-    width: {
-      type: String,
-      default: ''
-    }
-  },
-
-  emits: [
-    'update:modelValue',
-    'navigation'
-  ],
-
-  data () {
-    return {
-      currentDate: {},
-      dateElement: null,
-      dateObserver: undefined
-    }
-  },
-
-  computed: {
-    attributes () {
-      const {
-        color,
-        minimal,
-        textColor,
-        ...attributes
-      } = this.$attrs
-
-      return {
-        class: this.classes,
-        color: 'primary',
-        mask: this.mask,
-        minimal: true,
-        multiple: this.multiple,
-        options: this.normalizedOptions,
-        ref: 'date',
-        style: this.styles,
-        textColor: 'white',
-
-        // events
-        onNavigation: this.onNavigation,
-
-        ...attributes
-      }
-    },
-
-    classes () {
-      return ['qas-date', 'shadow-2', { 'qas-date--inative': this.useInactiveDates }]
-    },
-
-    hasModelValue () {
-      return this.multiple ? !!this.modelValue.length : !!this.modelValue
-    },
-
-    isEventsCallback () {
-      return typeof this.events === 'function'
-    },
-
-    isEventColorCallback () {
-      return typeof this.eventColor === 'function'
-    },
-
-    model: {
-      get () {
-        return this.modelValue
-      },
-
-      set (value) {
-        this.$emit('update:modelValue', this.useIso ? this.getISODate(value) : value)
-      }
-    },
-
-    styles () {
-      return {
-        ...(this.width && { width: this.width })
-      }
-    },
-
-    normalizedOptions () {
-      return this.useUnmaskOptions ? this.getUnmaskedList(this.options) : this.options
-    }
-  },
-
-  watch: {
-    events () {
-      this.setEvents(this.currentDate)
-    }
-  },
-
-  mounted () {
-    this.dateElement = this.$refs.date.$el
-
-    // muda estilo da navegação
-    this.setNewNavigatorDisplay()
-
-    // observa as mudanças no DOM do QDate > .q-date__content
-    this.setObserveDate()
-
-    // seta data atual de acordo com a view do mês atual
-    this.setCurrentDate()
-
-    // seta os eventos, ativos e inativos
-    this.setEvents(this.currentDate)
-  },
-
-  unmounted () {
-    this.dateObserver.disconnect()
-  },
-
-  methods: {
-    createActiveEventElement (dayElement, eventElement) {
-      const buttonElement = dayElement.querySelector('.q-btn__content')
-
-      buttonElement?.appendChild?.(eventElement)
-    },
-
-    createCounterInactiveEventElement (dayElement, eventElement) {
-      const spanElement = document.createElement('span')
-      const [child] = dayElement.children
-
-      spanElement.setAttribute('data-event', true)
-      dayElement.setAttribute('data-has-inactive-event', true)
-
-      spanElement.classList.add('flex', 'items-center', 'justify-center', 'text-center')
-
-      child.setAttribute('data-day-content', child.textContent)
-
-      spanElement.appendChild(child)
-      spanElement.appendChild(eventElement)
-      dayElement.appendChild(spanElement)
-    },
-
-    createPointerEventElement (isInactive, currentColor, eventElement) {
-      const eventPointerElement = document.createElement('div')
-
-      eventPointerElement.classList.add(
-        'qas-date__event-pointer',
-        `bg-${isInactive ? 'grey-4' : currentColor || 'primary'}`
-      )
-
-      eventElement.appendChild(eventPointerElement)
-    },
-
-    getCurrentColor (date, color) {
-      return (
-        (this.isEventColorCallback ? this.eventColor(date) : this.eventColor) || color
-      )
-    },
-
-    getCurrentDate () {
-      const modelDate = this.multiple ? this.modelValue[0] : this.modelValue
-      const extractedDate = this.hasModelValue ? date.extractDate(modelDate, this.mask) : new Date()
-
-      return this.getDate(extractedDate)
-    },
-
-    getCurrentEvent (date) {
-      return this.events.find(event => event.date === date)
-    },
-
-    getDate (date) {
-      return {
-        year: date.getFullYear(),
-        month: date.getMonth() + 1,
-        day: date.getDate()
-      }
-    },
-
-    getEventColor (currentDate) {
-      if (!this.modelValue) return 'primary'
-
-      const model = this.multiple ? this.modelValue : [this.modelValue]
-
-      const extractedModel = model.filter(Boolean).map(dateItem => {
-        const extractedDate = date.extractDate(dateItem, this.mask)
-        return asteroidDate(extractedDate, 'yyyy/MM/dd')
-      })
-
-      return extractedModel.includes(currentDate) ? 'white' : 'primary'
-    },
-
-    getEventClasses (currentColor, hasCounter, isInactive) {
-      return [
-        'qas-date__event',
-
-        isInactive ? 'qas-date__event--inactive' : 'qas-date__event--active',
-
-        `text-${currentColor || (isInactive ? 'grey-4' : 'primary')}`,
-
-        hasCounter ? 'qas-date__event--counter' : 'qas-date__event--pointer'
-      ]
-    },
-
-    getISODate (value) {
-      if (!value || (this.multiple && !value.length)) return value
-
-      return this.multiple
-        ? value.map(dateItem => date.extractDate(dateItem, this.mask).toISOString())
-        : date.extractDate(value, this.mask).toISOString()
-    },
-
-    getUnmaskedList (list) {
-      const invalidTypes = ['function', 'undefined']
-
-      return invalidTypes.includes(typeof list)
-        ? list
-        : list.map(item => asteroidDate(item, 'yyyy/MM/dd'))
-    },
-
-    getStatusDay ({ currentDay, index }) {
-      const status = {
-        isPrevious: false,
-        isNext: false,
-        isActiveMonthDay: false
-      }
-
-      if (currentDay > index) {
-        status.isPrevious = true
-
-        return status
-      }
-
-      if (index - 7 > currentDay) {
-        status.isNext = true
-
-        return status
-      }
-
-      status.isActiveMonthDay = true
-
-      return status
-    },
-
-    getNormalizedYear ({ isNext, isPrevious, month, year }) {
-      if (isPrevious && month === 1) return year - 1
-
-      if (isNext && month === 12) return year + 1
-
-      return year
-    },
-
-    getNormalizedMonth ({ month, isPrevious, isNext }) {
-      if (isPrevious) return month === 1 ? (month = 12) : month - 1
-
-      if (isNext) return month === 12 ? (month = 1) : month + 1
-
-      return month
-    },
-
-    resetInactiveEvents () {
-      const inactiveElementsToRemove = this.dateElement.querySelectorAll('[data-has-inactive-event]')
-
-      inactiveElementsToRemove.forEach(inactiveElement => {
-        const [element] = inactiveElement.children
-
-        const hasDayContent = element.querySelector('[data-day-content]')
-
-        if (hasDayContent) inactiveElement.append(hasDayContent)
-      })
-    },
-
-    resetEvents () {
-      if (this.useInactiveDates) this.resetInactiveEvents()
-
-      this.resetActiveEvents()
-    },
-
-    resetActiveEvents () {
-      const elementsToRemove = this.dateElement.querySelectorAll('[data-event]')
-
-      elementsToRemove.forEach(nodeElement => nodeElement.remove())
-    },
-
-    setCurrentDate (date) {
-      this.currentDate = date || this.getCurrentDate()
-    },
-
-    setEventClasses (currentColor, eventElement, hasCounter, isInactive) {
-      const classes = this.getEventClasses(currentColor, hasCounter, isInactive)
-
-      eventElement.classList.add(...classes)
-    },
-
-    setEvents ({ year, month }) {
-      this.resetEvents()
-
-      if (!this.events.length || !year || !month) return
-
-      const daysElement = this.dateElement.querySelectorAll('.q-date__calendar-days .q-date__calendar-item')
-      const daysElementList = Array.from(daysElement)
-
-      daysElementList.forEach((dayElement, index) => {
-        const [child] = dayElement.children
-
-        const day = child.textContent
-
-        const { isActiveMonthDay, isNext, isPrevious } = this.getStatusDay({ currentDay: day, index: index + 1 })
-
-        const normalizedYear = this.getNormalizedYear({ isNext, month, isPrevious, year })
-        const normalizedMonth = this.getNormalizedMonth({ isNext, isPrevious, month })
-        const newDate = date.buildDate({ year: normalizedYear, month: normalizedMonth, day })
-        const normalizedDate = asteroidDate(newDate, 'yyyy-MM-dd')
-
-        const currentEvent = this.isEventsCallback ? this.events(normalizedDate) : this.getCurrentEvent(normalizedDate)
-
-        const hasDisabledClass = dayElement.classList.contains('q-date__calendar-item--out')
-        const isInactive = !isActiveMonthDay || hasDisabledClass
-
-        /*
-          * Se não tiver evento para o dia atual no loop ou
-          * a opção de eventos inativos estiver desabilitada e o dia atual do loop
-          * for referente ao mês anterior ou ao mês posterior, então retorna
-        */
-        if (!currentEvent || (!this.useInactiveDates && !isActiveMonthDay)) return
-
-        const hasCounter = currentEvent.counter
-
-        const currentColor = this.getCurrentColor(normalizedDate, currentEvent?.color)
-
-        const eventElement = document.createElement('div')
-
-        eventElement.setAttribute('data-event', true)
-
-        dayElement.classList.add('qas-date__calendar-item-event')
-
-        this.setEventClasses(currentColor, eventElement, hasCounter, isInactive)
-
-        if (hasCounter) {
-          this.setTextCountEvent(eventElement, currentEvent)
-        } else {
-          this.createPointerEventElement(isInactive, currentColor, eventElement)
-        }
-
-        if (isInactive) {
-          this.createCounterInactiveEventElement(dayElement, eventElement)
-
-          return
-        }
-
-        this.createActiveEventElement(dayElement, eventElement)
-      })
-    },
-
-    setNewNavigatorDisplay () {
-      const navigationElement = this.dateElement.querySelector('.q-date__navigation')
-      const navigationChildren = navigationElement?.children || []
-
-      const nodesList = Array.from(navigationChildren)
-
-      if (nodesList.length <= 2) return
-
-      const firstDivElement = document.createElement('div')
-      const secondDivElement = document.createElement('div')
-
-      firstDivElement.classList.add('flex')
-      secondDivElement.classList.add('flex')
-
-      const firstList = nodesList.slice(0, 3)
-      const secondList = nodesList.slice(3, 6)
-
-      const newFirstElement = navigationElement.appendChild(firstDivElement)
-      const newSecondElement = navigationElement.appendChild(secondDivElement)
-
-      this.$nextTick(() => firstList.forEach(node => newFirstElement.appendChild(node)))
-      this.$nextTick(() => secondList.forEach(node => newSecondElement.appendChild(node)))
-    },
-
-    setObserveDate () {
-      const element = this.dateElement.querySelector('.q-date__content')
-      const config = { childList: true, subtree: true }
-
-      const callback = mutationList => {
-        mutationList.forEach(({ removedNodes, target }) => {
-          const [removedNode] = removedNodes
-
-          if (!removedNode) return
-
-          const hasCalendarDaysContainer = target.classList.contains('q-date__calendar-days-container')
-          const hasContent = target.classList.contains('q-date__content')
-          const hasMonths = removedNode.classList.contains('q-date__months')
-
-          if (hasCalendarDaysContainer || (hasContent && hasMonths)) {
-            this.setEvents(this.currentDate)
-          }
-        })
-      }
-
-      this.dateObserver = new MutationObserver(callback)
-      this.dateObserver.observe(element, config)
-    },
-
-    setTextCountEvent (eventElement, currentEvent) {
-      eventElement.innerText = `(${currentEvent.counter})`
-    },
-
-    async onNavigation (date) {
-      this.$emit('navigation', date)
-
-      this.setCurrentDate(date)
-
-      this.$nextTick(() => this.setNewNavigatorDisplay())
-    }
+function getDate (date) {
+  return {
+    year: date.getFullYear(),
+    month: date.getMonth() + 1,
+    day: date.getDate()
   }
+}
+
+function getISODate (value) {
+  if (!value || (props.multiple && !value.length)) return value
+
+  return props.multiple
+    ? value.map(dateItem => date.extractDate(dateItem, props.mask).toISOString())
+    : date.extractDate(value, props.mask).toISOString()
+}
+
+function getCurrentDate () {
+  const modelDate = props.multiple ? props.modelValue[0] : props.modelValue
+  const extractedDate = hasModelValue.value ? date.extractDate(modelDate, props.mask) : new Date()
+
+  return getDate(extractedDate)
+}
+
+function getCurrentEvent (date) {
+  return props.events.find(event => event.date === date)
+}
+
+function getEventClasses (currentColor, hasCounter, isInactive) {
+  return [
+    'qas-date__event',
+
+    isInactive ? 'qas-date__event--inactive' : 'qas-date__event--active',
+
+    `text-${currentColor || (isInactive ? 'grey-4' : 'primary')}`,
+
+    hasCounter ? 'qas-date__event--counter' : 'qas-date__event--pointer'
+  ]
+}
+
+function getStatusDay ({ currentDay, index }) {
+  const status = {
+    isPrevious: false,
+    isNext: false,
+    isActiveMonthDay: false
+  }
+
+  if (currentDay > index) {
+    status.isPrevious = true
+
+    return status
+  }
+
+  if (index - 7 > currentDay) {
+    status.isNext = true
+
+    return status
+  }
+
+  status.isActiveMonthDay = true
+
+  return status
+}
+
+function getNormalizedYear ({ isNext, isPrevious, month, year }) {
+  if (isPrevious && month === 1) return year - 1
+
+  if (isNext && month === 12) return year + 1
+
+  return year
+}
+
+function getNormalizedMonth ({ month, isPrevious, isNext }) {
+  if (isPrevious) return month === 1 ? (month = 12) : month - 1
+
+  if (isNext) return month === 12 ? (month = 1) : month + 1
+
+  return month
+}
+
+function resetActiveEvents () {
+  const elementsToRemove = dateElement.value.querySelectorAll('[data-event]')
+
+  elementsToRemove.forEach(nodeElement => nodeElement.remove())
+}
+
+function resetInactiveEvents () {
+  const inactiveElementsToRemove = dateElement.value.querySelectorAll('[data-has-inactive-event]')
+
+  inactiveElementsToRemove.forEach(inactiveElement => {
+    const [element] = inactiveElement.children
+
+    const hasDayContent = element.querySelector('[data-day-content]')
+
+    if (hasDayContent) inactiveElement.append(hasDayContent)
+  })
+}
+
+function resetEvents () {
+  if (props.useInactiveDates) resetInactiveEvents()
+
+  resetActiveEvents()
+}
+
+function setCurrentDate (date) {
+  currentDate.value = date || getCurrentDate()
+}
+
+function setEventClasses (currentColor, eventElement, hasCounter, isInactive) {
+  const classes = getEventClasses(currentColor, hasCounter, isInactive)
+
+  eventElement.classList.add(...classes)
+}
+
+function setTextCountEvent (eventElement, currentEvent) {
+  eventElement.innerText = `(${currentEvent.counter})`
+}
+
+function setEvents ({ year, month }) {
+  resetEvents()
+
+  if (!props.events.length || !year || !month) return
+
+  const daysElement = dateElement.value.querySelectorAll('.q-date__calendar-days .q-date__calendar-item')
+  const daysElementList = Array.from(daysElement)
+
+  daysElementList.forEach((dayElement, index) => {
+    const [child] = dayElement.children
+
+    const day = child.textContent
+
+    const { isActiveMonthDay, isNext, isPrevious } = getStatusDay({ currentDay: day, index: index + 1 })
+
+    const normalizedYear = getNormalizedYear({ isNext, month, isPrevious, year })
+    const normalizedMonth = getNormalizedMonth({ isNext, isPrevious, month })
+    const newDate = date.buildDate({ year: normalizedYear, month: normalizedMonth, day })
+    const normalizedDate = asteroidDate(newDate, 'yyyy-MM-dd')
+
+    const currentEvent = isEventsCallback.value ? props.events(normalizedDate) : getCurrentEvent(normalizedDate)
+
+    const hasDisabledClass = dayElement.classList.contains('q-date__calendar-item--out')
+    const isInactive = !isActiveMonthDay || hasDisabledClass
+
+    /*
+      * Se não tiver evento para o dia atual no loop ou
+      * a opção de eventos inativos estiver desabilitada e o dia atual do loop
+      * for referente ao mês anterior ou ao mês posterior, então retorna
+    */
+    if (!currentEvent || (!props.useInactiveDates && !isActiveMonthDay)) return
+
+    const hasCounter = currentEvent.counter
+
+    const currentColor = getCurrentColor(normalizedDate, currentEvent?.color)
+
+    const eventElement = document.createElement('div')
+
+    eventElement.setAttribute('data-event', true)
+
+    dayElement.classList.add('qas-date__calendar-item-event')
+
+    setEventClasses(currentColor, eventElement, hasCounter, isInactive)
+
+    if (hasCounter) {
+      setTextCountEvent(eventElement, currentEvent)
+    } else {
+      createPointerEventElement(isInactive, currentColor, eventElement)
+    }
+
+    if (isInactive) {
+      createCounterInactiveEventElement(dayElement, eventElement)
+
+      return
+    }
+
+    createActiveEventElement(dayElement, eventElement)
+  })
+}
+
+function setNewNavigatorDisplay () {
+  const navigationElement = dateElement.value.querySelector('.q-date__navigation')
+  const navigationChildren = navigationElement?.children || []
+
+  const nodesList = Array.from(navigationChildren)
+
+  if (nodesList.length <= 2) return
+
+  const firstDivElement = document.createElement('div')
+  const secondDivElement = document.createElement('div')
+
+  firstDivElement.classList.add('flex')
+  secondDivElement.classList.add('flex')
+
+  const firstList = nodesList.slice(0, 3)
+  const secondList = nodesList.slice(3, 6)
+
+  const newFirstElement = navigationElement.appendChild(firstDivElement)
+  const newSecondElement = navigationElement.appendChild(secondDivElement)
+
+  nextTick(() => firstList.forEach(node => newFirstElement.appendChild(node)))
+  nextTick(() => secondList.forEach(node => newSecondElement.appendChild(node)))
+}
+
+function setObserveDate () {
+  const element = dateElement.value.querySelector('.q-date__content')
+  const config = { childList: true, subtree: true }
+
+  const callback = mutationList => {
+    mutationList.forEach(({ removedNodes, target }) => {
+      const [removedNode] = removedNodes
+
+      if (!removedNode) return
+
+      const hasCalendarDaysContainer = target.classList.contains('q-date__calendar-days-container')
+      const hasContent = target.classList.contains('q-date__content')
+      const hasMonths = removedNode.classList.contains('q-date__months')
+
+      if (hasCalendarDaysContainer || (hasContent && hasMonths)) {
+        setEvents(currentDate.value)
+      }
+    })
+  }
+
+  dateObserver.value = new MutationObserver(callback)
+  dateObserver.value.observe(element, config)
+}
+
+function onNavigation (date) {
+  emits('navigation', date)
+
+  setCurrentDate(date)
+
+  nextTick(() => setNewNavigatorDisplay())
 }
 </script>
 

--- a/ui/src/components/date/QasDate.yml
+++ b/ui/src/components/date/QasDate.yml
@@ -45,11 +45,6 @@ props:
     default: true
     type: Boolean
 
-  use-unmask-events:
-    desc: A propriedade 'events' do Quasar só funciona com a formatação '/' mesmo que seja passada uma outra máscara. Esta propriedade transforma a formatação da propriedade 'events' de '-' em '/' (mas só funciona caso 'events' seja um Array).
-    default: true
-    type: Boolean
-
   use-unmask-options:
     desc: A propriedade 'options' do Quasar só funciona com a formatação '/' mesmo que seja passada uma outra máscara. Esta propriedade transforma a formatação da propriedade 'options' de '-' em '/' (mas só funciona caso 'options' seja um Array).
     default: true

--- a/ui/src/components/date/enums/DateMaskOptions.js
+++ b/ui/src/components/date/enums/DateMaskOptions.js
@@ -1,0 +1,6 @@
+export const MaskOptions = {
+  Dash: 'YYYY-MM-DD',
+  Slash: 'YYYY/MM/DD',
+  SlashPtBR: 'DD/MM/YYYY',
+  SlashDateAndHourPtBR: 'DD/MM/YYYY HH:mm'
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Modificado
- `QasDate`: alterado componente para Composition API.

### Removido
- `QasDate`: removido propriedade `useUnmaskEvents`, uma vez que ela não era utilizada para nada dentro do componente.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [x] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
