### PR TITLE
QasAppMenu: fixed issue on resize.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasAppMenu`: Corrigido bug que ocorria com o QDrawer quando usado com a versão do vue `v3.4+`, onde era removido o scroll da pagina quando ocorria um resize na pagina de desktop pra mobile.
+
 ## [3.15.0-beta.7] - 11-03-2024
 ### Corrigido
 - `boot/notifications`: corrigido a forma de passar o token para o método `setLaravelEcho`, onde precisou de uma validação para formatar o token passando o valor correto.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ## Não publicado
 ### Corrigido
-- `QasAppMenu`: Corrigido bug que ocorria com o QDrawer quando usado com a versão do vue `v3.4+`, onde era removido o scroll da pagina quando ocorria um resize na pagina de desktop pra mobile.
+- `QasAppMenu`: Correção temporária (ou permanente caso não seja resolvido no quasar), bug que ocorria com o QDrawer quando usado com a versão do vue `v3.4+`, onde era removido o scroll da pagina quando ocorria um resize na pagina de desktop pra mobile.
 
 ## [3.15.0-beta.7] - 11-03-2024
 ### Corrigido

--- a/ui/src/components/app-menu/QasAppMenu.vue
+++ b/ui/src/components/app-menu/QasAppMenu.vue
@@ -101,8 +101,6 @@ defineOptions({
   inheritAttrs: false
 })
 
-console.log('Fui chamado no app-menu')
-
 const props = defineProps({
   appUserProps: {
     type: Object,

--- a/ui/src/components/app-menu/QasAppMenu.vue
+++ b/ui/src/components/app-menu/QasAppMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="qas-app-menu">
-    <q-drawer v-model="model" :behavior="behavior" class="shadow-2" :mini="isMiniMode" :mini-width="88" show-if-above :width="drawerWidth" @mouseenter="onMouseEvent" @mouseleave="onMouseEvent">
+    <q-drawer :key="reRenderCount" v-model="model" :behavior="behavior" class="shadow-2" :mini="isMiniMode" :mini-width="88" show-if-above :width="drawerWidth" @mouseenter="onMouseEvent" @mouseleave="onMouseEvent">
       <div class="column full-height justify-between no-wrap">
         <div class="full-width">
           <!-- Brand -->
@@ -93,13 +93,15 @@ import useAppUser from './composables/use-app-user'
 import useDevelopmentBadge from './composables/use-development-badge'
 import { useScreen } from '../../composables'
 
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { useRouter } from 'vue-router'
 
 defineOptions({
   name: 'QasAppMenu',
   inheritAttrs: false
 })
+
+console.log('Fui chamado no app-menu')
 
 const props = defineProps({
   appUserProps: {
@@ -155,6 +157,7 @@ const rootRoute = router.hasRoute('Root') ? { name: 'Root' } : { path: '/' }
 
 const hasOpenedMenu = ref(false)
 const isMini = ref(screen.isLarge)
+const reRenderCount = ref(0)
 
 const composableParams = {
   props,
@@ -191,6 +194,24 @@ const classes = computed(() => {
     spacedItem: {
       'qas-app-menu__label--spaced': !isMiniMode.value
     }
+  }
+})
+
+/**
+ * @desc Recurso tecnológico temporário (ou definitivo), este bug ocorre por conta
+ * da atualização do vue para a versão `v3.4+`, onde tiveram mudanças referentes a
+ * reatividade, existem issues abertas no Quasar, porém sem expectativas
+ * de que um dia será resolvido por parte deles.
+ *
+ * @see {@link https://github.com/quasarframework/quasar/issues/16651}
+ */
+watch(() => behavior.value, value => {
+  /**
+   * @desc quando o comportamento passa a ser desktop novamente é porque aconteceu um
+   * resize na pagina, então é necessário renderizar o componente QDrawer novamente.
+   */
+  if (value === 'desktop') {
+    reRenderCount.value += 1
   }
 })
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Corrigido
- `QasAppMenu`: Corrigido bug que ocorria com o QDrawer quando usado com a versão do vue `v3.4+`, onde era removido o scroll da pagina quando ocorria um resize na pagina de desktop pra mobile.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
