### PR TITLE
Feature/stepper form view component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## [Não publicado]
+## BREAKING CHANGES
+- `QasStepper`: Removido possibilidade do model ser `String`, irá ser possível somente `Number`.
+
+### Removido
+- `QasStepper`: Removido possibilidade do model ser `String`, irá ser possível somente `Number`.
+
+### Adicionado
+- `QasStepperFormView`: Adicionado componente de gerador de steppers de formulário, utilizando o `QasSteppers`.
+
 ## [3.15.0-beta.10] - 12-04-2024
 ### Adicionado
 - `Spacing.js`: Adicionado espaçamentos `4xl e 5xl`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,7 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## [Não publicado]
-## BREAKING CHANGES
-- `QasStepper`: Removido possibilidade do model ser `String`, irá ser possível somente `Number`.
-
-### Removido
-- `QasStepper`: Removido possibilidade do model ser `String`, irá ser possível somente `Number`.
-
+## Não publicado
 ### Adicionado
 - `QasStepperFormView`: Adicionado componente de gerador de steppers de formulário, utilizando o `QasSteppers`.
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -26,7 +26,7 @@
         "highlight.js": "^11.8.0",
         "markdown-it": "^13.0.1",
         "quasar": "^2.14.2",
-        "vue": "^3.3.13",
+        "vue": "3.4.21",
         "vue-chartjs": "^5.2.0",
         "vue-router": "^4.2.2",
         "vuex": "^4.1.0",
@@ -48,7 +48,7 @@
     },
     "../ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.15.0-beta.9",
