### PR TITLE
Refactor QasDebugger to Composition API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `QasDebugger`: alterado componente para Composition API.
+
 ## [3.14.0-beta.0] - 03-01-2024
 ### Corrigido
 - `QasAppUSer`: corrigido select de empresa quando o select possuía busca, que ao clicar no botão de limpar, não limpava e ainda tentava alterar o vinculo para um vinculo vazio.

--- a/ui/src/components/debugger/QasDebugger.vue
+++ b/ui/src/components/debugger/QasDebugger.vue
@@ -1,23 +1,31 @@
 <template>
-  <details class="bg-grey-3 q-my-md q-pa-md rounded-borders">
+  <details class="bg-grey-3 q-my-md q-pa-md qas-debugger rounded-borders">
     <summary>Debugger</summary>
 
     <div class="row">
-      <pre v-for="(item, index) in inspect" :key="index" class="col q-pa-sm scroll" style="max-height: 300px;">{{ item }}</pre>
+      <pre v-for="(item, index) in props.inspect" :key="index" class="col q-pa-sm qas-debugger__code scroll">
+        {{ item }}
+      </pre>
     </div>
   </details>
 </template>
 
-<script>
-export default {
-  name: 'QasDebugger',
+<script setup>
+defineOptions({ name: 'QasDebugger' })
 
-  props: {
-    inspect: {
-      default: () => [],
-      required: true,
-      type: Array
-    }
+const props = defineProps({
+  inspect: {
+    default: () => [],
+    required: true,
+    type: Array
+  }
+})
+</script>
+
+<style lang="scss">
+.qas-debugger {
+  &__code {
+    max-height: 300px;
   }
 }
-</script>
+</style>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Modificado
- `QasDebugger`: alterado componente para Composition API.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
