### PR TITLE
Refactor QasTabsGenerator to Composition API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `QasTabsGenerator`: alterado componente para Composition API.
+
 ## [3.14.0-beta.0] - 03-01-2024
 ### Corrigido
 - `QasAppUSer`: corrigido select de empresa quando o select possuía busca, que ao clicar no botão de limpar, não limpava e ainda tentava alterar o vinculo para um vinculo vazio.

--- a/ui/src/components/tabs-generator/QasTabsGenerator.vue
+++ b/ui/src/components/tabs-generator/QasTabsGenerator.vue
@@ -18,92 +18,84 @@
   </div>
 </template>
 
-<script>
+<script setup>
 import QasStatus from '../status/QasStatus.vue'
 
+import { computed } from 'vue'
 import { extend } from 'quasar'
 
-export default {
-  name: 'QasTabsGenerator',
+defineOptions({ name: 'QasTabsGenerator' })
 
-  components: {
-    QasStatus
+const props = defineProps({
+  counters: {
+    default: () => ({}),
+    type: Object
   },
 
-  props: {
-    counters: {
-      default: () => ({}),
-      type: Object
-    },
-
-    modelValue: {
-      default: '',
-      type: [String, Number]
-    },
-
-    tabs: {
-      default: () => ({}),
-      required: true,
-      type: [Object, Array]
-    },
-
-    useRouteTab: {
-      type: Boolean
-    }
+  modelValue: {
+    default: '',
+    type: [String, Number]
   },
 
-  emits: ['update:modelValue'],
-
-  computed: {
-    formattedTabs () {
-      const tabs = extend(true, {}, this.tabs)
-
-      for (const key in tabs) {
-        if (typeof tabs[key] === 'string') {
-          tabs[key] = { label: tabs[key], value: key }
-        }
-      }
-
-      return tabs
-    },
-
-    model: {
-      get () {
-        return this.modelValue
-      },
-
-      set (value) {
-        const currentTab = Array.isArray(this.tabs)
-          ? this.tabs.find(tab => tab?.value === value)
-          : this.formattedTabs[value]
-
-        if (currentTab?.disabled) return
-
-        this.$emit('update:modelValue', value)
-      }
-    },
-
-    tabComponent () {
-      return this.useRouteTab ? 'q-route-tab' : 'q-tab'
-    }
+  tabs: {
+    default: () => ({}),
+    required: true,
+    type: [Object, Array]
   },
 
-  methods: {
-    getFormattedLabel ({ label, counter, value }) {
-      const normalizedCount = this.counters[value] || counter
+  useRouteTab: {
+    type: Boolean
+  }
+})
 
-      if (!normalizedCount) return label
+const emit = defineEmits(['update:modelValue'])
 
-      const countString = String(normalizedCount)
+// computed
+const model = computed({
+  get () {
+    return props.modelValue
+  },
 
-      return `${label} (${countString.padStart(2, '0')})`
-    },
+  set (value) {
+    const currentTab = Array.isArray(props.tabs)
+      ? props.tabs.find(tab => tab?.value === value)
+      : formattedTabs.value[value]
 
-    getTabProps (tab) {
-      const { icon, label, ...payload } = tab
-      return payload
+    if (currentTab?.disabled) return
+
+    emit('update:modelValue', value)
+  }
+})
+
+const formattedTabs = computed(() => {
+  const tabs = extend(true, {}, props.tabs)
+
+  for (const key in tabs) {
+    if (typeof tabs[key] === 'string') {
+      tabs[key] = { label: tabs[key], value: key }
     }
   }
+
+  return tabs
+})
+
+const tabComponent = computed(() => props.useRouteTab ? 'q-route-tab' : 'q-tab')
+
+// functions
+function getFormattedLabel ({ label, counter, value }) {
+  const normalizedCount = props.counters[value] || counter
+
+  if (!normalizedCount) return label
+
+  const countString = String(normalizedCount)
+
+  return `${label} (${countString.padStart(2, '0')})`
+}
+
+function getTabProps (tab) {
+  const { icon, label, ...payload } = tab
+
+  return payload
 }
 </script>
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Modificado
- `QasTabsGenerator`: alterado componente para Composition API.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [ ] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
