### PR TITLE
Refactor Composition Components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,25 +18,51 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasActionsMenu`: Corrigido problema da const `hasDelete` do composable `useDelete`, onde não estava reativo pois não foi feito como computada.
 
 ### Modificado
-- `QasDateTimeInput`: alterado componente para Composition API.
-- `QasDate`: alterado componente para Composition API.
-- `QasDelete`: alterado componente para Composition API.
-- `QasDialogRouter`: alterado componente para Composition API.
-- `QasTabsGenerator`: alterado componente para Composition API.
-- `QasPagination`: alterado componente para Composition API.
-- `QasPageHeader`: alterado componente para Composition API.
-- `QasMap`: alterado componente para Composition API.
-- `QasListItems`: alterado componente para Composition API.
-- `QasGallery`: alterado componente para Composition API.
-- `QasGalleryCard`: alterado componente para Composition API.
-- `QasLabel`: alterado componente para Composition API.
-- `QasHeaderActions`: alterado componente para Composition API.
-- `QasDialogRouter`: alterado componente para Composition API.
-- `QasDebugger`: alterado componente para Composition API.
-- `QasCopy`: alterado componente para Composition API.
-- `QasBtnDropdown`: alterado componente para Composition API.
-- `QasCard`: alterado componente para Composition API.
-- `QasCheckboxGroup`: alterado componente para Composition API.
+- Alterado componentes para Composition API:
+  - QasBtnDropdown.
+  - QasCard.
+  - QasCheckboxGroup.
+  - QasCopy.
+  - QasDate.
+  - QasDateTimeInput.
+  - QasDebugger.
+  - QasDelete.
+  - QasDialogRouter.
+  - QasGallery.
+  - QasGalleryCard.
+  - QasHeaderActions.
+  - QasLabel.
+  - QasListItems.
+  - QasMap.
+  - QasPageHeader.
+  - QasPagination.
+  - QasTabsGenerator.
+
+- Adicionado prefixo de `props` nas propriedades dentro do template:
+  - QasAppAlert: [text].
+  - QasAppBar: [brand, title].
+  - QasAppMenu: [items, title].
+  - QasAppUser: [users, notifications].
+  - QasAvatar: [image, icon, title].
+  - QasBreakline: [tag, icon, title].
+  - QasDialog: [card, persistent, useForm].
+  - QasFormGenerator: [fieldsProps, modelValue, errors].
+  - QasGridGenerator: [headerClass, contentClass].
+  - QasTimeline: [list].
+
+- Modificado nome `emits` para `emit` no script setup:
+  - QasAppBar.
+  - QasAppMenu.
+  - QasAppUser.
+  - QasBtnDropdown.
+
+- Modificado $attrs para useAttrs() no template:
+  - QasBreakline.
+  - QasDialog.
+
+- Modificado slots para useSlots() no template:
+  - QasSelectListDialog.
+
 - `/ui/src/vue-plugin.js`: adicionado método `getAction` do `@bildvitta/store-adapter` na variável global `qas` para conseguir utiliza-lo no composition API (NÃO UTILIZAR NO PROJETO).
 
 ### Removido

--- a/ui/src/components/alert/QasAlert.vue
+++ b/ui/src/components/alert/QasAlert.vue
@@ -5,7 +5,7 @@
 
       <div class="text-body1 text-white">
         <slot>
-          {{ text }}
+          {{ props.text }}
         </slot>
       </div>
 

--- a/ui/src/components/app-bar/QasAppBar.vue
+++ b/ui/src/components/app-bar/QasAppBar.vue
@@ -5,9 +5,9 @@
 
       <q-toolbar-title>
         <router-link class="flex items-center no-wrap text-no-decoration" :class="routerLinkClass" :to="rootRoute">
-          <img v-if="brand" :alt="title" class="qas-app-bar__brand" :src="brand">
+          <img v-if="props.brand" :alt="props.title" class="qas-app-bar__brand" :src="props.brand">
 
-          <span v-else class="ellipsis text-bold text-primary">{{ title }}</span>
+          <span v-else class="ellipsis text-bold text-primary">{{ props.title }}</span>
 
           <q-badge v-if="hasDevelopmentBadge" class="q-ml-sm" color="red" :label="developmentBadgeLabel" />
         </router-link>
@@ -54,7 +54,7 @@ const props = defineProps({
   }
 })
 
-const emits = defineEmits(['sign-out', 'toggle-menu'])
+const emit = defineEmits(['sign-out', 'toggle-menu'])
 
 const router = useRouter()
 const screen = useScreen()
@@ -93,11 +93,11 @@ const hasUser = computed(() => !!Object.keys(defaultAppUserProps.value.user || {
 const routerLinkClass = computed(() => screen.isSmall && 'justify-center')
 
 function signOut () {
-  emits('sign-out')
+  emit('sign-out')
 }
 
 function toggleMenuDrawer () {
-  emits('toggle-menu')
+  emit('toggle-menu')
 }
 </script>
 

--- a/ui/src/components/app-menu/QasAppMenu.vue
+++ b/ui/src/components/app-menu/QasAppMenu.vue
@@ -6,9 +6,9 @@
           <!-- Brand -->
           <div v-if="!screen.untilLarge" class="q-mb-xl q-pt-xl qas-app-menu__label" :class="classes.spacedItem">
             <router-link class="column flex items-center justify-center relative-position text-no-decoration" :to="rootRoute">
-              <q-img v-if="normalizedBrand" :alt="title" class="qas-app-menu__brand qas-app-menu__label" fit="contain" height="27px" img-class="qas-app-menu__brand-img" no-spinner :src="normalizedBrand" />
+              <q-img v-if="normalizedBrand" :alt="props.title" class="qas-app-menu__brand qas-app-menu__label" fit="contain" height="27px" img-class="qas-app-menu__brand-img" no-spinner :src="normalizedBrand" />
 
-              <span v-else-if="!isMiniMode" class="ellipsis text-bold text-primary text-subtitle2">{{ title }}</span>
+              <span v-else-if="!isMiniMode" class="ellipsis text-bold text-primary text-subtitle2">{{ props.title }}</span>
 
               <q-badge v-if="hasDevelopmentBadge" class="q-mt-sm" color="red" :label="developmentBadgeLabel" />
             </router-link>
@@ -30,8 +30,8 @@
           </div>
 
           <!-- List -->
-          <q-list v-if="items.length" class="q-mt-xl qas-app-menu__menu text-grey-10">
-            <template v-for="(menuItem, index) in items">
+          <q-list v-if="props.items.length" class="q-mt-xl qas-app-menu__menu text-grey-10">
+            <template v-for="(menuItem, index) in props.items">
               <div v-if="hasChildren(menuItem)" :key="`children-${index}`" class="qas-app-menu__content" :class="classes.content">
                 <q-item class="ellipsis items-center q-py-none qas-app-menu__item qas-app-menu__item--label-mini text-weight-bold">
                   <div class="ellipsis qas-app-menu__label text-grey-10 text-subtitle2" :class="classes.spacedItem">
@@ -146,7 +146,7 @@ const props = defineProps({
   }
 })
 
-const emits = defineEmits(['sign-out', 'update:modelValue'])
+const emit = defineEmits(['sign-out', 'update:modelValue'])
 
 const screen = useScreen()
 const router = useRouter()
@@ -159,7 +159,7 @@ const isMini = ref(screen.isLarge)
 const composableParams = {
   props,
   onMenuUpdate: setHasOpenedMenu,
-  onSignOut: () => emits('sign-out')
+  onSignOut: () => emit('sign-out')
 }
 
 const { defaultAppUserProps, showAppUser } = useAppUser(composableParams)
@@ -172,7 +172,7 @@ const model = computed({
   },
 
   set (value) {
-    emits('update:modelValue', value)
+    emit('update:modelValue', value)
   }
 })
 
@@ -195,7 +195,7 @@ const classes = computed(() => {
 
 // métodos
 function closeDrawer () {
-  emits('update:modelValue', false)
+  emit('update:modelValue', false)
 }
 
 function getNormalizedPath (path) {

--- a/ui/src/components/app-menu/private/PvAppMenuDropdown.vue
+++ b/ui/src/components/app-menu/private/PvAppMenuDropdown.vue
@@ -2,7 +2,7 @@
   <div class="pv-app-menu-dropdown">
     <qas-btn-dropdown v-bind="defaultButtonDropdownProps">
       <q-list>
-        <q-item v-for="item in modules" :key="item" :active="isActive(item)" active-class="text-primary" :href="item.value">
+        <q-item v-for="item in props.modules" :key="item" :active="isActive(item)" active-class="text-primary" :href="item.value">
           <q-item-section v-if="item.icon" avatar>
             <q-icon :name="item.icon" />
           </q-item-section>

--- a/ui/src/components/app-user/QasAppUser.vue
+++ b/ui/src/components/app-user/QasAppUser.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="cursor-pointer items-center no-wrap q-gutter-sm qas-app-user row" data-cy="app-user">
     <div class="relative-position">
-      <qas-avatar :image="user.photo" :size="avatarSize" :title="userName" />
+      <qas-avatar :image="props.user.photo" :size="props.avatarSize" :title="userName" />
 
       <q-badge v-if="hasNotifications" color="red" floating>
-        {{ notifications.count }}
+        {{ props.notifications.count }}
       </q-badge>
     </div>
 
@@ -14,26 +14,26 @@
       </div>
 
       <div class="ellipsis qas-app-user__email text-grey-8">
-        {{ user.email }}
+        {{ props.user.email }}
       </div>
     </div>
 
-    <q-menu class="shadow-2 text-grey-10" max-height="400px" v-bind="menuProps" @hide="onMenuHide">
+    <q-menu class="shadow-2 text-grey-10" max-height="400px" v-bind="props.menuProps" @hide="onMenuHide">
       <div class="q-pb-sm q-pt-md q-px-md qas-app-user__menu">
-        <qas-avatar class="q-mb-md" :image="user.photo" size="64px" :title="userName" />
+        <qas-avatar class="q-mb-md" :image="props.user.photo" size="64px" :title="userName" />
 
         <div class="ellipsis qas-app-user__menu-name">
           {{ userName }}
         </div>
 
         <div class="ellipsis">
-          {{ user.email }}
+          {{ props.user.email }}
         </div>
 
         <qas-select v-if="hasCompaniesSelect" v-bind="defaultCompanyProps" v-model="companiesModel" class="q-my-md" data-cy="app-user-companies-select" @update:model-value="setCompanies" />
 
         <q-list class="q-mt-md">
-          <q-item v-close-popup :active="false" class="qas-app-user__menu-item" clickable :to="user.to">
+          <q-item v-close-popup :active="false" class="qas-app-user__menu-item" clickable :to="props.user.to">
             <q-item-section avatar>
               <q-icon name="sym_r_person" />
             </q-item-section>
@@ -54,7 +54,7 @@
 
             <q-item-section side>
               <q-badge color="red">
-                {{ notifications.count }}
+                {{ props.notifications.count }}
               </q-badge>
             </q-item-section>
           </q-item>
@@ -111,7 +111,7 @@ const props = defineProps({
   }
 })
 
-const emits = defineEmits(['sign-out'])
+const emit = defineEmits(['sign-out'])
 
 // vindo direto do boot api.js
 const axios = inject('axios')
@@ -142,7 +142,7 @@ watch(() => props.companyProps.modelValue, value => {
 
 // métodos
 function signOut () {
-  emits('sign-out')
+  emit('sign-out')
 }
 
 async function setCompanies (value) {

--- a/ui/src/components/avatar/QasAvatar.vue
+++ b/ui/src/components/avatar/QasAvatar.vue
@@ -1,8 +1,8 @@
 <template>
   <q-avatar class="text-bold" v-bind="attributes">
-    <q-img v-if="hasImage" :alt="title" :ratio="1" spinner-color="primary" spinner-size="16px" :src="image" @error="onImageLoadedError" />
+    <q-img v-if="hasImage" :alt="props.title" :ratio="1" spinner-color="primary" spinner-size="16px" :src="props.image" @error="onImageLoadedError" />
     <template v-else-if="hasTitle">{{ firstLetter }}</template>
-    <q-icon v-else :name="icon" />
+    <q-icon v-else :name="props.icon" />
   </q-avatar>
 </template>
 

--- a/ui/src/components/breakline/QasBreakline.vue
+++ b/ui/src/components/breakline/QasBreakline.vue
@@ -1,16 +1,14 @@
 <template>
-  <component :is="tag" v-for="(line, index) in lines" :key="index" v-bind="$attrs">
+  <component :is="props.tag" v-for="(line, index) in lines" :key="index" v-bind="attrs">
     {{ line }}
   </component>
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, useAttrs, useSlots } from 'vue'
 import { getSlotChildrenText } from '../../helpers'
 
-defineOptions({
-  name: 'QasBreakline'
-})
+defineOptions({ name: 'QasBreakline' })
 
 const props = defineProps({
   split: {
@@ -29,7 +27,8 @@ const props = defineProps({
   }
 })
 
-const slots = defineSlots()
+const attrs = useAttrs()
+const slots = useSlots()
 
 const lines = computed(() => {
   const text = props.text || getSlotChildrenText(slots.default())

--- a/ui/src/components/btn-dropdown/QasBtnDropdown.vue
+++ b/ui/src/components/btn-dropdown/QasBtnDropdown.vue
@@ -60,7 +60,7 @@ const props = defineProps({
   }
 })
 
-const emits = defineEmits(['click', 'update:menu'])
+const emit = defineEmits(['click', 'update:menu'])
 
 const slots = useSlots()
 const screen = useScreen()
@@ -114,11 +114,11 @@ watch(() => props.menu, value => {
 }, { immediate: true })
 
 function onUpdateMenuValue (value) {
-  emits('update:menu', value)
+  emit('update:menu', value)
 }
 
 function onClick (event) {
-  emits('click', event)
+  emit('click', event)
 }
 </script>
 

--- a/ui/src/components/checkbox-group/QasCheckboxGroup.vue
+++ b/ui/src/components/checkbox-group/QasCheckboxGroup.vue
@@ -5,13 +5,13 @@
 
       <q-option-group v-if="hasChildren(option)" class="q-ml-sm" :inline="props.inline" :model-value="props.modelValue" :options="option.children" type="checkbox" @update:model-value="updateChildren($event, option, index)" />
 
-      <q-option-group v-else v-model="model" v-bind="$attrs" :options="[option]" type="checkbox" />
+      <q-option-group v-else v-model="model" v-bind="attrs" :options="[option]" type="checkbox" />
     </div>
   </div>
 </template>
 
 <script setup>
-import { watch, computed, ref, onMounted } from 'vue'
+import { watch, computed, ref, onMounted, useAttrs } from 'vue'
 
 defineOptions({ name: 'QasCheckboxGroup' })
 
@@ -32,7 +32,9 @@ const props = defineProps({
   }
 })
 
-const emits = defineEmits(['update:modelValue'])
+const emit = defineEmits(['update:modelValue'])
+
+const attrs = useAttrs()
 
 onMounted(handleParent)
 
@@ -91,7 +93,7 @@ function updateChildren (value, option, index) {
 }
 
 function updateModelValue (value) {
-  emits('update:modelValue', value)
+  emit('update:modelValue', value)
 }
 
 function getCheckboxClass (option) {

--- a/ui/src/components/date-time-input/QasDateTimeInput.vue
+++ b/ui/src/components/date-time-input/QasDateTimeInput.vue
@@ -76,7 +76,7 @@ const props = defineProps({
   }
 })
 
-const emits = defineEmits(['update:modelValue'])
+const emit = defineEmits(['update:modelValue'])
 
 const attrs = useAttrs()
 
@@ -197,7 +197,7 @@ function updateModelValue (value) {
 
   if (value === '' || valueLength === mask.value.length) {
     lastValue.value = props.useTimeOnly ? value : toISOString(value)
-    emits('update:modelValue', lastValue.value)
+    emit('update:modelValue', lastValue.value)
   }
 
   if (props.useDateOnly) {
@@ -247,7 +247,7 @@ function validateDateTimeOnBlur () {
   }
 
   if (error.value || hasInvalidDate.value) {
-    emits('update:modelValue', '')
+    emit('update:modelValue', '')
   }
 }
 

--- a/ui/src/components/date/QasDate.vue
+++ b/ui/src/components/date/QasDate.vue
@@ -69,7 +69,7 @@ const props = defineProps({
   }
 })
 
-const emits = defineEmits(['update:modelValue', 'navigation'])
+const emit = defineEmits(['update:modelValue', 'navigation'])
 
 const attrs = useAttrs()
 
@@ -139,7 +139,7 @@ const model = computed({
   },
 
   set (value) {
-    emits('update:modelValue', props.useIso ? getISODate(value) : value)
+    emit('update:modelValue', props.useIso ? getISODate(value) : value)
   }
 })
 
@@ -430,7 +430,7 @@ function setObserveDate () {
 }
 
 function onNavigation (date) {
-  emits('navigation', date)
+  emit('navigation', date)
 
   setCurrentDate(date)
 

--- a/ui/src/components/delete/QasDelete.vue
+++ b/ui/src/components/delete/QasDelete.vue
@@ -56,10 +56,9 @@ const props = defineProps({
   }
 })
 
-const emits = defineEmits(['success', 'error', 'update:deleting'])
+const emit = defineEmits(['success', 'error', 'update:deleting'])
 
 const slots = useSlots()
-console.log('TCL: slots', slots)
 const attrs = useAttrs()
 const route = useRoute()
 
@@ -91,11 +90,11 @@ function onDelete () {
     redirectRoute: props.redirectRoute,
 
     // callbacks
-    onDelete: isDeleting => emits('update:deleting', isDeleting),
+    onDelete: isDeleting => emit('update:deleting', isDeleting),
 
-    onDeleteError: error => emits('error', error),
+    onDeleteError: error => emit('error', error),
 
-    onDeleteSuccess: response => emits('success', response)
+    onDeleteSuccess: response => emit('success', response)
   })
 }
 </script>

--- a/ui/src/components/dialog-router/QasDialogRouter.vue
+++ b/ui/src/components/dialog-router/QasDialogRouter.vue
@@ -17,7 +17,7 @@ import { useRouter, useRoute } from 'vue-router'
 
 defineOptions({ name: 'QasDialogRouter' })
 
-const emits = defineEmits(['error', 'hide'])
+const emit = defineEmits(['error', 'hide'])
 
 defineExpose({ show, hide })
 
@@ -45,7 +45,7 @@ function onDialogHide () {
   parentRoute.value = ''
   normalizedRoute.value = null
 
-  emits('hide')
+  emit('hide')
 }
 
 function getResolvedRoute (path) {
@@ -78,7 +78,7 @@ async function show (routeParam) {
     }
   } catch (error) {
     NotifyError('Ops! Erro ao carregar item.')
-    emits('error', error)
+    emit('error', error)
   } finally {
     Loading.hide()
   }

--- a/ui/src/components/dialog/QasDialog.vue
+++ b/ui/src/components/dialog/QasDialog.vue
@@ -1,10 +1,10 @@
 <template>
-  <q-dialog ref="dialogRef" class="qas-dialog" data-cy="dialog" :persistent="persistent" v-bind="dialogProps" @update:model-value="updateModelValue">
+  <q-dialog ref="dialogRef" class="qas-dialog" data-cy="dialog" :persistent="props.persistent" v-bind="dialogProps" @update:model-value="updateModelValue">
     <div class="bg-white q-pa-lg" :style="style">
       <header v-if="hasHeader" class="q-mb-lg">
         <slot name="header">
           <div class="items-center justify-between row">
-            <h5 class="text-h5" data-cy="dialog-title">{{ card.title }}</h5>
+            <h5 class="text-h5" data-cy="dialog-title">{{ props.card.title }}</h5>
 
             <qas-btn v-if="isInfoDialog" v-close-popup color="grey-10" data-cy="dialog-close-btn" icon="sym_r_close" variant="tertiary" />
           </div>
@@ -14,14 +14,14 @@
       <section class="text-body1 text-grey-8">
         <component :is="mainComponent.is" ref="form" v-bind="mainComponent.props">
           <slot name="description">
-            <component :is="descriptionComponent" data-cy="dialog-description">{{ card.description }}</component>
+            <component :is="descriptionComponent" data-cy="dialog-description">{{ props.card.description }}</component>
           </slot>
 
           <div v-if="!isInfoDialog">
             <slot name="actions">
               <qas-actions v-bind="defaultActionsProps">
                 <template v-if="hasOk" #primary>
-                  <qas-btn v-close-popup="!useForm" class="full-width" data-cy="dialog-ok-btn" variant="primary" v-bind="defaultOk" />
+                  <qas-btn v-close-popup="!props.useForm" class="full-width" data-cy="dialog-ok-btn" variant="primary" v-bind="defaultOk" />
                 </template>
 
                 <template v-if="hasCancel" #secondary>
@@ -107,7 +107,7 @@ const props = defineProps({
   }
 })
 
-const emits = defineEmits([
+const emit = defineEmits([
   // model
   'update:modelValue',
 
@@ -130,7 +130,7 @@ const { dialogRef, onDialogHide } = useDialogPluginComponent()
 // QForm template
 const form = ref(null)
 
-const composablesParams = { emits, form, props, screen, slots }
+const composablesParams = { emit, form, props, screen, slots }
 
 const { defaultCancel, hasCancel } = useCancel(composablesParams)
 const { defaultOk, hasOk, onOk } = useOk(composablesParams)
@@ -174,7 +174,7 @@ const defaultActionsProps = computed(() => {
 })
 
 function updateModelValue (value) {
-  emits('update:modelValue', value)
+  emit('update:modelValue', value)
 }
 </script>
 

--- a/ui/src/components/dialog/composables/use-cancel.js
+++ b/ui/src/components/dialog/composables/use-cancel.js
@@ -3,13 +3,13 @@ import { computed } from 'vue'
 /**
  * @param {{
  *  props: { cancel: object },
- *  emits: (event: 'cancel') => void
+ *  emit: (event: 'cancel') => void
  * }} config
  */
 export default function useCancel (config = {}) {
   const {
     props,
-    emits
+    emit
   } = config
 
   const defaultCancel = computed(() => {
@@ -30,7 +30,7 @@ export default function useCancel (config = {}) {
   function onCancel () {
     props.cancel.onClick?.()
 
-    emits('cancel')
+    emit('cancel')
   }
 
   return {

--- a/ui/src/components/dialog/composables/use-dynamic-components.js
+++ b/ui/src/components/dialog/composables/use-dynamic-components.js
@@ -6,7 +6,7 @@ import { QForm } from 'quasar'
  *  props: { card: object, useForm: boolean, useValidationAllAtOnce: boolean },
  *  form: import('vue').Ref<HTMLInputElement | null>,
  *  hasOk: import('vue').ComputedRef<boolean>,
- *  emits: (event: 'validate', payload: Promise<boolean> | boolean) => void,
+ *  emit: (event: 'validate', payload: Promise<boolean> | boolean) => void,
  *  onOk: Function
  * }} config
  */
@@ -17,7 +17,7 @@ export default function useDynamicComponents (config = {}) {
     hasOk,
 
     onOk = () => {},
-    emits
+    emit
   } = config
 
   const mainComponent = computed(() => {
@@ -58,12 +58,12 @@ export default function useDynamicComponents (config = {}) {
         }
       }
 
-      emits('validate', isAllComponentValid)
+      emit('validate', isAllComponentValid)
 
       return
     }
 
-    emits('validate', form.value.validate())
+    emit('validate', form.value.validate())
   }
 
   /**

--- a/ui/src/components/dialog/composables/use-ok.js
+++ b/ui/src/components/dialog/composables/use-ok.js
@@ -3,13 +3,13 @@ import { computed } from 'vue'
 /**
  * @param {{
  *  props: { ok: object, useForm: boolean },
- *  emits: (event: 'ok') => void
+ *  emit: (event: 'ok') => void
  * }} config
  */
 export default function useOk (config = {}) {
   const {
     props,
-    emits
+    emit
   } = config
 
   const defaultOk = computed(() => {
@@ -33,7 +33,7 @@ export default function useOk (config = {}) {
   function onOk () {
     props.ok.onClick?.()
 
-    emits('ok')
+    emit('ok')
   }
 
   return {

--- a/ui/src/components/form-generator/QasFormGenerator.vue
+++ b/ui/src/components/form-generator/QasFormGenerator.vue
@@ -10,14 +10,14 @@
         <div :class="classes">
           <div v-for="(field, key) in fieldsetItem.fields.visible" :key="key" :class="getFieldClass({ index: key, fields: normalizedFields })">
             <slot :field="field" :name="`field-${field.name}`">
-              <qas-field :disable="isFieldDisabled(field)" v-bind="fieldsProps[field.name]" :error="errors[key]" :field="field" :model-value="modelValue[field.name]" @update:model-value="updateModelValue({ key: field.name, value: $event })" />
+              <qas-field :disable="isFieldDisabled(field)" v-bind="props.fieldsProps[field.name]" :error="props.errors[key]" :field="field" :model-value="props.modelValue[field.name]" @update:model-value="updateModelValue({ key: field.name, value: $event })" />
             </slot>
           </div>
         </div>
 
         <div v-for="(field, key) in fieldsetItem.fields.hidden" :key="key">
           <slot :field="field" :name="`field-${field.name}`">
-            <qas-field :disable="isFieldDisabled(field)" v-bind="fieldsProps[field.name]" :field="field" :model-value="modelValue[field.name]" @update:model-value="updateModelValue({ key: field.name, value: $event })" />
+            <qas-field :disable="isFieldDisabled(field)" v-bind="props.fieldsProps[field.name]" :field="field" :model-value="props.modelValue[field.name]" @update:model-value="updateModelValue({ key: field.name, value: $event })" />
           </slot>
         </div>
       </div>

--- a/ui/src/components/gallery/QasGallery.vue
+++ b/ui/src/components/gallery/QasGallery.vue
@@ -11,7 +11,7 @@
 
       <slot>
         <div v-if="!hideShowMore" class="full-width text-center">
-          <qas-btn color="primary" data-cy="gallery-btn-show-more" :label="showMoreLabel" variant="tertiary" @click="showMore" />
+          <qas-btn color="primary" data-cy="gallery-btn-show-more" :label="props.showMoreLabel" variant="tertiary" @click="showMore" />
         </div>
       </slot>
 

--- a/ui/src/components/grid-generator/QasGridGenerator.vue
+++ b/ui/src/components/grid-generator/QasGridGenerator.vue
@@ -3,13 +3,13 @@
     <div v-for="(field, key) in fieldsByResult" :key="key" :class="getFieldClass({ index: key, isGridGenerator: true })">
       <slot :field="field" :name="`field-${field.name}`">
         <slot :field="field" name="header">
-          <header :class="headerClass" :data-cy="`grid-generator-${field.name}-field`">
+          <header :class="props.headerClass" :data-cy="`grid-generator-${field.name}-field`">
             {{ field.label }}
           </header>
         </slot>
 
         <slot :field="field" name="content">
-          <div :class="contentClass" :data-cy="`grid-generator-${field.name}-result`">
+          <div :class="props.contentClass" :data-cy="`grid-generator-${field.name}-result`">
             {{ field.formattedResult }}
           </div>
         </slot>

--- a/ui/src/components/infinite-scroll/QasInfiniteScroll.vue
+++ b/ui/src/components/infinite-scroll/QasInfiniteScroll.vue
@@ -62,7 +62,7 @@ const props = defineProps({
 
 defineExpose({ refresh, remove })
 
-const emits = defineEmits(['update:list'])
+const emit = defineEmits(['update:list'])
 
 const axios = inject('axios')
 
@@ -97,7 +97,7 @@ const model = computed({
   },
 
   set (newList) {
-    emits('update:list', newList)
+    emit('update:list', newList)
   }
 })
 

--- a/ui/src/components/select-list-dialog/QasSelectListDialog.vue
+++ b/ui/src/components/select-list-dialog/QasSelectListDialog.vue
@@ -55,7 +55,7 @@
       v-bind="defaultDialogProps"
       v-model="showDialog"
     >
-      <template v-for="(_, name) in $slots" #[name]="context">
+      <template v-for="(_, name) in slots" #[name]="context">
         <slot :name="`dialog-${name}`" v-bind="context || {}" />
       </template>
 
@@ -76,7 +76,7 @@
 </template>
 
 <script setup>
-import { computed, ref, watch } from 'vue'
+import { computed, ref, watch, useSlots } from 'vue'
 
 defineOptions({ name: 'QasSelectListDialog' })
 
@@ -140,6 +140,8 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['add', 'remove', 'update:modelValue'])
+
+const slots = useSlots()
 
 const hasError = computed(() => Array.isArray(props.error) ? !!props.error.length : !!props.error)
 const errorMessage = computed(() => Array.isArray(props.error) ? props.error.join(' ') : props.error)

--- a/ui/src/components/timeline/QasTimeline.vue
+++ b/ui/src/components/timeline/QasTimeline.vue
@@ -5,7 +5,7 @@
     layout="comfortable"
   >
     <template
-      v-for="(item, index) in list"
+      v-for="(item, index) in props.list"
       :key="`timeline-${index}-${uid()}`"
     >
       <q-timeline-entry

--- a/ui/src/composables/private/use-generator.js
+++ b/ui/src/composables/private/use-generator.js
@@ -3,14 +3,6 @@ import { Spacing } from '../../enums/Spacing'
 
 const IRREGULAR_CLASSES = ['col', 'col-auto', 'fit']
 
-/**
- * @constant
- * @type {{
- *  columns: (string|Object|Array.<Object>),
- *  fields: Object,
- *  gutter: (string|Boolean)
- * }}
-*/
 export const baseProps = {
   columns: {
     default: () => [],


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Corrigido
- `QasActionsMenu`: Corrigido problema da const `hasDelete` do composable `useDelete`, onde não estava reativo pois não foi feito como computada.

### Modificado
- Adicionado prefixo de `props` nas propriedades dentro do template:
  - QasAppAlert: [text].
  - QasAppBar: [brand, title].
  - QasAppMenu: [items, title].
  - QasAppUser: [users, notifications].
  - QasAvatar: [image, icon, title].
  - QasBreakline: [tag, icon, title].
  - QasDialog: [card, persistent, useForm].
  - QasFormGenerator: [fieldsProps, modelValue, errors].
  - QasGridGenerator: [headerClass, contentClass].
  - QasTimeline: [list].

- Modificado nome `emits` para `emit` no script setup:
  - QasAppBar.
  - QasAppMenu.
  - QasAppUser.
  - QasBtnDropdown.

- Modificado $attrs para useAttrs() no template:
  - QasBreakline.
  - QasDialog.

- Modificado slots para useSlots() no template:
  - QasSelectListDialog.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
