### PR TITLE
Refactor QasGalleryCard to Composition API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `QasGalleryCard`: alterado componente para Composition API.
+
 ## [3.14.0-beta.0] - 03-01-2024
 ### Corrigido
 - `QasAppUSer`: corrigido select de empresa quando o select possuía busca, que ao clicar no botão de limpar, não limpava e ainda tentava alterar o vinculo para um vinculo vazio.

--- a/ui/src/components/gallery-card/QasGalleryCard.vue
+++ b/ui/src/components/gallery-card/QasGalleryCard.vue
@@ -3,8 +3,8 @@
     <header class="flat items-center no-wrap row" :class="headerClasses">
       <slot name="header">
         <div class="ellipsis q-mr-xs qas-gallery__name text-subtitle1">
-          <slot v-if="card.name" name="name">
-            {{ card.name }}
+          <slot v-if="props.card.name" name="name">
+            {{ props.card.name }}
           </slot>
         </div>
 
@@ -18,19 +18,19 @@
 
     <div class="qas-gallery-card__image">
       <slot name="image">
-        <q-img class="rounded-borders" height="100%" :src="card.url" v-bind="imageProps">
+        <q-img class="rounded-borders" height="100%" :src="props.card.url" v-bind="props.imageProps">
           <template #error>
             <div :class="errorClasses">
               <div class="text-center">
                 <slot name="image-error-icon">
-                  <div v-if="errorIcon">
-                    <q-icon :name="errorIcon" size="sm" />
+                  <div v-if="props.errorIcon">
+                    <q-icon :name="props.errorIcon" size="sm" />
                   </div>
                 </slot>
 
                 <slot name="image-error">
                   <div>
-                    {{ errorMessage }}
+                    {{ props.errorMessage }}
                   </div>
                 </slot>
               </div>
@@ -42,112 +42,99 @@
 
     <div v-if="hasBottom" class="q-mt-md">
       <slot name="bottom">
-        <qas-grid-generator v-if="hasGridGenerator" v-bind="gridGeneratorProps" />
+        <qas-grid-generator v-if="hasGridGenerator" v-bind="props.gridGeneratorProps" />
       </slot>
     </div>
   </div>
 </template>
 
-<script>
-export default {
-  name: 'QasGalleryCard',
+<script setup>
+import { computed, useSlots } from 'vue'
 
-  props: {
-    actionsMenuProps: {
-      type: Object,
-      default: () => ({})
-    },
+defineOptions({ name: 'QasGalleryCard' })
 
-    card: {
-      type: Object,
-      default: () => ({})
-    },
-
-    disable: {
-      type: Boolean
-    },
-
-    errorIcon: {
-      type: String,
-      default: ''
-    },
-
-    errorMessage: {
-      type: String,
-      default: ''
-    },
-
-    gridGeneratorProps: {
-      type: Object,
-      default: () => ({})
-    },
-
-    imageProps: {
-      type: Object,
-      default: () => ({})
-    }
+const props = defineProps({
+  actionsMenuProps: {
+    type: Object,
+    default: () => ({})
   },
 
-  computed: {
-    classes () {
-      return {
-        'text-grey-6': this.disable
-      }
-    },
+  card: {
+    type: Object,
+    default: () => ({})
+  },
 
-    defaultActionsMenuProps () {
-      const { buttonProps } = this.actionsMenuProps
+  disable: {
+    type: Boolean
+  },
 
-      return {
-        useLabel: false,
-        ...this.actionsMenuProps,
+  errorIcon: {
+    type: String,
+    default: ''
+  },
 
-        buttonProps: {
-          disable: this.disable,
-          ...buttonProps
-        }
-      }
-    },
+  errorMessage: {
+    type: String,
+    default: ''
+  },
 
-    hasActions () {
-      return !!Object.keys(this.actionsMenuProps).length || this.hasActionsSlot
-    },
+  gridGeneratorProps: {
+    type: Object,
+    default: () => ({})
+  },
 
-    hasActionsSlot () {
-      return !!this.$slots.actions
-    },
+  imageProps: {
+    type: Object,
+    default: () => ({})
+  }
+})
 
-    hasBottom () {
-      return !!this.$slots.bottom || this.hasGridGenerator
-    },
+const slots = useSlots()
 
-    hasGridGenerator () {
-      return !!Object.keys(this.gridGeneratorProps).length
-    },
+const errorClasses = [
+  'bg-grey-4',
+  'flex',
+  'full-height',
+  'full-width',
+  'items-center',
+  'justify-center',
+  'text-grey-10',
+  'text-subtitle2'
+]
 
-    headerClasses () {
-      return {
-        'justify-between': this.card.name,
-        'justify-right': !this.card.name,
-        'text-grey-10': !this.disable,
-        'q-mb-md': this.hasActions || this.card.name
-      }
-    },
+const classes = computed(() => {
+  return {
+    'text-grey-6': props.disable
+  }
+})
 
-    errorClasses () {
-      return [
-        'bg-grey-4',
-        'flex',
-        'full-height',
-        'full-width',
-        'items-center',
-        'justify-center',
-        'text-grey-10',
-        'text-subtitle2'
-      ]
+const headerClasses = computed(() => {
+  return {
+    'justify-between': props.card.name,
+    'justify-right': !props.card.name,
+    'text-grey-10': !props.disable,
+    'q-mb-md': hasActions.value || props.card.name
+  }
+})
+
+const defaultActionsMenuProps = computed(() => {
+  const { buttonProps } = props.actionsMenuProps
+
+  return {
+    useLabel: false,
+    ...props.actionsMenuProps,
+
+    buttonProps: {
+      disable: props.disable,
+      ...buttonProps
     }
   }
-}
+})
+
+const hasActionsSlot = computed(() => !!slots.actions)
+const hasActions = computed(() => !!Object.keys(props.actionsMenuProps).length || hasActionsSlot.value)
+const hasGridGenerator = computed(() => !!Object.keys(props.gridGeneratorProps).length)
+const hasBottom = computed(() => !!slots.bottom || hasGridGenerator.value)
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Modificado
- `QasGalleryCard`: alterado componente para Composition API.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
