### PR TITLE
Fix issue in QasActionsMenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasActionsMenu`: Corrigido problema da const `hasDelete` do composable `useDelete`, onde não estava reativo pois não foi feito como computada.
+
 ## [3.13.0] - 27-12-2023
 ## BREAKING CHANGES
 - Anteriormente, o componente `QasFormView` não atualizava automaticamente o v-model após um evento de "submit" com sucesso, o que levava a alguns problemas relacionados a não atualização de certos campos retornados da API. Para resolver isso, implementamos uma mudança para garantir que o `v-model` agora seja sempre atualizado com o resultado retornado pela API após um submit. Isso pode exigir testes para confirmar que o comportamento dos formulários estão alinhados com o esperado.

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -9,7 +9,9 @@
             </q-item-section>
 
             <q-item-section>
-              <div>{{ item.label }}</div>
+              <div>
+                {{ item.label }}
+              </div>
             </q-item-section>
           </q-item>
         </slot>
@@ -86,7 +88,7 @@ const { deleteBtnProps, hasDelete } = useDelete()
 const fullList = computed(() => {
   return {
     ...props.list,
-    ...deleteBtnProps
+    ...deleteBtnProps.value
   }
 })
 
@@ -189,20 +191,20 @@ function onClick (item = {}) {
 
 // ------------------------------- composables ---------------------------------
 function useDelete () {
-  const deleteBtnProps = {}
-
   const hasDelete = computed(() => !!Object.keys(props.deleteProps).length)
 
-  if (hasDelete.value) {
-    Object.assign(deleteBtnProps, {
-      delete: {
-        color: 'grey-10',
-        icon: props.deleteIcon,
-        label: props.deleteLabel,
-        handler: () => qas.delete(props.deleteProps)
-      }
-    })
-  }
+  const deleteBtnProps = computed(() => {
+    return {
+      ...(hasDelete.value && {
+        delete: {
+          color: 'grey-10',
+          icon: props.deleteIcon,
+          label: props.deleteLabel,
+          handler: () => qas.delete(props.deleteProps)
+        }
+      })
+    }
+  })
 
   return {
     deleteBtnProps,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Corrigido
- `QasActionsMenu`: Corrigido problema da const `hasDelete` do composable `useDelete`, onde não estava reativo pois não foi feito como computada.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [ ] v3-beta.x -> a partir da branch `develop`.
- [x] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
