### PR TITLE
Refactor QasLabel to Composition API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `QasLabel`: alterado componente para Composition API.
+
 ## [3.14.0-beta.0] - 03-01-2024
 ### Corrigido
 - `QasAppUSer`: corrigido select de empresa quando o select possuía busca, que ao clicar no botão de limpar, não limpava e ainda tentava alterar o vinculo para um vinculo vazio.

--- a/ui/src/components/label/QasLabel.vue
+++ b/ui/src/components/label/QasLabel.vue
@@ -4,70 +4,58 @@
   </div>
 </template>
 
-<script>
-import { addCounterSuffix, getRequiredLabel } from '../../helpers'
+<script setup>
 import { Spacing } from '../../enums/Spacing'
+import { addCounterSuffix, getRequiredLabel } from '../../helpers'
 
-export default {
-  name: 'QasLabel',
+import { computed } from 'vue'
 
-  props: {
-    color: {
-      type: String,
-      default: 'grey-10'
-    },
+defineOptions({ name: 'QasLabel' })
 
-    count: {
-      default: 0,
-      type: [Number, String]
-    },
-
-    label: {
-      default: '',
-      type: String
-    },
-
-    margin: {
-      default: Spacing.Md,
-      type: String,
-      validator: value => {
-        const availableSpacings = Object.values(Spacing)
-
-        return availableSpacings.includes(value)
-      }
-    },
-
-    required: {
-      type: Boolean
-    },
-
-    typography: {
-      default: 'h4',
-      type: String,
-      validator: value => {
-        const availableTypography = ['h4', 'h5']
-
-        return availableTypography.includes(value)
-      }
-    }
+const props = defineProps({
+  color: {
+    type: String,
+    default: 'grey-10'
   },
 
-  computed: {
-    labelWithSuffix () {
-      return addCounterSuffix(this.label, parseFloat(this.count))
-    },
+  count: {
+    default: 0,
+    type: [Number, String]
+  },
 
-    formattedLabel () {
-      return getRequiredLabel({ label: this.labelWithSuffix, required: this.required })
-    },
+  label: {
+    default: '',
+    type: String
+  },
 
-    classes () {
-      return [
-        `q-mb-${this.margin}`,
-        `text-${this.color}`,
-        `text-${this.typography}`
-      ]
-    }
+  margin: {
+    default: Spacing.Md,
+    type: String,
+    validator: value => Object.values(Spacing).includes(value)
+  },
+
+  required: {
+    type: Boolean
+  },
+
+  typography: {
+    default: 'h4',
+    type: String,
+    validator: value => ['h4', 'h5'].includes(value)
   }
-}
+})
+
+const classes = computed(() => {
+  return [
+    `q-mb-${props.margin}`,
+    `text-${props.color}`,
+    `text-${props.typography}`
+  ]
+})
+
+const labelWithSuffix = computed(() => addCounterSuffix(props.label, parseFloat(props.count)))
+
+const formattedLabel = computed(() => {
+  return getRequiredLabel({ label: labelWithSuffix.value, required: props.required })
+})
 </script>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Modificado
- `QasLabel`: alterado componente para Composition API.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
