### PR TITLE
Fixed maxWidth prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasDrawer`: loading estava quebrando no mobile.
+
+### Modificado
+- `QasDrawer`: adicionado default `60%` na propriedade `maxWidth`.
+
 ## [3.14.0-beta.5] - 02-02-2024
 ### Corrigido
 - `QasLayout`: propriedade "initialUnreadNotificationsCount" só era escutada por uma vez, o que gerava problemas quando os dados eram alterados.

--- a/docs/src/examples/QasDrawer/Basic.vue
+++ b/docs/src/examples/QasDrawer/Basic.vue
@@ -29,7 +29,6 @@ export default {
   computed: {
     drawerProps () {
       return {
-        maxWidth: '',
         title: 'Título de exemplo',
         position: this.position
       }

--- a/docs/src/examples/QasDrawer/Basic.vue
+++ b/docs/src/examples/QasDrawer/Basic.vue
@@ -29,6 +29,7 @@ export default {
   computed: {
     drawerProps () {
       return {
+        maxWidth: '',
         title: 'Título de exemplo',
         position: this.position
       }

--- a/ui/src/components/drawer/QasDrawer.vue
+++ b/ui/src/components/drawer/QasDrawer.vue
@@ -50,7 +50,7 @@ const props = defineProps({
 
   maxWidth: {
     type: String,
-    default: ''
+    default: '60%'
   },
 
   position: {
@@ -74,15 +74,16 @@ const emit = defineEmits(['update:modelValue'])
 const attrs = useAttrs()
 const screen = useScreen()
 
+// computed
+const normalizedMaxWidth = computed(() => screen.isSmall ? '100%' : props.maxWidth)
+
 const loadingStyle = computed(() => {
   return {
-    right: `calc(100% - ${props.maxWidth})`
+    right: `calc(100% - ${normalizedMaxWidth.value})`
   }
 })
 
 const attributes = computed(() => {
-  const maxWidth = screen.isSmall ? '100%' : props.maxWidth
-
   const { modelValue } = attrs
 
   return {
@@ -92,7 +93,7 @@ const attributes = computed(() => {
     ...props.dialogProps,
 
     cancel: false,
-    maxWidth,
+    maxWidth: normalizedMaxWidth.value,
     maximized: true,
     ok: false,
     position: props.position,

--- a/ui/src/components/drawer/QasDrawer.yml
+++ b/ui/src/components/drawer/QasDrawer.yml
@@ -11,6 +11,7 @@ props:
 
   max-width:
     desc: Tamanho máximo do dialog.
+    default: 60%
     type: String
 
   model-value:

--- a/ui/src/components/layout/private/PvLayoutNotificationsDrawer.vue
+++ b/ui/src/components/layout/private/PvLayoutNotificationsDrawer.vue
@@ -89,7 +89,6 @@ const model = computed({
 const drawerProps = computed(() => {
   return {
     loading: isMarkingNotificationsAsRead.value,
-    maxWidth: '60%',
     title: 'Notificações'
   }
 })


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Corrigido
- `QasDrawer`: loading estava quebrando no mobile.

### Modificado
- `QasDrawer`: adicionado default `60%` na propriedade `maxWidth`.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
