### PR TITLE
Changes in QasOptionGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `QasOptionGroup`: alterado componente para sobrescrever a prop `inline`.
+
 ## [3.15.0-beta.3] - 28-02-2024
 ## BREAKING CHANGES
 -  `QasCard`: Componente agora se chama `QasCardImage`, pois agora foi criado um novo componente com o nome  de `QasCard` (`QasCard <-> QasCardImage`).

--- a/docs/src/pages/components/option-group.md
+++ b/docs/src/pages/components/option-group.md
@@ -2,11 +2,14 @@
 title: QasOptionGroup
 ---
 
-Componente wrapper do [QOptionGroup](https://quasar.dev/vue-components/option-group#introduction). Componente para padronizar propriedade `inline`, a partir do mobile componente segue comportamento de linha, em telas mobile segue comportamento de bloco, não sendo possível alterar este comportamento.
+Componente wrapper do [QOptionGroup](https://quasar.dev/vue-components/option-group#introduction).
 
 <doc-api file="option-group/QasOptionGroup" name="QasOptionGroup" />
 
 ## Uso
 
-<doc-example file="QasOptionGroup/Basic" title="Básico" />
+:::info
+O componente fica "inline" (uma única linha) a partir do mobile, e em blocos (varias linhas) no mobile, porém é possível sobrescrever a prop `inline` caso desejar.
+:::
 
+<doc-example file="QasOptionGroup/Basic" title="Básico" />

--- a/ui/src/components/option-group/QasOptionGroup.vue
+++ b/ui/src/components/option-group/QasOptionGroup.vue
@@ -35,8 +35,8 @@ export default {
   computed: {
     attributes () {
       return {
-        ...this.$attrs,
-        inline: !this.$qas.screen.isSmall
+        inline: !this.$qas.screen.isSmall,
+        ...this.$attrs
       }
     },
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- (Remova este texto de descrição.) -->
## Não publicado
### Modificado
- `QasOptionGroup`: alterado componente para sobrescrever a prop `inline`.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
