### PR TITLE
Feature/token notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## [Não publicado]
+### Corrigido
+- `boot/notifications`: corrigido a forma de passar o token para o método `setLaravelEcho`, onde precisou de uma validação para formatar o token passando o valor correto.
+
 ## [3.15.0-beta.6] - 04-03-2024
 ## BREAKING CHANGES
 - `QasBoardGenerator`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## [Não publicado]
+## Não publicado
 ### Corrigido
 - `boot/notifications`: corrigido a forma de passar o token para o método `setLaravelEcho`, onde precisou de uma validação para formatar o token passando o valor correto.
 

--- a/app-extension/src/boot/notifications.js
+++ b/app-extension/src/boot/notifications.js
@@ -12,7 +12,6 @@ import { boot } from 'quasar/wrappers'
 
 export default boot(() => {
   window.addEventListener('message', ({ data }) => {
-    console.log('passou aqui xddd')
     if (data.type !== 'updateUser') return
 
     const user = data.user

--- a/app-extension/src/boot/notifications.js
+++ b/app-extension/src/boot/notifications.js
@@ -18,15 +18,15 @@ export default boot(() => {
     const user = data.user
     const accessToken = LocalStorage.getItem('accessToken')
 
+    const hasBearerPrefix = accessToken.startsWith('Bearer ')
+    const userToken = hasBearerPrefix ? accessToken : `Bearer ${accessToken}`
+
     /**
      * Aqui vamos estabelecer a conexão com o servidor apenas na tab (aba) líder.
      * Vamos escutar por novas notificações, sempre que receber uma notificação,
      * iremos enviar via BroadcastChannel.postMessage().
      */
     onLeaderElectionChannel(channel => {
-      const hasBearerPrefix = accessToken.startsWith('Bearer ')
-      const userToken = hasBearerPrefix ? accessToken : `Bearer ${accessToken}`
-
       setLaravelEcho(userToken)
       setLaravelEchoListener({ user, channel })
     })

--- a/app-extension/src/boot/notifications.js
+++ b/app-extension/src/boot/notifications.js
@@ -12,6 +12,7 @@ import { boot } from 'quasar/wrappers'
 
 export default boot(() => {
   window.addEventListener('message', ({ data }) => {
+    console.log('passou aqui xddd')
     if (data.type !== 'updateUser') return
 
     const user = data.user
@@ -23,7 +24,10 @@ export default boot(() => {
      * iremos enviar via BroadcastChannel.postMessage().
      */
     onLeaderElectionChannel(channel => {
-      setLaravelEcho(accessToken)
+      const hasBearerPrefix = accessToken.startsWith('Bearer ')
+      const userToken = hasBearerPrefix ? accessToken : `Bearer ${accessToken}`
+
+      setLaravelEcho(userToken)
       setLaravelEchoListener({ user, channel })
     })
 


### PR DESCRIPTION
### Corrigido
- `boot/notifications`: corrigido a forma de passar o token para o método `setLaravelEcho`, onde precisou de uma validação para formatar o token passando o valor correto.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [ ] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [x] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
