### PR TITLE
fix: QasGrabbable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasGrabbable`:
+  - corrigido problema do conteúdo ser alterado após o componente ser montado e o grab não ser ajustado de acordo com o novo conteúdo.
+  - corrigido z-index do fade lateral.
+
 ## [3.15.0-beta.0] - 21-02-2024
 ### Adicionado
 - `QasGrabbable`: adicionado componente de scroll em uma determinada área (elemento) ao realizar evento de grab (puxar/agarrar) com o mouse/touch.

--- a/ui/src/components/grabbable/QasGrabbable.vue
+++ b/ui/src/components/grabbable/QasGrabbable.vue
@@ -28,6 +28,7 @@ const grabContainer = ref(null)
 const grabPosition = ref(null)
 const isGrabbing = ref(false)
 const scrollOnGrab = ref({})
+const resizeObserver = ref(null)
 
 const classes = computed(() => {
   const baseClass = 'qas-grabbable__container'
@@ -54,7 +55,7 @@ function handleEnableScrollOnGrab () {
     return
   }
 
-  disableScrollOnGrab()
+  destroyScrollOnGrab()
 }
 
 function initScrollOnGrab () {
@@ -67,7 +68,7 @@ function initScrollOnGrab () {
   })
 }
 
-function disableScrollOnGrab () {
+function destroyScrollOnGrab () {
   if (!hasScrollOnGrab.value) return
 
   scrollOnGrab.value.destroyEvents()
@@ -109,16 +110,26 @@ function setGrabPosition () {
   }
 }
 
+function setResizeObserver () {
+  resizeObserver.value = new ResizeObserver(entries => {
+    entries.forEach(() => handleEnableScrollOnGrab())
+  })
+
+  resizeObserver.value.observe(grabContainer.value)
+}
+
+function destroyResizeObserver () {
+  resizeObserver.value.unobserve(grabContainer.value)
+}
+
 onMounted(() => {
   handleEnableScrollOnGrab()
-
-  window.addEventListener('resize', handleEnableScrollOnGrab)
+  setResizeObserver()
 })
 
 onBeforeUnmount(() => {
-  window.removeEventListener('resize', handleEnableScrollOnGrab)
-
-  disableScrollOnGrab()
+  destroyResizeObserver()
+  destroyScrollOnGrab()
 })
 </script>
 
@@ -156,6 +167,7 @@ onBeforeUnmount(() => {
       position: absolute;
       top: 0;
       pointer-events: none;
+      z-index: 1;
     }
 
     &::before {

--- a/ui/src/components/grabbable/QasGrabbable.vue
+++ b/ui/src/components/grabbable/QasGrabbable.vue
@@ -111,9 +111,7 @@ function setGrabPosition () {
 }
 
 function setResizeObserver () {
-  resizeObserver.value = new ResizeObserver(entries => {
-    entries.forEach(() => handleEnableScrollOnGrab())
-  })
+  resizeObserver.value = new ResizeObserver(handleEnableScrollOnGrab)
 
   resizeObserver.value.observe(grabContainer.value)
 }
@@ -123,7 +121,6 @@ function destroyResizeObserver () {
 }
 
 onMounted(() => {
-  handleEnableScrollOnGrab()
   setResizeObserver()
 })
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- (Remova este texto de descrição.) -->
### Corrigido
- `QasGrabbable`:
  - corrigido problema do conteúdo ser alterado após o componente ser montado e o grab não ser ajustado de acordo com o novo conteúdo.
  - corrigido z-index do fade lateral.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