+      "version": "3.15.0-beta.10",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/store-adapter": "^1.0.0",
@@ -2533,8 +2533,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.6",
-      "license": "MIT",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.4.tgz",
+      "integrity": "sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -5229,11 +5230,12 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.4.15",
-      "license": "MIT",
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.21.tgz",
+      "integrity": "sha512-MjXawxZf2SbZszLPYxaFCjxfibYrzr3eYbKxwpLR9EQN+oaziSu3qKVbwBERj1IFIB8OLUewxB5m/BFzi613og==",
       "dependencies": {
-        "@babel/parser": "^7.23.6",
-        "@vue/shared": "3.4.15",
+        "@babel/parser": "^7.23.9",
+        "@vue/shared": "3.4.21",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.0.2"
@@ -5241,7 +5243,8 @@
     },
     "node_modules/@vue/compiler-core/node_modules/entities": {
       "version": "4.5.0",
-      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "engines": {
         "node": ">=0.12"
       },
@@ -5250,34 +5253,37 @@
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.4.15",
-      "license": "MIT",
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.21.tgz",
+      "integrity": "sha512-IZC6FKowtT1sl0CR5DpXSiEB5ayw75oT2bma1BEhV7RRR1+cfwLrxc2Z8Zq/RGFzJ8w5r9QtCOvTjQgdn0IKmA==",
       "dependencies": {
-        "@vue/compiler-core": "3.4.15",
-        "@vue/shared": "3.4.15"
+        "@vue/compiler-core": "3.4.21",
+        "@vue/shared": "3.4.21"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.4.15",
-      "license": "MIT",
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.21.tgz",
+      "integrity": "sha512-me7epoTxYlY+2CUM7hy9PCDdpMPfIwrOvAXud2Upk10g4YLv9UBW7kL798TvMeDhPthkZ0CONNrK2GoeI1ODiQ==",
       "dependencies": {
-        "@babel/parser": "^7.23.6",
-        "@vue/compiler-core": "3.4.15",
-        "@vue/compiler-dom": "3.4.15",
-        "@vue/compiler-ssr": "3.4.15",
-        "@vue/shared": "3.4.15",
+        "@babel/parser": "^7.23.9",
+        "@vue/compiler-core": "3.4.21",
+        "@vue/compiler-dom": "3.4.21",
+        "@vue/compiler-ssr": "3.4.21",
+        "@vue/shared": "3.4.21",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.5",
-        "postcss": "^8.4.33",
+        "magic-string": "^0.30.7",
+        "postcss": "^8.4.35",
         "source-map-js": "^1.0.2"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.4.15",
-      "license": "MIT",
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.21.tgz",
+      "integrity": "sha512-M5+9nI2lPpAsgXOGQobnIueVqc9sisBFexh5yMIMRAPYLa7+5wEJs8iqOZc1WAa9WQbx9GR2twgznU8LTIiZ4Q==",
       "dependencies": {
-        "@vue/compiler-dom": "3.4.15",
-        "@vue/shared": "3.4.15"
+        "@vue/compiler-dom": "3.4.21",
+        "@vue/shared": "3.4.21"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -5285,43 +5291,48 @@
       "license": "MIT"
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.4.15",
-      "license": "MIT",
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.21.tgz",
+      "integrity": "sha512-UhenImdc0L0/4ahGCyEzc/pZNwVgcglGy9HVzJ1Bq2Mm9qXOpP8RyNTjookw/gOCUlXSEtuZ2fUg5nrHcoqJcw==",
       "dependencies": {
-        "@vue/shared": "3.4.15"
+        "@vue/shared": "3.4.21"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.4.15",
-      "license": "MIT",
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.21.tgz",
+      "integrity": "sha512-pQthsuYzE1XcGZznTKn73G0s14eCJcjaLvp3/DKeYWoFacD9glJoqlNBxt3W2c5S40t6CCcpPf+jG01N3ULyrA==",
       "dependencies": {
-        "@vue/reactivity": "3.4.15",
-        "@vue/shared": "3.4.15"
+        "@vue/reactivity": "3.4.21",
+        "@vue/shared": "3.4.21"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.4.15",
-      "license": "MIT",
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.21.tgz",
+      "integrity": "sha512-gvf+C9cFpevsQxbkRBS1NpU8CqxKw0ebqMvLwcGQrNpx6gqRDodqKqA+A2VZZpQ9RpK2f9yfg8VbW/EpdFUOJw==",
       "dependencies": {
-        "@vue/runtime-core": "3.4.15",
-        "@vue/shared": "3.4.15",
+        "@vue/runtime-core": "3.4.21",
+        "@vue/shared": "3.4.21",
         "csstype": "^3.1.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.4.15",
-      "license": "MIT",
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.21.tgz",
+      "integrity": "sha512-aV1gXyKSN6Rz+6kZ6kr5+Ll14YzmIbeuWe7ryJl5muJ4uwSwY/aStXTixx76TwkZFJLm1aAlA/HSWEJ4EyiMkg==",
       "dependencies": {
-        "@vue/compiler-ssr": "3.4.15",
-        "@vue/shared": "3.4.15"
+        "@vue/compiler-ssr": "3.4.21",
+        "@vue/shared": "3.4.21"
       },
       "peerDependencies": {
-        "vue": "3.4.15"
+        "vue": "3.4.21"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.4.15",
-      "license": "MIT"
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.21.tgz",
+      "integrity": "sha512-PuJe7vDIi6VYSinuEbUIQgMIRZGgM8e4R+G+/dQTk0X1NEdvgvvgv7m+rfmDH1gZzyA1OjjoWskvHlfRNfQf3g=="
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.6",
@@ -7236,7 +7247,8 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/custom-idle-queue": {
       "version": "3.0.1",
@@ -11133,13 +11145,11 @@
       "license": "MIT"
     },
     "node_modules/magic-string": {
-      "version": "0.30.5",
-      "license": "MIT",
+      "version": "0.30.10",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -12268,7 +12278,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.33",
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
       "funding": [
         {
           "type": "opencollective",
@@ -12283,11 +12295,10 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -15101,8 +15112,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "license": "BSD-3-Clause",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16332,14 +16344,15 @@
       "license": "MIT"
     },
     "node_modules/vue": {
-      "version": "3.4.15",
-      "license": "MIT",
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.21.tgz",
+      "integrity": "sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA==",
       "dependencies": {
-        "@vue/compiler-dom": "3.4.15",
-        "@vue/compiler-sfc": "3.4.15",
-        "@vue/runtime-dom": "3.4.15",
-        "@vue/server-renderer": "3.4.15",
-        "@vue/shared": "3.4.15"
+        "@vue/compiler-dom": "3.4.21",
+        "@vue/compiler-sfc": "3.4.21",
+        "@vue/runtime-dom": "3.4.21",
+        "@vue/server-renderer": "3.4.21",
+        "@vue/shared": "3.4.21"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -18037,7 +18050,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.23.6"
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.4.tgz",
+      "integrity": "sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg=="
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
       "version": "7.18.6",
@@ -20859,81 +20874,101 @@
       "dev": true
     },
     "@vue/compiler-core": {
-      "version": "3.4.15",
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.21.tgz",
+      "integrity": "sha512-MjXawxZf2SbZszLPYxaFCjxfibYrzr3eYbKxwpLR9EQN+oaziSu3qKVbwBERj1IFIB8OLUewxB5m/BFzi613og==",
       "requires": {
-        "@babel/parser": "^7.23.6",
-        "@vue/shared": "3.4.15",
+        "@babel/parser": "^7.23.9",
+        "@vue/shared": "3.4.21",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.0.2"
       },
       "dependencies": {
         "entities": {
-          "version": "4.5.0"
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
         }
       }
     },
     "@vue/compiler-dom": {
-      "version": "3.4.15",
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.21.tgz",
+      "integrity": "sha512-IZC6FKowtT1sl0CR5DpXSiEB5ayw75oT2bma1BEhV7RRR1+cfwLrxc2Z8Zq/RGFzJ8w5r9QtCOvTjQgdn0IKmA==",
       "requires": {
-        "@vue/compiler-core": "3.4.15",
-        "@vue/shared": "3.4.15"
+        "@vue/compiler-core": "3.4.21",
+        "@vue/shared": "3.4.21"
       }
     },
     "@vue/compiler-sfc": {
-      "version": "3.4.15",
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.21.tgz",
+      "integrity": "sha512-me7epoTxYlY+2CUM7hy9PCDdpMPfIwrOvAXud2Upk10g4YLv9UBW7kL798TvMeDhPthkZ0CONNrK2GoeI1ODiQ==",
       "requires": {
-        "@babel/parser": "^7.23.6",
-        "@vue/compiler-core": "3.4.15",
-        "@vue/compiler-dom": "3.4.15",
-        "@vue/compiler-ssr": "3.4.15",
-        "@vue/shared": "3.4.15",
+        "@babel/parser": "^7.23.9",
+        "@vue/compiler-core": "3.4.21",
+        "@vue/compiler-dom": "3.4.21",
+        "@vue/compiler-ssr": "3.4.21",
+        "@vue/shared": "3.4.21",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.5",
-        "postcss": "^8.4.33",
+        "magic-string": "^0.30.7",
+        "postcss": "^8.4.35",
         "source-map-js": "^1.0.2"
       }
     },
     "@vue/compiler-ssr": {
-      "version": "3.4.15",
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.21.tgz",
+      "integrity": "sha512-M5+9nI2lPpAsgXOGQobnIueVqc9sisBFexh5yMIMRAPYLa7+5wEJs8iqOZc1WAa9WQbx9GR2twgznU8LTIiZ4Q==",
       "requires": {
-        "@vue/compiler-dom": "3.4.15",
-        "@vue/shared": "3.4.15"
+        "@vue/compiler-dom": "3.4.21",
+        "@vue/shared": "3.4.21"
       }
     },
     "@vue/devtools-api": {
       "version": "6.5.0"
     },
     "@vue/reactivity": {
-      "version": "3.4.15",
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.21.tgz",
+      "integrity": "sha512-UhenImdc0L0/4ahGCyEzc/pZNwVgcglGy9HVzJ1Bq2Mm9qXOpP8RyNTjookw/gOCUlXSEtuZ2fUg5nrHcoqJcw==",
       "requires": {
-        "@vue/shared": "3.4.15"
+        "@vue/shared": "3.4.21"
       }
     },
     "@vue/runtime-core": {
-      "version": "3.4.15",
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.21.tgz",
+      "integrity": "sha512-pQthsuYzE1XcGZznTKn73G0s14eCJcjaLvp3/DKeYWoFacD9glJoqlNBxt3W2c5S40t6CCcpPf+jG01N3ULyrA==",
       "requires": {
-        "@vue/reactivity": "3.4.15",
-        "@vue/shared": "3.4.15"
+        "@vue/reactivity": "3.4.21",
+        "@vue/shared": "3.4.21"
       }
     },
     "@vue/runtime-dom": {
-      "version": "3.4.15",
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.21.tgz",
+      "integrity": "sha512-gvf+C9cFpevsQxbkRBS1NpU8CqxKw0ebqMvLwcGQrNpx6gqRDodqKqA+A2VZZpQ9RpK2f9yfg8VbW/EpdFUOJw==",
       "requires": {
-        "@vue/runtime-core": "3.4.15",
-        "@vue/shared": "3.4.15",
+        "@vue/runtime-core": "3.4.21",
+        "@vue/shared": "3.4.21",
         "csstype": "^3.1.3"
       }
     },
     "@vue/server-renderer": {
-      "version": "3.4.15",
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.21.tgz",
+      "integrity": "sha512-aV1gXyKSN6Rz+6kZ6kr5+Ll14YzmIbeuWe7ryJl5muJ4uwSwY/aStXTixx76TwkZFJLm1aAlA/HSWEJ4EyiMkg==",
       "requires": {
-        "@vue/compiler-ssr": "3.4.15",
-        "@vue/shared": "3.4.15"
+        "@vue/compiler-ssr": "3.4.21",
+        "@vue/shared": "3.4.21"
       }
     },
     "@vue/shared": {
-      "version": "3.4.15"
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.21.tgz",
+      "integrity": "sha512-PuJe7vDIi6VYSinuEbUIQgMIRZGgM8e4R+G+/dQTk0X1NEdvgvvgv7m+rfmDH1gZzyA1OjjoWskvHlfRNfQf3g=="
     },
     "@webassemblyjs/ast": {
       "version": "1.11.6",
@@ -22196,7 +22231,9 @@
       }
     },
     "csstype": {
-      "version": "3.1.3"
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "custom-idle-queue": {
       "version": "3.0.1",
@@ -24687,7 +24724,9 @@
       "version": "2.2.1"
     },
     "magic-string": {
-      "version": "0.30.5",
+      "version": "0.30.10",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
       "requires": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
       }
@@ -25390,11 +25429,13 @@
       }
     },
     "postcss": {
-      "version": "8.4.33",
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
       "requires": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       }
     },
     "postcss-calc": {
@@ -27326,7 +27367,9 @@
       "version": "0.6.1"
     },
     "source-map-js": {
-      "version": "1.0.2"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg=="
     },
     "source-map-support": {
       "version": "0.5.21",
@@ -28078,13 +28121,15 @@
       "dev": true
     },
     "vue": {
-      "version": "3.4.15",
+      "version": "3.4.21",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.21.tgz",
+      "integrity": "sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA==",
       "requires": {
-        "@vue/compiler-dom": "3.4.15",
-        "@vue/compiler-sfc": "3.4.15",
-        "@vue/runtime-dom": "3.4.15",
-        "@vue/server-renderer": "3.4.15",
-        "@vue/shared": "3.4.15"
+        "@vue/compiler-dom": "3.4.21",
+        "@vue/compiler-sfc": "3.4.21",
+        "@vue/runtime-dom": "3.4.21",
+        "@vue/server-renderer": "3.4.21",
+        "@vue/shared": "3.4.21"
       }
     },
     "vue-chartjs": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -30,7 +30,7 @@
     "highlight.js": "^11.8.0",
     "markdown-it": "^13.0.1",
     "quasar": "^2.14.2",
-    "vue": "^3.3.13",
+    "vue": "3.4.21",
     "vue-chartjs": "^5.2.0",
     "vue-router": "^4.2.2",
     "vuex": "^4.1.0",

--- a/docs/src/assets/menu.js
+++ b/docs/src/assets/menu.js
@@ -292,6 +292,10 @@ module.exports = [
         path: '/components/stepper'
       },
       {
+        name: 'StepperFormView',
+        path: '/components/stepper-form-view'
+      },
+      {
         name: 'TableGenerator',
         path: '/components/table-generator'
       },

--- a/docs/src/examples/QasStepperFormView/Basic.vue
+++ b/docs/src/examples/QasStepperFormView/Basic.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="container spaced">
+    <qas-stepper-form-view v-model="model" :form-view-props="formViewProps" :steppers="steppers" />
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import FirstStep from './FirstStep.vue'
+import SecondStep from './SecondStep'
+
+defineOptions({ name: 'Basic' })
+
+const model = ref(1)
+
+const formViewProps = {
+  entity: 'users',
+  mode: 'create'
+}
+
+const steppers = computed(() => {
+  return [
+    {
+      stepProps: {
+        title: 'Página 1',
+        caption: '20/04/2024',
+        prefix: 1
+      },
+      component: FirstStep
+    },
+    {
+      stepProps: {
+        title: 'Página 2',
+        prefix: 2
+      },
+      component: SecondStep
+    }
+  ]
+})
+</script>

--- a/docs/src/examples/QasStepperFormView/Basic.vue
+++ b/docs/src/examples/QasStepperFormView/Basic.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container spaced">
-    <qas-stepper-form-view v-model="model" :form-view-props="formViewProps" :steppers="steppers" />
+    <qas-stepper-form-view v-model="model" :form-view-props="formViewProps" :steps="steps" />
   </div>
 </template>
 
@@ -18,7 +18,7 @@ const formViewProps = {
   mode: 'create'
 }
 
-const steppers = computed(() => {
+const steps = computed(() => {
   return [
     {
       stepProps: {

--- a/docs/src/examples/QasStepperFormView/FirstStep.vue
+++ b/docs/src/examples/QasStepperFormView/FirstStep.vue
@@ -1,0 +1,7 @@
+<template>
+  <div>página 1</div>
+</template>
+
+<script setup>
+defineOptions({ name: 'FirstStep' })
+</script>

--- a/docs/src/examples/QasStepperFormView/FirstStep.vue
+++ b/docs/src/examples/QasStepperFormView/FirstStep.vue
@@ -16,7 +16,9 @@ defineOptions({ name: 'FirstStep' })
 const fields = ref({})
 const values = ref({})
 
-// Através do inject do stepper, é possível você ter ações que o componente fornece.
+/*
+ * Através do inject do stepper, é possível você ter ações que o componente fornece.
+ */
 const stepper = inject('stepper')
 
 const formattedFields = computed(() => {
@@ -30,20 +32,20 @@ const formattedFields = computed(() => {
 const formViewProps = computed(() => {
   return {
     /* É possível pegar as props passadas para o componente (QasStepperFormView),
-    * sendo uma boa prática para pegar propriedades que são comuns entre as páginas (entity, mode, etc)
-    */
+     * sendo uma boa prática para pegar propriedades que são comuns entre as páginas (entity, mode, etc)
+     */
     ...stepper.formViewProps.value
   }
 })
 
 /*
-* O correto seria usar no submit-success, porém para
-* simulação na documentação foi feito dessa forma.
-*/
+ * O correto seria usar no submit-success, porém para
+ * simulação na documentação foi feito dessa forma.
+ */
 function onBeforeSubmit ({ payload }) {
   /* Avança para o próximo step, passando o payload da página, para que
-  * na próxima página tenha acesso ao dados para efetuar o merge.
-  */
+   * na próxima página tenha acesso ao dados para efetuar o merge.
+   */
   stepper.next({ payload: payload.payload })
 }
 </script>

--- a/docs/src/examples/QasStepperFormView/FirstStep.vue
+++ b/docs/src/examples/QasStepperFormView/FirstStep.vue
@@ -20,7 +20,6 @@ const values = ref({})
 const stepper = inject('stepper')
 
 const formattedFields = computed(() => {
-  console.log(fields.value)
   if (!Object.keys(fields.value).length) return {}
 
   const { company, name } = fields.value

--- a/docs/src/examples/QasStepperFormView/FirstStep.vue
+++ b/docs/src/examples/QasStepperFormView/FirstStep.vue
@@ -1,7 +1,50 @@
 <template>
-  <div>página 1</div>
+  <qas-form-view v-model="values" v-model:fields="fields" :before-submit="onBeforeSubmit" :cancel-route="false" v-bind="formViewProps">
+    <template #default>
+      <qas-form-generator v-model="values" :fields="formattedFields" />
+    </template>
+  </qas-form-view>
+
+  v-model: <qas-debugger :inspect="[values]" />
 </template>
 
 <script setup>
+import { ref, inject, computed } from 'vue'
+
 defineOptions({ name: 'FirstStep' })
+
+const fields = ref({})
+const values = ref({})
+
+// Através do inject do stepper, é possível você ter ações que o componente fornece.
+const stepper = inject('stepper')
+
+const formattedFields = computed(() => {
+  console.log(fields.value)
+  if (!Object.keys(fields.value).length) return {}
+
+  const { company, name } = fields.value
+
+  return { company, name }
+})
+
+const formViewProps = computed(() => {
+  return {
+    /* É possível pegar as props passadas para o componente (QasStepperFormView),
+    * sendo uma boa prática para pegar propriedades que são comuns entre as páginas (entity, mode, etc)
+    */
+    ...stepper.formViewProps.value
+  }
+})
+
+/*
+* O correto seria usar no submit-success, porém para
+* simulação na documentação foi feito dessa forma.
+*/
+function onBeforeSubmit ({ payload }) {
+  /* Avança para o próximo step, passando o payload da página, para que
+  * na próxima página tenha acesso ao dados para efetuar o merge.
+  */
+  stepper.next({ payload: payload.payload })
+}
 </script>

--- a/docs/src/examples/QasStepperFormView/SecondStep.vue
+++ b/docs/src/examples/QasStepperFormView/SecondStep.vue
@@ -1,7 +1,62 @@
 <template>
-  <div>página 2</div>
+  <qas-form-view v-model="values" v-model:fields="fields" :cancel-route="cancelRoute" v-bind="formViewProps">
+    <template #default>
+      <qas-form-generator v-model="values" :fields="formattedFields" />
+    </template>
+  </qas-form-view>
+
+  <div class="full-width q-my-md">
+    <qas-btn label="Mudar título do segundo step" @click="changeStepTitle" />
+  </div>
+
+  Payload mergeado com a página 1: <qas-debugger :inspect="[values]" />
 </template>
 
 <script setup>
+import { ref, inject, computed } from 'vue'
+
 defineOptions({ name: 'SecondStep' })
+
+// Através do inject do stepper, é possível você ter ações que o componente fornece.
+const stepper = inject('stepper')
+
+const fields = ref({})
+
+/*
+* Payload mergeado com a página 1 para ser enviado o payload completo para API.
+*/
+const values = ref({ ...stepper.steppersValues.value })
+
+const formViewProps = computed(() => {
+  return {
+    /* É possível pegar as props passadas para o componente (QasStepperFormView),
+    * sendo uma boa prática para pegar propriedades que são comuns entre as páginas (entity, mode, etc)
+    */
+    ...stepper.formViewProps.value
+  }
+})
+
+const formattedFields = computed(() => {
+  if (!Object.keys(fields.value).length) return {}
+
+  const { phone, document } = fields.value
+
+  return { phone, document }
+})
+
+// função para voltar para o step anterior.
+function cancelRoute () {
+  stepper.previous()
+}
+
+function changeStepTitle () {
+  stepper.setStepProps({
+    step: 2,
+    payload: {
+      title: 'Titulo alterado',
+      caption: 'Caption',
+      prefix: 2
+    }
+  })
+}
 </script>

--- a/docs/src/examples/QasStepperFormView/SecondStep.vue
+++ b/docs/src/examples/QasStepperFormView/SecondStep.vue
@@ -1,0 +1,7 @@
+<template>
+  <div>página 2</div>
+</template>
+
+<script setup>
+defineOptions({ name: 'SecondStep' })
+</script>

--- a/docs/src/pages/components/stepper-form-view.md
+++ b/docs/src/pages/components/stepper-form-view.md
@@ -1,0 +1,13 @@
+---
+title: QasStepperFormView
+---
+
+Trocar depois
+
+<doc-api file="stepper/QasStepper" name="QasStepper" />
+
+## Uso
+
+<doc-example file="QasStepper/Basic" title="Básico" />
+
+<doc-example file="QasStepper/StepperWithIcon" title="Com ícone" />

--- a/docs/src/pages/components/stepper-form-view.md
+++ b/docs/src/pages/components/stepper-form-view.md
@@ -6,6 +6,28 @@ Componente para lidar com formulário em steps.
 
 <doc-api file="stepper-form-view/QasStepperFormView" name="QasStepperFormView" />
 
+::: danger
+O componente internamente utiliza `defineModel`(https://vuejs.org/api/sfc-script-setup.html#definemodel), recurso disponível
+somente para versões `3.4+` do Vue.
+:::
+
+:::info
+Existem alguns padrões de API que é recomendado utilizar.
+Os endpoints devem seguir o padrão `:entity/step/:stepActive/new`, onde o `stepActive` é o valor do step atual.
+
+Exemplos:
+
+Estou na página 1 de criação de usuário, considerando que a entidade é `users` -> `users/step/one/new`.
+Estou na página 2 de criação de usuário, considerando que a entidade é `users` -> `users/step/two/new`.
+Estou na página 1 de edição de usuário, considerando que a entidade é `users` -> `users/:id/step/one/edit`.
+Estou na página 2 de edição de usuário, considerando que a entidade é `users` -> `users/:id/step/two/edit`.
+
+Outro ponto também, é que nos endpoints de POST das páginas, deverá ser sempre usado somente para validar os campos,
+sendo o último step sendo encarregado de enviar o payload mergeando todos payloads de todas páginas, para isso existe 
+a combinação da função `next` e o `stepper.stepsValues.value` para recuperar o payload dos outros step estando no
+último step(para mais detalhes, há um exemplo usado na documentação abaixo).
+:::
+
 ## Uso
 
 <doc-example file="QasStepperFormView/Basic" title="Básico" />
@@ -15,7 +37,7 @@ Siga os exemplos de como utilizar as funções fornecidas pelo componente atrav�
 Os componentes de página estão todos comentados.
 :::
 
-Página 1:
+Página 1 usada no exemplo ácima:
 ```js
 <template>
   <qas-form-view v-model="values" v-model:fields="fields" :cancel-route="false" v-bind="formViewProps" @submit-success="onSubmitSuccess">
@@ -50,7 +72,7 @@ function onSubmitSuccess (payload) {
 </script>
 ```
 
-Página 2:
+Página 2 usada no exemplo ácima:
 ```js
 <template>
   <qas-form-view v-model="values" v-model:fields="fields" :cancel-route="cancelRoute" v-bind="formViewProps" :before-submit="beforeSubmit">

--- a/docs/src/pages/components/stepper-form-view.md
+++ b/docs/src/pages/components/stepper-form-view.md
@@ -2,7 +2,7 @@
 title: QasStepperFormView
 ---
 
-Componente para lidar com formulário em steps.
+Componente para lidar com formulário em steps de formulário.
 
 <doc-api file="stepper-form-view/QasStepperFormView" name="QasStepperFormView" />
 
@@ -22,10 +22,10 @@ Estou na página 2 de criação de usuário, considerando que a entidade é `use
 Estou na página 1 de edição de usuário, considerando que a entidade é `users` -> `users/:id/step/one/edit`.
 Estou na página 2 de edição de usuário, considerando que a entidade é `users` -> `users/:id/step/two/edit`.
 
-Outro ponto também, é que nos endpoints de POST das páginas, deverá ser sempre usado somente para validar os campos,
-sendo o último step sendo encarregado de enviar o payload mergeando todos payloads de todas páginas, para isso existe 
+Outro ponto também, é que nos endpoints de POST/PUT/PATCH das páginas, deverá ser sempre usado somente para validar os campos,
+sendo o último step o encarregado de enviar o payload mergeando todos payloads de todas páginas, para isso existe 
 a combinação da função `next` e o `stepper.stepsValues.value` para recuperar o payload dos outros step estando no
-último step(para mais detalhes, há um exemplo usado na documentação abaixo).
+último step (para mais detalhes, há um exemplo usado na documentação abaixo).
 :::
 
 ## Uso

--- a/docs/src/pages/components/stepper-form-view.md
+++ b/docs/src/pages/components/stepper-form-view.md
@@ -4,10 +4,8 @@ title: QasStepperFormView
 
 Trocar depois
 
-<doc-api file="stepper/QasStepper" name="QasStepper" />
+<doc-api file="stepper-form-view/QasStepperFormView" name="QasStepperFormView" />
 
 ## Uso
 
-<doc-example file="QasStepper/Basic" title="Básico" />
-
-<doc-example file="QasStepper/StepperWithIcon" title="Com ícone" />
+<doc-example file="QasStepperFormView/Basic" title="Básico" />

--- a/docs/src/pages/components/stepper-form-view.md
+++ b/docs/src/pages/components/stepper-form-view.md
@@ -2,7 +2,7 @@
 title: QasStepperFormView
 ---
 
-Trocar depois
+Componente para lidar com formulário em steps.
 
 <doc-api file="stepper-form-view/QasStepperFormView" name="QasStepperFormView" />
 
@@ -26,14 +26,16 @@ Página 1:
 </template>
 
 <script setup>
-// Através do inject do stepper, é possível você ter ações/atributos fornecidos pelo componente.
+/*
+ * Através do inject do stepper, é possível você ter ações/atributos fornecidos pelo componente.
+ */
 const stepper = inject('stepper')
 
 const formViewProps = computed(() => {
   return {
     /* É possível pegar as props passadas para o componente (QasStepperFormView),
-    * sendo uma boa prática para pegar propriedades que são comuns entre as páginas (entity, mode, etc)
-    */
+     * sendo uma boa prática para pegar propriedades que são comuns entre as páginas (entity, mode, etc)
+     */
     ...,
     ...stepper.formViewProps.value
   }
@@ -41,8 +43,8 @@ const formViewProps = computed(() => {
 
 function onSubmitSuccess (payload) {
   /* Avança para o próximo step, passando o payload da página, para que
-  * na próxima página tenha acesso ao dados para efetuar o merge.
-  */
+   * na próxima página tenha acesso ao dados para efetuar o merge.
+   */
   stepper.next({ payload: payload.data.result })
 }
 </script>
@@ -51,7 +53,7 @@ function onSubmitSuccess (payload) {
 Página 2:
 ```js
 <template>
-  <qas-form-view v-model="values" v-model:fields="fields" :cancel-route="cancelRoute" v-bind="formViewProps">
+  <qas-form-view v-model="values" v-model:fields="fields" :cancel-route="cancelRoute" v-bind="formViewProps" :before-submit="beforeSubmit">
     <template #default>
       <qas-form-generator v-model="values" :fields="fields" />
     </template>
@@ -65,29 +67,32 @@ Página 2:
 </template>
 
 <script setup>
-// Através do inject do stepper, é possível você ter ações que o componente fornece.
+/*
+ * Através do inject do stepper, é possível você ter ações que o componente fornece.
+ */
 const stepper = inject('stepper')
 
-/*
-* Payload mergeado com a página 1 para ser enviado o payload completo para API.
-*/
-const values = ref({ ...stepper.steppersValues.value })
+const values = ref({})
 
 const formViewProps = computed(() => {
   return {
     /* É possível pegar as props passadas para o componente (QasStepperFormView),
-    * sendo uma boa prática para pegar propriedades que são comuns entre as páginas (entity, mode, etc)
-    */
+     * sendo uma boa prática para pegar propriedades que são comuns entre as páginas (entity, mode, etc)
+     */
     ...stepper.formViewProps.value
   }
 })
 
-// Função para voltar para o step anterior.
+/*
+ * Função para voltar para o step anterior.
+ */
 function cancelRoute () {
   stepper.previous()
 }
 
-// É possível alterar as props de um determinado step através da função "setStepProps".
+/*
+ * É possível alterar as props de um determinado step através da função "setStepProps".
+ */
 function changeStepTitle () {
   stepper.setStepProps({
     step: 2,
@@ -97,6 +102,19 @@ function changeStepTitle () {
       prefix: 2
     }
   })
+}
+
+function beforeSubmit () {
+  /*
+   * Por ser o último step, precisamos enviar para API um payload com todos os dados
+   * de todos steps. Através do "stepper.steppersValues.value", conseguimos obter os
+   * dados dos demais steps, então só devemos mergear com nosso values do formulário
+   * atual antes do envio para API.
+   */
+  values.value = {
+    ...stepper.stepsValues.value,
+    ...values.value
+  }
 }
 </script>
 

--- a/docs/src/pages/components/stepper-form-view.md
+++ b/docs/src/pages/components/stepper-form-view.md
@@ -9,3 +9,95 @@ Trocar depois
 ## Uso
 
 <doc-example file="QasStepperFormView/Basic" title="Básico" />
+
+:::warning
+Siga os exemplos de como utilizar as funções fornecidas pelo componente através do inject.
+Os componentes de página estão todos comentados.
+:::
+
+Página 1:
+```js
+<template>
+  <qas-form-view v-model="values" v-model:fields="fields" :cancel-route="false" v-bind="formViewProps" @submit-success="onSubmitSuccess">
+    <template #default>
+      <qas-form-generator v-model="values" :fields="fields" />
+    </template>
+  </qas-form-view>
+</template>
+
+<script setup>
+// Através do inject do stepper, é possível você ter ações/atributos fornecidos pelo componente.
+const stepper = inject('stepper')
+
+const formViewProps = computed(() => {
+  return {
+    /* É possível pegar as props passadas para o componente (QasStepperFormView),
+    * sendo uma boa prática para pegar propriedades que são comuns entre as páginas (entity, mode, etc)
+    */
+    ...,
+    ...stepper.formViewProps.value
+  }
+})
+
+function onSubmitSuccess (payload) {
+  /* Avança para o próximo step, passando o payload da página, para que
+  * na próxima página tenha acesso ao dados para efetuar o merge.
+  */
+  stepper.next({ payload: payload.data.result })
+}
+</script>
+```
+
+Página 2:
+```js
+<template>
+  <qas-form-view v-model="values" v-model:fields="fields" :cancel-route="cancelRoute" v-bind="formViewProps">
+    <template #default>
+      <qas-form-generator v-model="values" :fields="fields" />
+    </template>
+  </qas-form-view>
+
+  <div class="full-width q-my-md">
+    <qas-btn label="Mudar título do segundo step" @click="changeStepTitle" />
+  </div>
+
+  Payload mergeado com a página 1: <qas-debugger :inspect="[values]" />
+</template>
+
+<script setup>
+// Através do inject do stepper, é possível você ter ações que o componente fornece.
+const stepper = inject('stepper')
+
+/*
+* Payload mergeado com a página 1 para ser enviado o payload completo para API.
+*/
+const values = ref({ ...stepper.steppersValues.value })
+
+const formViewProps = computed(() => {
+  return {
+    /* É possível pegar as props passadas para o componente (QasStepperFormView),
+    * sendo uma boa prática para pegar propriedades que são comuns entre as páginas (entity, mode, etc)
+    */
+    ...stepper.formViewProps.value
+  }
+})
+
+// Função para voltar para o step anterior.
+function cancelRoute () {
+  stepper.previous()
+}
+
+// É possível alterar as props de um determinado step através da função "setStepProps".
+function changeStepTitle () {
+  stepper.setStepProps({
+    step: 2,
+    payload: {
+      title: 'Titulo alterado',
+      caption: 'Caption',
+      prefix: 2
+    }
+  })
+}
+</script>
+
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-quasar": "^1.1.0",
-        "eslint-plugin-vue": "^9.13.0",
+        "eslint-plugin-vue": "^9.25.0",
         "execa": "^7.1.1",
         "fs-jetpack": "^5.1.0",
         "husky": "^8.0.3",
@@ -1260,8 +1260,9 @@
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -2051,23 +2052,25 @@
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "9.15.0",
+      "version": "9.25.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.25.0.tgz",
+      "integrity": "sha512-tDWlx14bVe6Bs+Nnh3IGrD+hb11kf2nukfm6jLsmJIhmiRQ1SUaksvwY9U5MvPB0pcrg0QK0xapQkfITs3RKOA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.3.0",
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "globals": "^13.24.0",
         "natural-compare": "^1.4.0",
-        "nth-check": "^2.0.1",
-        "postcss-selector-parser": "^6.0.9",
-        "semver": "^7.3.5",
-        "vue-eslint-parser": "^9.3.0",
+        "nth-check": "^2.1.1",
+        "postcss-selector-parser": "^6.0.15",
+        "semver": "^7.6.0",
+        "vue-eslint-parser": "^9.4.2",
         "xml-name-validator": "^4.0.0"
       },
       "engines": {
         "node": "^14.17.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "eslint": "^6.2.0 || ^7.0.0 || ^8.0.0"
+        "eslint": "^6.2.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -2546,9 +2549,10 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.20.0",
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -4021,9 +4025,10 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.13",
+      "version": "6.0.16",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.16.tgz",
+      "integrity": "sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -4475,9 +4480,10 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.2",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -5140,9 +5146,10 @@
       "license": "MIT"
     },
     "node_modules/vue-eslint-parser": {
-      "version": "9.3.1",
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.4.2.tgz",
+      "integrity": "sha512-Ry9oiGmCAK91HrKMtCrKFWmSFWvYkpGglCeFAIqDdr9zdXmMMpJOmUJS7WWsW7fX81h6mwHmUZCQQ1E0PkSwYQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
         "eslint-scope": "^7.1.1",
@@ -5436,7 +5443,7 @@
     },
     "ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.15.0-beta.9",
+      "version": "3.15.0-beta.10",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9407,6 +9414,8 @@
     },
     "cssesc": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
     "cssstyle": {
@@ -9934,15 +9943,18 @@
       }
     },
     "eslint-plugin-vue": {
-      "version": "9.15.0",
+      "version": "9.25.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.25.0.tgz",
+      "integrity": "sha512-tDWlx14bVe6Bs+Nnh3IGrD+hb11kf2nukfm6jLsmJIhmiRQ1SUaksvwY9U5MvPB0pcrg0QK0xapQkfITs3RKOA==",
       "dev": true,
       "requires": {
-        "@eslint-community/eslint-utils": "^4.3.0",
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "globals": "^13.24.0",
         "natural-compare": "^1.4.0",
-        "nth-check": "^2.0.1",
-        "postcss-selector-parser": "^6.0.9",
-        "semver": "^7.3.5",
-        "vue-eslint-parser": "^9.3.0",
+        "nth-check": "^2.1.1",
+        "postcss-selector-parser": "^6.0.15",
+        "semver": "^7.6.0",
+        "vue-eslint-parser": "^9.4.2",
         "xml-name-validator": "^4.0.0"
       }
     },
@@ -10240,7 +10252,9 @@
       }
     },
     "globals": {
-      "version": "13.20.0",
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -11067,7 +11081,9 @@
       "requires": {}
     },
     "postcss-selector-parser": {
-      "version": "6.0.13",
+      "version": "6.0.16",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.16.tgz",
+      "integrity": "sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==",
       "dev": true,
       "requires": {
         "cssesc": "^3.0.0",
@@ -11313,7 +11329,9 @@
       }
     },
     "semver": {
-      "version": "7.5.2",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -11696,7 +11714,9 @@
       "dev": true
     },
     "vue-eslint-parser": {
-      "version": "9.3.1",
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.4.2.tgz",
+      "integrity": "sha512-Ry9oiGmCAK91HrKMtCrKFWmSFWvYkpGglCeFAIqDdr9zdXmMMpJOmUJS7WWsW7fX81h6mwHmUZCQQ1E0PkSwYQ==",
       "dev": true,
       "requires": {
         "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-quasar": "^1.1.0",
-    "eslint-plugin-vue": "^9.13.0",
+    "eslint-plugin-vue": "^9.25.0",
     "execa": "^7.1.1",
     "fs-jetpack": "^5.1.0",
     "husky": "^8.0.3",

--- a/ui/src/components/stepper-form-view/QasStepperFormView.vue
+++ b/ui/src/components/stepper-form-view/QasStepperFormView.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script setup>
-import { defineModel, ref, provide, onMounted } from 'vue'
+import { defineModel, ref, provide, onMounted, computed } from 'vue'
 
 defineOptions({ name: 'QasStepperFormView' })
 
@@ -47,6 +47,14 @@ onMounted(() => {
   goTo.value = stepper.value.goTo
 })
 
+const formattedFormViewProps = computed(() => {
+  return {
+    useBoundary: false,
+    useNotifySuccess: false,
+    ...props.formViewProps
+  }
+})
+
 function setStepProps ({ step, payload }) {
   if (!step) {
     stepPropsList.value = payload
@@ -75,7 +83,7 @@ function stepName (stepIndex) {
 
 provide('stepper', {
   currentStep: model,
-  formViewProps: props.formViewProps,
+  formViewProps: formattedFormViewProps,
   goTo: step => goTo.value(step),
   next: nextStep,
   previous: () => previous.value(),

--- a/ui/src/components/stepper-form-view/QasStepperFormView.vue
+++ b/ui/src/components/stepper-form-view/QasStepperFormView.vue
@@ -1,10 +1,7 @@
 <template>
-  <qas-stepper ref="stepper" v-model="model" :keep-alive-include="[1,2]">
+  <qas-stepper ref="stepper" v-model="model" :keep-alive-include="stepsList">
     <template #default>
-      <q-step
-        v-for="(step, stepIndex) in props.steppers" :key="stepIndex" :done="isDone(stepIndex)"
-        :name="stepName(stepIndex)" v-bind="stepPropsList[stepIndex]"
-      >
+      <q-step v-for="(step, stepIndex) in props.steps" :key="stepIndex" :done="isDone(stepIndex)" :name="getStepName(stepIndex)" v-bind="stepPropsList[stepIndex]">
         <component :is="step.component" />
       </q-step>
     </template>
@@ -12,12 +9,12 @@
 </template>
 
 <script setup>
-import { defineModel, ref, provide, onMounted, computed } from 'vue'
+import { defineModel, ref, provide, computed } from 'vue'
 
 defineOptions({ name: 'QasStepperFormView' })
 
 const props = defineProps({
-  steppers: {
+  steps: {
     type: Array,
     required: true
   },
@@ -35,17 +32,8 @@ const values = ref({})
 const stepPropsList = ref([])
 
 const stepper = ref(null)
-const next = ref(null)
-const previous = ref(null)
-const goTo = ref(null)
 
-setStepProps({ payload: [...props.steppers.map(step => step.stepProps)] })
-
-onMounted(() => {
-  next.value = stepper.value.next
-  previous.value = stepper.value.previous
-  goTo.value = stepper.value.goTo
-})
+setStepProps({ payload: [...props.steps.map(step => step.stepProps)] })
 
 const formattedFormViewProps = computed(() => {
   return {
@@ -55,39 +43,41 @@ const formattedFormViewProps = computed(() => {
   }
 })
 
+const stepsList = computed(() => props.steps.map((_, stepIndex) => stepIndex + 1))
+
 function setStepProps ({ step, payload }) {
-  if (!step) {
-    stepPropsList.value = payload
-  } else {
+  if (step) {
     stepPropsList.value[step - 1] = payload
+  } else {
+    stepPropsList.value = payload
   }
 }
 
 /*
-* - Merge do payload com objetivo de enviar o payload completo de todos steppers no stepper final
+* - Merge do payload com objetivo de enviar o payload completo de todos steps no stepper final
 * - É possível ir para um step especifico ou somente ir para o próximo.
 */
 function nextStep ({ payload = {} }) {
   Object.assign(values.value, payload)
 
-  next.value()
+  stepper.value.next()
 }
 
 function isDone (stepIndex) {
   return model.value > stepIndex + 1
 }
 
-function stepName (stepIndex) {
+function getStepName (stepIndex) {
   return stepIndex + 1
 }
 
 provide('stepper', {
   currentStep: model,
   formViewProps: formattedFormViewProps,
-  goTo: step => goTo.value(step),
+  goTo: step => stepper.value.goTo(step),
   next: nextStep,
-  previous: () => previous.value(),
+  previous: () => stepper.value.previous(),
   setStepProps,
-  steppersValues: values
+  stepsValues: values
 })
 </script>

--- a/ui/src/components/stepper-form-view/QasStepperFormView.vue
+++ b/ui/src/components/stepper-form-view/QasStepperFormView.vue
@@ -1,0 +1,77 @@
+<template>
+  <qas-stepper ref="stepper" v-model="model" :keep-alive-include="[1,2]">
+    <template #default>
+      <q-step
+        v-for="(step, stepIndex) in props.steppers" :key="stepIndex" :done="model > stepIndex + 1"
+        :name="stepIndex + 1" v-bind="stepPropsList[stepIndex]"
+      >
+        <component :is="step.component" />
+      </q-step>
+    </template>
+  </qas-stepper>
+</template>
+
+<script setup>
+import { defineModel, ref, provide, onMounted } from 'vue'
+
+defineOptions({ name: 'QasStepperFormView' })
+
+const props = defineProps({
+  steppers: {
+    type: Array,
+    required: true
+  },
+
+  formViewProps: {
+    type: Object,
+    default: () => ({})
+  }
+})
+
+const model = defineModel({ type: [String, Number] })
+
+const values = ref({})
+
+const stepPropsList = ref([])
+
+const stepper = ref(null)
+const next = ref(null)
+const previous = ref(null)
+const goTo = ref(null)
+
+setStepProps({ payload: [...props.steppers.map(step => step.stepProps)] })
+
+onMounted(() => {
+  next.value = stepper.value.next
+  previous.value = stepper.value.previous
+  goTo.value = stepper.value.goTo
+})
+
+function setStepProps ({ step, payload }) {
+  if (!step) {
+    stepPropsList.value = payload
+  } else {
+    stepPropsList.value[step - 1] = payload
+  }
+}
+
+/*
+* - Merge do payload com objetivo de enviar o payload completo de todos steppers no stepper final
+* - É possível ir para um step especifico ou somente ir para o próximo.
+*/
+function nextStep ({ payload = {} }) {
+  Object.assign(values.value, payload)
+
+  next.value()
+}
+
+provide('stepper', {
+  currentStep: model,
+  formViewProps: props.formViewProps,
+  goTo: step => goTo.value(step),
+  next: nextStep,
+  previous: () => previous.value(),
+  setStepProps,
+  steppersValues: values
+})
+</script>

--- a/ui/src/components/stepper-form-view/QasStepperFormView.vue
+++ b/ui/src/components/stepper-form-view/QasStepperFormView.vue
@@ -2,8 +2,8 @@
   <qas-stepper ref="stepper" v-model="model" :keep-alive-include="[1,2]">
     <template #default>
       <q-step
-        v-for="(step, stepIndex) in props.steppers" :key="stepIndex" :done="model > stepIndex + 1"
-        :name="stepIndex + 1" v-bind="stepPropsList[stepIndex]"
+        v-for="(step, stepIndex) in props.steppers" :key="stepIndex" :done="isDone(stepIndex)"
+        :name="stepName(stepIndex)" v-bind="stepPropsList[stepIndex]"
       >
         <component :is="step.component" />
       </q-step>
@@ -63,6 +63,14 @@ function nextStep ({ payload = {} }) {
   Object.assign(values.value, payload)
 
   next.value()
+}
+
+function isDone (stepIndex) {
+  return model.value > stepIndex + 1
+}
+
+function stepName (stepIndex) {
+  return stepIndex + 1
 }
 
 provide('stepper', {

--- a/ui/src/components/stepper-form-view/QasStepperFormView.vue
+++ b/ui/src/components/stepper-form-view/QasStepperFormView.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script setup>
-import { defineModel, ref, provide, computed } from 'vue'
+import { ref, provide, computed } from 'vue'
 
 defineOptions({ name: 'QasStepperFormView' })
 

--- a/ui/src/components/stepper-form-view/QasStepperFormView.vue
+++ b/ui/src/components/stepper-form-view/QasStepperFormView.vue
@@ -25,7 +25,7 @@ const props = defineProps({
   }
 })
 
-const model = defineModel({ type: [String, Number] })
+const model = defineModel({ type: [Number], default: 1 })
 
 const values = ref({})
 

--- a/ui/src/components/stepper-form-view/QasStepperFormView.vue
+++ b/ui/src/components/stepper-form-view/QasStepperFormView.vue
@@ -1,5 +1,5 @@
 <template>
-  <qas-stepper ref="stepper" v-model="model" :keep-alive-include="stepsList">
+  <qas-stepper ref="stepper" v-model="model" v-bind="stepperProps">
     <template #default>
       <q-step v-for="(step, stepIndex) in props.steps" :key="stepIndex" :done="isDone(stepIndex)" :name="getStepName(stepIndex)" v-bind="stepPropsList[stepIndex]">
         <component :is="step.component" />
@@ -22,28 +22,29 @@ const props = defineProps({
   formViewProps: {
     type: Object,
     default: () => ({})
+  },
+
+  stepperProps: {
+    type: Object,
+    default: () => ({})
   }
 })
 
-const model = defineModel({ type: [Number], default: 1 })
+const model = defineModel({ type: Number, default: 1 })
 
 const values = ref({})
-
 const stepPropsList = ref([])
-
 const stepper = ref(null)
 
-setStepProps({ payload: [...props.steps.map(step => step.stepProps)] })
+setStepProps({ payload: [...props.steps.map(({ stepProps }) => stepProps)] })
 
-const formattedFormViewProps = computed(() => {
+const defaultFormViewProps = computed(() => {
   return {
     useBoundary: false,
     useNotifySuccess: false,
     ...props.formViewProps
   }
 })
-
-const stepsList = computed(() => props.steps.map((_, stepIndex) => stepIndex + 1))
 
 function setStepProps ({ step, payload }) {
   if (step) {
@@ -72,8 +73,8 @@ function getStepName (stepIndex) {
 }
 
 provide('stepper', {
-  currentStep: model,
-  formViewProps: formattedFormViewProps,
+  stepperModel: model,
+  formViewProps: defaultFormViewProps,
   goTo: step => stepper.value.goTo(step),
   next: nextStep,
   previous: () => stepper.value.previous(),

--- a/ui/src/components/stepper-form-view/QasStepperFormView.yml
+++ b/ui/src/components/stepper-form-view/QasStepperFormView.yml
@@ -13,6 +13,9 @@ props:
     desc: Propriedades que serão repassadas para os componentes, podendo repassar coisas que serão comúm entre as páginas, como "entity", "mode".
     type: Object
 
+  stepper-props:
+    desc: Propriedades que serão repassadas para o QasStepper.
+    type: Object
 
 inject:
   stepper-model:
@@ -20,7 +23,7 @@ inject:
     type: Number
 
   form-view-props:
-    desc: Propriedades do QasFormView que são comuns entre todos os steppers.
+    desc: Propriedades do QasFormView que são comuns entre todos os steppers. Possui reatividade, portanto para acessar é necessário do ".value"
     type: Object
 
   'goTo: (step) => void':

--- a/ui/src/components/stepper-form-view/QasStepperFormView.yml
+++ b/ui/src/components/stepper-form-view/QasStepperFormView.yml
@@ -15,8 +15,8 @@ props:
 
 
 inject:
-  current-step:
-    desc: Step atual caso precise para alguma lógica.
+  stepper-model:
+    desc: Model do stepper caso precise recuperar o step atual para alguma lógica. Possui reatividade, portanto para acessar é necessário do ".value"
     type: Number
 
   form-view-props:
@@ -51,5 +51,5 @@ inject:
         desc: Propriedades do step como "title", "prefix", "caption", entre outros.
 
   steps-values:
-    desc: Payload com todos valores que foram mergeados através da função "next" ao decorrer dos avanços dos steps. É usado para você recuperar no último step com intenção de enviar o payload completo de todos step para a API.
+    desc: Payload com todos valores que foram mergeados através da função "next" ao decorrer dos avanços dos steps. É usado para você recuperar no último step com intenção de enviar o payload completo de todos step para a API. Possui reatividade, portanto para acessar é necessário do ".value"
     type: Object

--- a/ui/src/components/stepper-form-view/QasStepperFormView.yml
+++ b/ui/src/components/stepper-form-view/QasStepperFormView.yml
@@ -20,7 +20,7 @@ inject:
     type: Number
 
   form-view-props:
-    desc: Propriedades do form-view que foram passadas para o QasStepperFormView.
+    desc: Propriedades do QasFormView que são comuns entre todos os steppers.
     type: Object
 
   'goTo: (step) => void':

--- a/ui/src/components/stepper-form-view/QasStepperFormView.yml
+++ b/ui/src/components/stepper-form-view/QasStepperFormView.yml
@@ -1,0 +1,10 @@
+type: component
+
+meta:
+  desc: Componente de stepper.
+
+props:
+  disable:
+    desc: Deixa o componente desabilitado.
+    default: false
+    type: Boolean

--- a/ui/src/components/stepper-form-view/QasStepperFormView.yml
+++ b/ui/src/components/stepper-form-view/QasStepperFormView.yml
@@ -1,10 +1,55 @@
 type: component
 
 meta:
-  desc: Componente de stepper.
+  desc: Componente para steppers de formulário.
 
 props:
-  disable:
-    desc: Deixa o componente desabilitado.
-    default: false
-    type: Boolean
+  steppers:
+    desc: Lista de step, cada item possuindo "stepProps" e "component".
+    required: true
+    type: Array
+
+  form-view-props:
+    desc: Propriedades que serão repassadas para os componentes, podendo repassar coisas que serão comúm entre as páginas, como "entity", "mode".
+    type: Object
+
+
+inject:
+  current-step:
+    desc: Step atual caso precise para alguma lógica.
+    type: Number
+
+  form-view-props:
+    desc: Propriedades do form-view que foram passadas para o QasStepperFormView.
+    type: Object
+
+  'goTo: (step) => void':
+    desc: Função usada para mudar o step atual.
+    params:
+      step:
+        desc: Nome do step que deseja visualizar.
+        type: Number
+
+  'next: (payload) => void':
+    desc: Avança para o próximo step.
+    params:
+      payload:
+        desc: Payload do formulário atual, que será mergeado no "stepperValues", com a intenção de guardar o payload completo para ser enviado no último step.
+        type: Object
+
+  'previous: () => void':
+    desc: Volta para o step anterior.
+
+  'setStepProps: () => void':
+    desc: Altera as propriedades de um step específico caso precise que seja alterado com base em alguma lógica atual da página.
+    params:
+      step:
+        desc: Step que deseja alterar as propriedades
+        type: Number
+
+      payload:
+        desc: Propriedades do step como "title", "prefix", "caption", entre outros.
+
+  steppers-values:
+    desc: Payload com todos valores que foram mergeados através da função "next" ao decorrer dos avanços dos steps. É usado para você recuperar no último step com intenção de enviar o payload completo de todos step para a API.
+    type: Object

--- a/ui/src/components/stepper-form-view/QasStepperFormView.yml
+++ b/ui/src/components/stepper-form-view/QasStepperFormView.yml
@@ -4,7 +4,7 @@ meta:
   desc: Componente para steppers de formulário.
 
 props:
-  steppers:
+  steps:
     desc: Lista de step, cada item possuindo "stepProps" e "component".
     required: true
     type: Array
@@ -50,6 +50,6 @@ inject:
       payload:
         desc: Propriedades do step como "title", "prefix", "caption", entre outros.
 
-  steppers-values:
+  steps-values:
     desc: Payload com todos valores que foram mergeados através da função "next" ao decorrer dos avanços dos steps. É usado para você recuperar no último step com intenção de enviar o payload completo de todos step para a API.
     type: Object

--- a/ui/src/components/stepper/QasStepper.vue
+++ b/ui/src/components/stepper/QasStepper.vue
@@ -22,7 +22,7 @@ const props = defineProps({
   },
 
   modelValue: {
-    type: [Number],
+    type: [String, Number],
     default: 0
   },
 

--- a/ui/src/components/stepper/QasStepper.vue
+++ b/ui/src/components/stepper/QasStepper.vue
@@ -22,7 +22,7 @@ const props = defineProps({
   },
 
   modelValue: {
-    type: [Number, String],
+    type: [Number],
     default: 0
   },
 
@@ -39,7 +39,7 @@ const screen = useScreen()
 
 const emit = defineEmits(['update:modelValue'])
 
-defineExpose({ next, previous })
+defineExpose({ next, previous, goTo })
 
 const model = computed({
   get () {
@@ -61,6 +61,10 @@ function getContext (context) {
     next,
     previous
   }
+}
+
+function goTo (step) {
+  stepper.value.goTo(step)
 }
 
 function next () {

--- a/ui/src/vue-plugin.js
+++ b/ui/src/vue-plugin.js
@@ -58,6 +58,7 @@ import QasSingleView from './components/single-view/QasSingleView.vue'
 import QasSortable from './components/sortable/QasSortable.vue'
 import QasStatus from './components/status/QasStatus.vue'
 import QasStepper from './components/stepper/QasStepper.vue'
+import QasStepperFormView from './components/stepper-form-view/QasStepperFormView.vue'
 import QasTableGenerator from './components/table-generator/QasTableGenerator.vue'
 import QasTabsGenerator from './components/tabs-generator/QasTabsGenerator.vue'
 import QasTextTruncate from './components/text-truncate/QasTextTruncate.vue'
@@ -149,6 +150,7 @@ async function install (app) {
   app.component('QasSortable', QasSortable)
   app.component('QasStatus', QasStatus)
   app.component('QasStepper', QasStepper)
+  app.component('QasStepperFormView', QasStepperFormView)
   app.component('QasTableGenerator', QasTableGenerator)
   app.component('QasTabsGenerator', QasTabsGenerator)
   app.component('QasTextTruncate', QasTextTruncate)
@@ -241,6 +243,7 @@ export {
   QasSortable,
   QasStatus,
   QasStepper,
+  QasStepperFormView,
   QasTableGenerator,
   QasTabsGenerator,
   QasTextTruncate,


### PR DESCRIPTION
## BREAKING CHANGES
- `QasStepper`: Removido possibilidade do model ser `String`, irá ser possível somente `Number`.

### Removido
- `QasStepper`: Removido possibilidade do model ser `String`, irá ser possível somente `Number`.

### Adicionado
- `QasStepperFormView`: Adicionado componente de gerador de steppers de formulário, utilizando o `QasSteppers`.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [x] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
