### PR TITLE
fix: single btn dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## [Não publicado]
+### Corrigido
+- `QasBtnDropdown`: corrigido dropdown para o uso do botão no menu para troca dos módulos.
+
 ## [3.15.0-beta.9] - 04-04-2024
 ## BREAKING CHANGES
 - `QasBtnDropdown`:

--- a/ui/src/components/app-menu/private/PvAppMenuDropdown.vue
+++ b/ui/src/components/app-menu/private/PvAppMenuDropdown.vue
@@ -41,14 +41,16 @@ const props = defineProps({
 const defaultButtonDropdownProps = computed(() => ({
   ...props.buttonDropdownProps,
 
-  buttonProps: {
-    align: 'between',
-    class: 'text-subtitle2',
-    color: 'primary',
-    iconRight: 'sym_r_expand_more',
-    label: props.currentModule.label,
-    useEllipsis: true,
-    useLabelOnSmallScreen: true
+  buttonsPropsList: {
+    modules: {
+      align: 'between',
+      class: 'text-subtitle2',
+      color: 'primary',
+      iconRight: 'sym_r_expand_more',
+      label: props.currentModule.label,
+      useEllipsis: true,
+      useLabelOnSmallScreen: true
+    }
   }
 }))
 

--- a/ui/src/components/btn-dropdown/QasBtnDropdown.vue
+++ b/ui/src/components/btn-dropdown/QasBtnDropdown.vue
@@ -1,10 +1,13 @@
 <template>
   <div class="qas-btn-dropdown" :class="classes.parent">
-    <div v-if="hasButtons" class="flex">
+    <div v-if="hasButtons" :class="classes.list">
       <div v-for="(buttonProps, key, index) in props.buttonsPropsList" :key="key">
         <div class="flex">
           <qas-btn :disable="props.disable" v-bind="buttonProps" variant="tertiary" @click="onClick">
-            <q-menu v-if="hasMenuOnLeftSide" v-model="isMenuOpened" anchor="bottom right" auto-close self="top right" @update:model-value="onUpdateMenuValue">
+            <q-menu
+              v-if="hasMenuOnLeftSide" v-model="isMenuOpened" anchor="bottom right" auto-close self="top right"
+              @update:model-value="onUpdateMenuValue"
+            >
               <div :class="classes.menuContent">
                 <slot />
               </div>
@@ -13,7 +16,10 @@
 
           <slot :name="`bottom-${key}`" />
 
-          <q-separator v-if="hasSeparator(index)" class="q-mx-sm qas-btn-dropdown__separator self-center" dark vertical />
+          <q-separator
+            v-if="hasSeparator(index)" class="q-mx-sm qas-btn-dropdown__separator self-center" dark
+            vertical
+          />
         </div>
       </div>
     </div>
@@ -88,6 +94,10 @@ const classes = computed(() => {
 
     menuContent: {
       'q-pa-md': props.useMenuPadding
+    },
+
+    list: {
+      flex: !isSingleButton.value
     }
   }
 })


### PR DESCRIPTION
- `QasBtnDropdown`: corrigido dropdown para o uso do botão no menu para troca dos módulos.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
