### PR TITLE
Changes in QasListItens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## [Não publicado]
+### Modificado
+- `QasListItens`:
+  - alterado cor do botão de `primary` para `grey-10`.
+  - alterado espaçamento entre itens de `lg` para `md`.
+  - removido `v-ripple` para se adequar ao design.
+
 ## [3.14.0-beta.7] - 15-02-2024
 ### Corrigido
 - `QasDate`: Corrigido exibição de eventos com mais de 3 dígitos no calendário.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## [Não publicado]
+## Não publicado
 ### Modificado
 - `QasListItens`:
   - alterado cor do botão de `primary` para `grey-10`.

--- a/ui/src/components/list-items/QasListItems.vue
+++ b/ui/src/components/list-items/QasListItems.vue
@@ -1,7 +1,7 @@
 <template>
   <component :is="component" class="qas-list-items" :class="classes">
     <q-list separator>
-      <q-item v-for="(item, index) in props.list" :key="index" v-ripple :clickable="props.useClickableItem" @click="onClick({ item, index }, true)">
+      <q-item v-for="(item, index) in props.list" :key="index" :clickable="props.useClickableItem" @click="onClick({ item, index }, true)">
         <slot :index="index" :item="item" name="item">
           <q-item-section>
             <slot :index="index" :item="item" name="item-section" />
@@ -9,7 +9,7 @@
 
           <q-item-section v-if="props.useSectionActions" side>
             <slot :index="index" :item="item" name="item-section-side">
-              <qas-btn color="primary" :icon="props.icon" variant="tertiary" @click="onClick({ item, index })" />
+              <qas-btn color="grey-10" :icon="props.icon" variant="tertiary" @click="onClick({ item, index })" />
             </slot>
           </q-item-section>
         </slot>
@@ -82,7 +82,7 @@ function onClick ({ item, index }, fromItem) {
 
   .q-list {
     & > .q-item {
-      padding: var(--qas-spacing-lg) 0;
+      padding: var(--qas-spacing-md) 0;
     }
 
     & > .q-item:last-child {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## [Não publicado]
### Modificado
- `QasListItens`:
  - alterado cor do botão de `primary` para `grey-10`.
  - alterado espaçamento entre itens de `lg` para `md`.
  - removido `v-ripple` para se adequar ao design.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
