### PR TITLE
Refactor QasDelete to Compositon API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `QasDelete`: alterado componente para Composition API.
+
 ## [3.14.0-beta.0] - 03-01-2024
 ### Corrigido
 - `QasAppUSer`: corrigido select de empresa quando o select possuía busca, que ao clicar no botão de limpar, não limpava e ainda tentava alterar o vinculo para um vinculo vazio.

--- a/ui/src/components/delete/QasDelete.vue
+++ b/ui/src/components/delete/QasDelete.vue
@@ -1,110 +1,99 @@
 <template>
-  <component v-bind="attributes" :is="tag" @click.stop.prevent="onDelete">
+  <component v-bind="attributes" :is="props.tag" @click.stop.prevent="onDelete">
     <template v-for="(_, name) in $slots" #[name]="context">
       <slot :name="name" v-bind="context || {}" />
     </template>
   </component>
 </template>
 
-<script>
-import QasBtn from '../btn/QasBtn.vue'
+<script setup>
+import { inject, computed, useAttrs } from 'vue'
+import { useRoute } from 'vue-router'
 
-export default {
+defineOptions({
   name: 'QasDelete',
+  inheritAttrs: false
+})
 
-  components: {
-    QasBtn
+const props = defineProps({
+  customId: {
+    default: '',
+    type: [Number, String]
   },
 
-  inheritAttrs: false,
-
-  props: {
-    customId: {
-      default: '',
-      type: [Number, String]
-    },
-
-    dialogProps: {
-      default: () => ({}),
-      type: Object
-    },
-
-    entity: {
-      required: true,
-      type: String
-    },
-
-    tag: {
-      default: 'qas-btn',
-      type: String
-    },
-
-    url: {
-      default: '',
-      type: String
-    },
-
-    deleting: {
-      type: Boolean
-    },
-
-    useAutoDeleteRoute: {
-      default: true,
-      type: Boolean
-    },
-
-    redirectRoute: {
-      type: [Object, String],
-      default: ''
-    }
+  dialogProps: {
+    default: () => ({}),
+    type: Object
   },
 
-  emits: [
-    'success',
-    'error',
-    'update:deleting'
-  ],
-
-  computed: {
-    attributes () {
-      return {
-        ...this.$attrs,
-        color: this.isButton ? 'grey-10' : this.$attrs.color
-      }
-    },
-
-    id () {
-      return this.customId || this.$route.params.id
-    },
-
-    isButton () {
-      return this.tag === 'qas-btn'
-    }
+  entity: {
+    required: true,
+    type: String
   },
 
-  methods: {
-    onDelete () {
-      this.$qas.delete({
-        deleteActionParams: {
-          entity: this.entity,
-          id: this.id,
-          url: this.url
-        },
+  tag: {
+    default: 'qas-btn',
+    type: String
+  },
 
-        dialogProps: this.dialogProps,
+  url: {
+    default: '',
+    type: String
+  },
 
-        useAutoDeleteRoute: this.useAutoDeleteRoute,
+  deleting: {
+    type: Boolean
+  },
 
-        redirectRoute: this.redirectRoute,
+  useAutoDeleteRoute: {
+    default: true,
+    type: Boolean
+  },
 
-        // callbacks
-        onDelete: isDeleting => this.$emit('update:deleting', isDeleting),
-
-        onDeleteError: error => this.$emit('error', error),
-
-        onDeleteSuccess: response => this.$emit('success', response)
-      })
-    }
+  redirectRoute: {
+    type: [Object, String],
+    default: ''
   }
+})
+
+const emits = defineEmits(['success', 'error', 'update:deleting'])
+
+const attrs = useAttrs()
+const route = useRoute()
+
+// global
+const qas = inject('qas')
+
+const id = computed(() => props.customId || route.params.id)
+const isButton = computed(() => props.tag === 'qas-btn')
+
+const attributes = computed(() => {
+  return {
+    ...attrs,
+    color: isButton.value ? 'grey-10' : attrs.color
+  }
+})
+
+function onDelete () {
+  qas.delete({
+    deleteActionParams: {
+      entity: props.entity,
+      id: id.value,
+      url: props.url
+    },
+
+    dialogProps: props.dialogProps,
+
+    useAutoDeleteRoute: props.useAutoDeleteRoute,
+
+    redirectRoute: props.redirectRoute,
+
+    // callbacks
+    onDelete: isDeleting => emits('update:deleting', isDeleting),
+
+    onDeleteError: error => emits('error', error),
+
+    onDeleteSuccess: response => emits('success', response)
+  })
 }
 </script>

--- a/ui/src/components/delete/QasDelete.vue
+++ b/ui/src/components/delete/QasDelete.vue
@@ -1,13 +1,13 @@
 <template>
   <component v-bind="attributes" :is="props.tag" @click.stop.prevent="onDelete">
-    <template v-for="(_, name) in $slots" #[name]="context">
+    <template v-for="(_, name) in slots" #[name]="context">
       <slot :name="name" v-bind="context || {}" />
     </template>
   </component>
 </template>
 
 <script setup>
-import { inject, computed, useAttrs } from 'vue'
+import { inject, computed, useAttrs, useSlots } from 'vue'
 import { useRoute } from 'vue-router'
 
 defineOptions({
@@ -58,6 +58,8 @@ const props = defineProps({
 
 const emits = defineEmits(['success', 'error', 'update:deleting'])
 
+const slots = useSlots()
+console.log('TCL: slots', slots)
 const attrs = useAttrs()
 const route = useRoute()
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Modificado
- `QasDelete`: alterado componente para Composition API.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
