### PR TITLE
feat: created results model/fields slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
   - alterado prop `use-shallow-ref` para `use-mark-raw`.
 
 ### Adicionado
-- `QasBoardGenerator`: Adicionado eventos `fetch-columns-success`, `fetch-columns-error`, `fetch-column-success` e `fetch-column-error`.
+- `QasBoardGenerator`: 
+  - Adicionado eventos `fetch-columns-success`, `fetch-columns-error`, `fetch-column-success` e `fetch-column-error`.
+  - Adicionad prop `lazy-loading-fields-keys`.
 
 ## [3.15.0-beta.5] - 01-03-2024
 ### Modificado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
   - alterado prop `use-shallow-ref` para `use-mark-raw`.
 
 ### Adicionado
-- `QasBoardGenerator`: adicionado v-model de fields para cada coluna.
+- `QasBoardGenerator`: Adicionado eventos `fetch-columns-success`, `fetch-columns-error`, `fetch-column-success` e `fetch-column-error`.
 
 ## [3.15.0-beta.3] - 28-02-2024
 ## BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,16 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ## Não publicado
 ## BREAKING CHANGES
--  `QasBoardGenerator`: props `results` alterada para `headers`, onde o `v-model` agora é recuperado pelo `v-model:results`.
+- `QasBoardGenerator`:
+  - props `results` alterada para `headers`,
+  - `v-model` agora é recuperado pelo `v-model:results`.
+  - alterado prop `use-shallow-ref` para `use-mark-raw`.
 
 ### Modificado
 - `QasBoardGenerator`: 
-  - props `results` alterada para `headers`.
-  - `v-model` agora é recuperado pelo `v-model:results`
+  - alterado prop `results` para `headers`.
+  - `v-model` agora é recuperado pelo `v-model:results`.
+  - alterado prop `use-shallow-ref` para `use-mark-raw`.
 
 ### Adicionado
 - `QasBoardGenerator`: adicionado v-model de fields para cada coluna.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ### Adicionado
 - `QasBoardGenerator`: Adicionado eventos `fetch-columns-success`, `fetch-columns-error`, `fetch-column-success` e `fetch-column-error`.
+
 ## [3.15.0-beta.5] - 01-03-2024
 ### Modificado
 - `QasNestedFields`: alterado comportamento da propriedade `formGutter`, agora ela é repassada para o componente `QasFormGenerator` e utilizada nos espaçamentos dos campos do formulário.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+## BREAKING CHANGES
