### PR TITLE
Feature/qas date inactive event style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasDate`: Corrigido exibição de eventos em dias inativos.
+
 ## [3.14.0-beta.9] - 15-02-2024
 ### Modificado
 - `QasListItens`: resetado `min-height` que existia no q-item.

--- a/ui/src/components/date/QasDate.vue
+++ b/ui/src/components/date/QasDate.vue
@@ -451,6 +451,7 @@ function onNavigation (date) {
     font-size: 10px !important;
     line-height: 1;
     transition: color var(--qas-generic-transition);
+    width: 100%;
 
     &--pointer {
       bottom: -6px;
@@ -479,10 +480,11 @@ function onNavigation (date) {
         @include set-typography($subtitle2);
 
         color: $grey-4;
+        line-height: 1;
         visibility: unset;
 
         span {
-          height: 36px;
+          height: auto;
           padding: var(--qas-spacing-xs);
         }
       }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- (Remova este texto de descrição.) -->
### Corrigido
- `QasDate`: Corrigido exibição de eventos em dias inativos.

_Antes_
![Screenshot 2024-02-16 at 09 54 33](https://github.com/bildvitta/asteroid/assets/19765074/7d0adc15-5fba-45ab-bfa6-377d426d4eb6)

_Depois_
![Screenshot 2024-02-16 at 09 50 07](https://github.com/bildvitta/asteroid/assets/19765074/c917b1cc-483e-4042-8021-e194e8bd6783)

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
