### PR TITLE
Refactor QasGallery to Composition API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `QasGallery`: alterado componente para Composition API.
+- `/ui/src/vue-plugin.js`: adicionado método `getAction` do `@bildvitta/store-adapter` na variável global `qas` para conseguir utiliza-lo no composition API (NÃO UTILIZAR NO PROJETO).
+
 ## [3.14.0-beta.0] - 03-01-2024
 ### Corrigido
 - `QasAppUSer`: corrigido select de empresa quando o select possuía busca, que ao clicar no botão de limpar, não limpava e ainda tentava alterar o vinculo para um vinculo vazio.

--- a/ui/src/components/gallery/composables/use-delete.js
+++ b/ui/src/components/gallery/composables/use-delete.js
@@ -1,0 +1,54 @@
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+
+export const baseProps = {
+  customId: {
+    default: '',
+    type: [Number, String]
+  },
+
+  dialogProps: {
+    default: () => ({}),
+    type: Object
+  },
+
+  entity: {
+    default: '',
+    type: String
+  },
+
+  url: {
+    default: '',
+    type: String
+  }
+}
+
+export default function useDelete ({ props, destroyFn, emit }) {
+  const route = useRoute()
+
+  const defaultDialogProps = computed(() => {
+    return {
+      card: {
+        description: 'Tem certeza que deseja excluir este item?'
+      },
+
+      ok: {
+        label: 'Excluir',
+        onClick: destroyFn
+      },
+
+      cancel: {
+        onClick: () => emit('cancel')
+      },
+
+      ...props.dialogProps
+    }
+  })
+
+  const id = computed(() => props.customId || route.params.id)
+
+  return {
+    defaultDialogProps,
+    id
+  }
+}

--- a/ui/src/components/gallery/private/PvGalleryCarouselDialog.vue
+++ b/ui/src/components/gallery/private/PvGalleryCarouselDialog.vue
@@ -8,9 +8,9 @@
       </template>
 
       <template #description>
-        <q-carousel v-model="imageIndexModel" animated :arrows="!$qas.screen.isSmall" class="pv-gallery-carousel-dialog__carousel" control-text-color="primary" data-cy="gallery-carousel" :fullscreen="$qas.screen.isSmall" :height="carouselImageHeight" next-icon="sym_r_chevron_right" prev-icon="sym_r_chevron_left" swipeable :thumbnails="!isSingleImage">
-          <q-carousel-slide v-for="(image, index) in images" :key="index" class="bg-no-repeat bg-size-contain" :data-cy="`gallery-carousel-slide-${index}`" :img-src="image.url" :name="index">
-            <div v-if="$qas.screen.isSmall" class="full-width justify-end row">
+        <q-carousel v-model="imageIndexModel" animated :arrows="!screen.isSmall" class="pv-gallery-carousel-dialog__carousel" control-text-color="primary" data-cy="gallery-carousel" :fullscreen="screen.isSmall" :height="carouselImageHeight" next-icon="sym_r_chevron_right" prev-icon="sym_r_chevron_left" swipeable :thumbnails="!isSingleImage">
+          <q-carousel-slide v-for="(image, index) in props.images" :key="index" class="bg-no-repeat bg-size-contain" :data-cy="`gallery-carousel-slide-${index}`" :img-src="image.url" :name="index">
+            <div v-if="screen.isSmall" class="full-width justify-end row">
               <qas-btn color="grey-10" icon="sym_r_close" variant="tertiary" @click="close" />
             </div>
           </q-carousel-slide>
@@ -20,66 +20,59 @@
   </div>
 </template>
 
-<script>
-export default {
-  name: 'PvGalleryCarouselDialog',
+<script setup>
+import { useScreen } from '../../../composables'
 
-  props: {
-    images: {
-      type: Array,
-      default: () => []
-    },
+import { computed } from 'vue'
 
-    imageIndex: {
-      type: Number,
-      default: 0
-    },
+defineOptions({ name: 'PvGalleryCarouselDialog' })
 
-    modelValue: {
-      type: Boolean
-    }
+const props = defineProps({
+  images: {
+    type: Array,
+    default: () => []
   },
 
-  emits: [
-    'update:modelValue',
-    'update:imageIndex'
-  ],
-
-  computed: {
-    model: {
-      get () {
-        return this.modelValue
-      },
-
-      set (value) {
-        return this.$emit('update:modelValue', value)
-      }
-    },
-
-    imageIndexModel: {
-      get () {
-        return this.imageIndex
-      },
-
-      set (value) {
-        return this.$emit('update:imageIndex', value)
-      }
-    },
-
-    carouselImageHeight () {
-      return 'calc((500/976) * 100vh)'
-    },
-
-    isSingleImage () {
-      return this.images.length === 1
-    }
+  imageIndex: {
+    type: Number,
+    default: 0
   },
 
-  methods: {
-    close () {
-      this.$emit('update:modelValue', false)
-    }
+  modelValue: {
+    type: Boolean
   }
+})
+
+const emit = defineEmits(['update:modelValue', 'update:imageIndex'])
+
+const screen = useScreen()
+
+const carouselImageHeight = 'calc((500/976) * 100vh)'
+
+const model = computed({
+  get () {
+    return props.modelValue
+  },
+
+  set (value) {
+    emit('update:modelValue', value)
+  }
+})
+
+const imageIndexModel = computed({
+  get () {
+    return props.imageIndex
+  },
+
+  set (value) {
+    return emit('update:imageIndex', value)
+  }
+})
+
+const isSingleImage = props.images.length === 1
+
+function close () {
+  emit('update:modelValue', false)
 }
 </script>
 

--- a/ui/src/vue-plugin.js
+++ b/ui/src/vue-plugin.js
@@ -64,6 +64,8 @@ import QasWelcome from './components/welcome/QasWelcome.vue'
 
 import { Notify, Loading, Quasar, Dialog as QuasarDialog } from 'quasar'
 
+import { getAction } from '@bildvitta/store-adapter'
+
 // Plugins
 import {
   Delete,
@@ -156,7 +158,9 @@ async function install (app) {
   }
 
   app.provide('qas', {
-    delete: params => Delete.call(app.config.globalProperties, params)
+    delete: params => Delete.call(app.config.globalProperties, params),
+
+    getAction: params => getAction.call(app.config.globalProperties, params)
   })
 
   app.directive(Test.name, Test)


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Modificado
- `QasGallery`: alterado componente para Composition API.
- `/ui/src/vue-plugin.js`: adicionado método `getAction` do `@bildvitta/store-adapter` na variável global `qas` para conseguir utiliza-lo no composition API (NÃO UTILIZAR NO PROJETO).

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