+-  `QasBoardGenerator`: props `results` alterada para `headers`, onde o `v-model` agora é recuperado pelo `v-model:results`.
+
+### Modificado
+- `QasBoardGenerator`: 
+  - props `results` alterada para `headers`.
+  - `v-model` agora é recuperado pelo `v-model:results`
+
+### Adicionado
+- `QasBoardGenerator`: adicionado v-model de fields para cada coluna.
+
 ## [3.15.0-beta.3] - 28-02-2024
 ## BREAKING CHANGES
 -  `QasCard`: Componente agora se chama `QasCardImage`, pois agora foi criado um novo componente com o nome  de `QasCard` (`QasCard <-> QasCardImage`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ### Adicionado
 - `QasBoardGenerator`: 
-  - Adicionado eventos `fetch-columns-success`, `fetch-columns-error`, `fetch-column-success` e `fetch-column-error`.
-  - Adicionad prop `lazy-loading-fields-keys`.
+  - adicionado eventos `fetch-columns-success`, `fetch-columns-error`, `fetch-column-success` e `fetch-column-error`.
+  - adicionado prop `lazy-loading-fields-keys`.
 
 ## [3.15.0-beta.5] - 01-03-2024
 ### Modificado

--- a/docs/src/examples/QasBoardGenerator/Basic.vue
+++ b/docs/src/examples/QasBoardGenerator/Basic.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="q-py-md" style="height: 500px; background-color: var(--qas-background-color);">
     <qas-board-generator
-      v-model:fields="fieldsColumns"
       v-model:results="resultsColumns"
       column-id-key="id"
       column-url="url-example"
@@ -34,7 +33,6 @@ export default {
 
   data () {
     return {
-      fieldsColumns: {},
       resultsColumns: {
         /*
         * Somente de exemplo, quando na verdade o componente será responsável por bater

--- a/docs/src/examples/QasBoardGenerator/Basic.vue
+++ b/docs/src/examples/QasBoardGenerator/Basic.vue
@@ -1,25 +1,26 @@
 <template>
   <div class="q-py-md" style="height: 500px; background-color: var(--qas-background-color);">
     <qas-board-generator
-      v-model="boardColumns"
+      v-model:fields="fieldsColumns"
+      v-model:results="resultsColumns"
       column-id-key="id"
       column-url="url-example"
+      :headers="headers"
       height="400px"
-      :results="results"
     >
-      <template #header-column="{ context }">
+      <template #header-column="{ header }">
         <div class="flex justify-between text-subtitle1">
-          <div>{{ context.name }}</div>
+          <div>{{ header.name }}</div>
         </div>
       </template>
 
-      <template #column-item="{ context }">
+      <template #column-item="{ item }">
         <qas-box
           class="full-width q-mb-lg"
           style="height: 200px;"
         >
           <div class="q-mb-lg">
-            Card - {{ context.item }}
+            Card - {{ item.card }}
           </div>
         </qas-box>
       </template>
@@ -33,33 +34,34 @@ export default {
 
   data () {
     return {
-      boardColumns: {
+      fieldsColumns: {},
+      resultsColumns: {
         /*
         * Somente de exemplo, quando na verdade o componente será responsável por bater
         * as APIs das colunas com base no headers fornecidos. É possível manipular as
         * colunas do lado de fora através deste model, como neste exemplo.
         */
         'col-1': [
-          { item: 'item 1 da coluna 1' },
-          { item: 'item 2 da coluna 1' },
-          { item: 'item 3 da coluna 1' }
+          { card: 'item 1 da coluna 1' },
+          { card: 'item 2 da coluna 1' },
+          { card: 'item 3 da coluna 1' }
         ],
         'col-2': [
-          { item: 'item 1 da coluna 2' },
-          { item: 'item 2 da coluna 2' },
-          { item: 'item 3 da coluna 2' }
+          { card: 'item 1 da coluna 2' },
+          { card: 'item 2 da coluna 2' },
+          { card: 'item 3 da coluna 2' }
         ],
         'col-3': [
-          { item: 'item 1 da coluna 3' },
-          { item: 'item 2 da coluna 3' },
-          { item: 'item 3 da coluna 3' }
+          { card: 'item 1 da coluna 3' },
+          { card: 'item 2 da coluna 3' },
+          { card: 'item 3 da coluna 3' }
         ]
       },
 
       /*
       * Headers na qual deverá fornecer para o componente.
       */
-      results: [
+      headers: [
         {
           id: 'col-1',
           name: 'Coluna 1'

--- a/docs/src/pages/components/board-generator.md
+++ b/docs/src/pages/components/board-generator.md
@@ -9,7 +9,7 @@ Componente usado para board de colunas.
 ## Uso
 
 :::info
-Caso precise manipular os dados do model das colunas em camadas mais profundas, use a prop "use-shallow-ref" como false.
+Caso precise manipular os dados do model das colunas em camadas mais profundas, use a prop "use-mark-raw" como false.
 :::
 
 <doc-example file="QasBoardGenerator/Basic" title="Básico" />

--- a/docs/src/pages/components/board-generator.md
+++ b/docs/src/pages/components/board-generator.md
@@ -12,4 +12,18 @@ Componente usado para board de colunas.
 Caso precise manipular os dados do model das colunas em camadas mais profundas, use a prop "use-mark-raw" como false.
 :::
 
+:::info
+Utilize a prop "lazy-loading-fields-keys" para caso você tenha campos que são lazy loading e o back retorna somente 
+as options usadas no results atual. É feito um tratamento interno onde mergeamos as options, evitando duplicidade e 
+perca de dados com base nas buscas anteriores.
+
+Exemplo de cenário:
+- É feita uma busca para a página 1 onde o campo "realEstateDevelopment" possui as options [1, 2, 3, 4].
+- É feita uma busca para a página 2, onde o campo "realEstateDevelopment" possui as options [4, 5, 6]
+- Os itens da página 1 irá ter a perca de dados, já que não houve o merge das options, sendo necessário passar para o 
+componente a prop lazy-loading-fields-keys="['realEstateDevelopment']" para o componente cuidar do merge do campo 
+passado.
+- Passando a prop o resultado será [1, 2, 3, 4, 5, 6]
+:::
+
 <doc-example file="QasBoardGenerator/Basic" title="Básico" />

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -141,13 +141,17 @@ function setColumnHeightContainer () {
 * Bater API pra cada header
 */
 async function fetchColumns () {
-  const promises = []
+  const promises = props.headers.map(header => fetchColumn(header))
 
-  props.headers.forEach(header => promises.push(fetchColumn(header)))
+  const { error } = await promiseHandler(promises, { useLoading: false })
 
-  Promise.all(promises)
-    .then(() => emit('fetch-columns-success'))
-    .catch(error => emit('fetch-columns-error', error))
+  if (error) {
+    emit('fetch-columns-error', error)
+
+    return
+  }
+
+  emit('fetch-columns-success')
 }
 
 /*
@@ -177,7 +181,7 @@ async function fetchColumn (header) {
   if (error) {
     emit('fetch-column-error', error)
 
-    throw new Error(error)
+    throw error
   }
 
   /*

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -206,7 +206,7 @@ async function fetchColumn (header) {
   * Pode acontecer das options nos fields da segunda página serem diferentes da primeira página,
   * portanto deve ocorrer o merge.
   */
-  if (!response.data?.fields) {
+  if (response.data?.fields) {
     columnsFieldsModel.value[headerKey] = getMergedFields(columnsFieldsModel.value[headerKey], response.data?.fields)
   }
 

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -176,7 +176,6 @@ async function fetchColumn (header) {
 
   if (error) {
     emit('fetch-column-error', error)
-    console.log(error)
 
     throw new Error(error)
   }

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -84,7 +84,8 @@ const props = defineProps({
 
 const emit = defineEmits([
   'update:results',
-  'fetch-column-success'
+  'fetch-column-success',
+  'fetch-column-error'
 ])
 
 watch(
@@ -165,7 +166,7 @@ async function fetchColumn (header) {
     }
   )
 
-  if (error) return
+  if (error) return emit('fetch-column-error', error)
 
   /*
   * exemplo de como columnsResultsModel irá ficar:

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -146,7 +146,6 @@ async function fetchColumns () {
   const { error } = await promiseHandler(promises, { useLoading: false })
 
   if (error) {
-    console.log(error)
     emit('fetch-columns-error', error)
 
     return

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -85,7 +85,9 @@ const props = defineProps({
 const emit = defineEmits([
   'update:results',
   'fetch-column-success',
-  'fetch-column-error'
+  'fetch-column-error',
+  'fetch-columns-success',
+  'fetch-columns-error'
 ])
 
 watch(
@@ -139,7 +141,13 @@ function setColumnHeightContainer () {
 * Bater API pra cada header
 */
 async function fetchColumns () {
-  props.headers.forEach(header => fetchColumn(header))
+  const promises = []
+
+  props.headers.forEach(header => promises.push(fetchColumn(header)))
+
+  Promise.all(promises)
+    .then(() => emit('fetch-columns-success'))
+    .catch(error => emit('fetch-columns-error', error))
 }
 
 /*
@@ -166,7 +174,12 @@ async function fetchColumn (header) {
     }
   )
 
-  if (error) return emit('fetch-column-error', error)
+  if (error) {
+    emit('fetch-column-error', error)
+    console.log(error)
+
+    throw new Error(error)
+  }
 
   /*
   * exemplo de como columnsResultsModel irá ficar:

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script setup>
-import { ref, watch, computed, onMounted, shallowRef, inject } from 'vue'
+import { ref, watch, computed, onMounted, markRaw, inject } from 'vue'
 import promiseHandler from '../../helpers/promise-handler'
 
 defineOptions({ name: 'QasBoardGenerator' })
@@ -81,7 +81,7 @@ const props = defineProps({
     default: '300px'
   },
 
-  useShallowRef: {
+  useMarkRaw: {
     type: Boolean,
     default: true
   }
@@ -190,7 +190,7 @@ async function fetchColumn (header) {
     ...response.data?.results || []
   ]
 
-  columnsResultsModel.value[headerKey] = props.useShallowRef ? shallowRef(newColumnValues) : newColumnValues
+  columnsResultsModel.value[headerKey] = props.useMarkRaw ? markRaw(newColumnValues) : newColumnValues
   columnsFieldsModel.value[headerKey] = response.data?.fields || {}
 
   columnsPagination.value[headerKey].offset = columnsResultsModel.value[headerKey].length

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -46,11 +46,6 @@ const props = defineProps({
     default: () => ({})
   },
 
-  fields: {
-    type: Object,
-    default: () => ({})
-  },
-
   columnIdKey: {
     type: String,
     required: true
@@ -89,7 +84,7 @@ const props = defineProps({
 
 const emit = defineEmits([
   'update:results',
-  'update:fields'
+  'fetch-column-success'
 ])
 
 watch(
@@ -103,8 +98,6 @@ watch(
 )
 
 watch(columnContainer, setColumnHeightContainer)
-
-watch(columnsFieldsModel.value, newValues => emit('update:fields', newValues))
 
 onMounted(() => {
   setColumnsPagination()
@@ -195,6 +188,8 @@ async function fetchColumn (header) {
 
   columnsPagination.value[headerKey].offset = columnsResultsModel.value[headerKey].length
   columnsPagination.value[headerKey].count = response.data?.count
+
+  emit('fetch-column-success', { response, header })
 }
 
 function getItemsByHeader (header) {

--- a/ui/src/components/board-generator/QasBoardGenerator.yml
+++ b/ui/src/components/board-generator/QasBoardGenerator.yml
@@ -38,8 +38,8 @@ props:
     type: Number
     default: 12
 
-  use-shallow-ref:
-    desc: Define se os valores dos itens das colunas irá ser atribuido utilizando o "shallowRef", onde somente a primeira camada do model será reativa.(https://vuejs.org/api/reactivity-advanced.html#shallowref)
+  use-mark-raw:
+    desc: Define se os valores dos itens das colunas irá ser atribuido utilizando o "markRaw", onde somente a primeira camada do model será reativa.(https://vuejs.org/api/reactivity-advanced.html#markraw)
     type: Boolean
     default: true
 

--- a/ui/src/components/board-generator/QasBoardGenerator.yml
+++ b/ui/src/components/board-generator/QasBoardGenerator.yml
@@ -4,7 +4,7 @@ meta:
   desc: Componente usado para board de colunas.
 
 props:
-  results:
+  headers:
     desc: Lista de itens sendo cada um o header de cada coluna.
     default: []
     type: Array
@@ -43,33 +43,50 @@ props:
     type: Boolean
     default: true
 
-  model-value:
-    desc: Model do componente, usado para o v-model.
+  results:
+    desc: Model do componente, usado para o v-model dos itens da coluna.
     default: {}
     type: Object
-    examples: [v-model="value"]
+    examples: [v-model:results="resultsColumns"]
+    model: true
+  
+  fields:
+    desc: Model dos fields, usado para recuperar os fields por coluna fora do template.
+    default: {}
+    type: Object
+    examples: [v-model:fields="fieldsColumns"]
     model: true
 
 slots:
   header-column:
     desc: Slot para acessar o card do header de cada coluna.
     scope:
-      context:
-        desc: Informações de cada item do header que foi fornecido através do "results".
+      fields:
+        desc: Fields referente à coluna atual do template.
+        type: Object
+        default: {}
+      
+      header:
+        desc: Informações de cada item do header que foi fornecido através da prop "headers"
         type: Object
         default: {}
 
   column-item:
     desc: Slot para acessar o item da coluna.
     scope:
-      context:
+      fields:
+        desc: Fields referente à coluna atual do template.
+        type: Object
+        default: {}
+      
+      item:
         desc: Informações de cada item da coluna que foi buscado através da API.
         type: Object
         default: {}
 
 events:
-  '@update:model-value -> function(value)':
-    desc: Dispara quando o model-value altera, também usado para v-model.
+  '@update:results -> function(value)':
+    desc: Dispara quando o "results" altera, também usado para v-model.
     params:
       value:
         desc: Novo valor do model.

--- a/ui/src/components/board-generator/QasBoardGenerator.yml
+++ b/ui/src/components/board-generator/QasBoardGenerator.yml
@@ -106,7 +106,7 @@ events:
   '@update:fetch-columns-success -> function()':
     desc: Dispara quando todos "fetchColumn" foram executados com sucesso.
 
-  '@update:fetch-columns-error -> function()':
+  '@update:fetch-columns-error -> function(error)':
     desc: Dispara quando algum "fetchColumn" cai em uma exceção.
     params:
       error:

--- a/ui/src/components/board-generator/QasBoardGenerator.yml
+++ b/ui/src/components/board-generator/QasBoardGenerator.yml
@@ -49,13 +49,6 @@ props:
     type: Object
     examples: [v-model:results="resultsColumns"]
     model: true
-  
-  fields:
-    desc: Model dos fields, usado para recuperar os fields por coluna fora do template.
-    default: {}
-    type: Object
-    examples: [v-model:fields="fieldsColumns"]
-    model: true
 
 slots:
   header-column:
@@ -90,6 +83,17 @@ events:
     params:
       value:
         desc: Novo valor do model.
+        type: Object
+
+  '@update:fetch-column-success -> function({ response, header })':
+    desc: Dispara após uma busca de uma coluna for feita.
+    params:
+      response:
+        desc: Retorno da API.
+        type: Object
+
+      header:
+        desc: header da coluna atual.
         type: Object
 
 methods:

--- a/ui/src/components/board-generator/QasBoardGenerator.yml
+++ b/ui/src/components/board-generator/QasBoardGenerator.yml
@@ -103,6 +103,16 @@ events:
         desc: Retorna todos os dados "cru" respondido na exceção do fetch.
         type: Object
 
+  '@update:fetch-columns-success -> function()':
+    desc: Dispara quando todos "fetchColumn" foram executados com sucesso.
+
+  '@update:fetch-columns-error -> function()':
+    desc: Dispara quando algum "fetchColumn" cai em uma exceção.
+    params:
+      error:
+        desc: Retorna todos os dados "cru" respondido na exceção do fetch.
+        type: Object
+
 methods:
   'fetchColumns: () => void':
     desc: Busca todas colunas com base nos headers fornecidos.

--- a/ui/src/components/board-generator/QasBoardGenerator.yml
+++ b/ui/src/components/board-generator/QasBoardGenerator.yml
@@ -4,11 +4,6 @@ meta:
   desc: Componente usado para board de colunas.
 
 props:
-  headers:
-    desc: Lista de itens sendo cada um o header de cada coluna.
-    default: []
-    type: Array
-
   column-id-key:
     desc: chave que será o id usado para ser o identificador da coluna.
     type: String
@@ -28,10 +23,20 @@ props:
     desc: Largura da coluna
     type: String
     default: 288
+
+  headers:
+    desc: Lista de itens sendo cada um o header de cada coluna.
+    default: []
+    type: Array
   
   height:
     desc: Altura do container do board. Caso não seja passado um height, o calculo é feito para ocupar a maior altura possível da página.
     type: String
+  
+  lazy-loading-fields-keys:
+    desc: Chaves dos campos que são lazy loading para o tratamento de merge das options.
+    type: Array
+    default: []
 
   limit:
     desc: Quantidade de itens da coluna por busca na API.

--- a/ui/src/components/board-generator/QasBoardGenerator.yml
+++ b/ui/src/components/board-generator/QasBoardGenerator.yml
@@ -86,7 +86,7 @@ events:
         type: Object
 
   '@update:fetch-column-success -> function({ response, header })':
-    desc: Dispara após uma busca de uma coluna for feita.
+    desc: Dispara quando o "fetchColumn" é executado com sucesso.
     params:
       response:
         desc: Retorno da API.
@@ -94,6 +94,13 @@ events:
 
       header:
         desc: header da coluna atual.
+        type: Object
+
+  '@update:fetch-column-error -> function(error)':
+    desc: Dispara quando o "fetchColumn" cai em uma exceção.
+    params:
+      error:
+        desc: Retorna todos os dados "cru" respondido na exceção do fetch.
         type: Object
 
 methods:


### PR DESCRIPTION
### Modificado
- `QasBoardGenerator`: 
  - alterado prop `results` para `headers`.
  - `v-model` agora é recuperado pelo `v-model:results`.
  - alterado prop `use-shallow-ref` para `use-mark-raw`.

### Adicionado
- `QasBoardGenerator`: Adicionado eventos `fetch-columns-success`, `fetch-columns-error`, `fetch-column-success` e `fetch-column-error`.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
