### PR TITLE
Feature/qas grid generator adjusts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasGridGenerator`: Corrigido ao passar `col` na prop columns(`{ lg: 'col' }`).
 
 ### Modificado
-- `QasFormGenerator`: Alterado valor do margin-bottom da label do field-set. Quando possuir descrição será `sm`, caso contrário `md`.
+- `QasFormGenerator`: Alterado valor do margin-bottom da label do fieldset. Quando possuir descrição será `sm`, caso contrário `md`.
 
 ## [3.15.0-beta.10] - 12-04-2024
 ### Adicionado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,13 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ## Não publicado
 ### Adicionado
-- `QasGridGenerator`: Adicionado prop `useEllipsis` que por default é `true`, que irá adicionar a classe `ellipsis` em seu conteúdo.
-- `QasGridGenerator`: Adicionado prop `useInline` para mudar a disposição dos campos para ser por linha, ou seja, header e content ocupando a linha toda.
+- `QasGridGenerator`:
+  - Adicionado prop `useEllipsis` que por default é `true`, que irá adicionar a classe `ellipsis` em cada item do grid.
+  - Adicionado prop `useInline` para mudar a disposição dos campos para ser por linha, ou seja, header e content ocupando a linha toda.
 - [`QasFormGenerator`, `QasGridGenerator`]: Adicionado prop `useCommonColumns` onde será possível passar um único objeto com seus breakpoints e será replicado para todos fields.
 
 ### Corrigido
-- `QasGridGenerator`: Corrigido ao passar `col` na prop columns(`{ lg: 'col' }`).
+- `QasGridGenerator`: Corrigido comportamento da propriedade `columns` quando passado com valores `col`, exemplo `{ lg: 'col' }`.
 
 ### Modificado
 - `QasFormGenerator`: Alterado valor do margin-bottom da label do fieldset. Quando possuir descrição será `sm`, caso contrário `md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ### Adicionado
 - `QasGridGenerator`: Adicionado prop `useEllipsis` que por default é `true`, que irá adicionar a classe `ellipsis` em seu conteúdo.
 - `QasGridGenerator`: Adicionado prop `useInline` para mudar a disposição dos campos para ser por linha, ou seja, header e content ocupando a linha toda.
+- [`QasFormGenerator`, `QasGridGenerator`]: Adicionado prop `useCommonColumns` onde será possível passar um único objeto com seus breakpoints e será replicado para todos fields.
 
 ### Corrigido
 - `QasGridGenerator`: Corrigido ao passar `col` na prop columns(`{ lg: 'col' }`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasGridGenerator`:
   - Adicionado prop `useEllipsis` que por default é `true`, que irá adicionar a classe `ellipsis` em cada item do grid.
   - Adicionado prop `useInline` para mudar a disposição dos campos para ser por linha, ou seja, header e content ocupando a linha toda.
+  - Adicionado title ao header e content ao utilizar a prop `useEllipsis`.
 - [`QasFormGenerator`, `QasGridGenerator`]: Adicionado prop `useCommonColumns` onde será possível passar um único objeto com seus breakpoints e será replicado para todos fields.
 
 ### Corrigido

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ### Corrigido
 - `QasGridGenerator`: Corrigido ao passar `col` na prop columns(`{ lg: 'col' }`).
 
+### Modificado
+- `QasFormGenerator`: Alterado valor do margin-bottom da label do field-set. Quando possuir descrição será `sm`, caso contrário `md`.
+
 ## [3.15.0-beta.10] - 12-04-2024
 ### Adicionado
 - `Spacing.js`: Adicionado espaçamentos `4xl e 5xl`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasGridGenerator`: Adicionado prop `useEllipsis` que por default é `true`, que irá adicionar a classe `ellipsis` em seu conteúdo.
+- `QasGridGenerator`: Adicionado prop `useInline` para mudar a disposição dos campos para ser por linha, ou seja, header e content ocupando a linha toda.
+
+### Corrigido
+- `QasGridGenerator`: Corrigido ao passar `col` na prop columns(`{ lg: 'col' }`).
+
 ## [3.15.0-beta.10] - 12-04-2024
 ### Adicionado
 - `Spacing.js`: Adicionado espaçamentos `4xl e 5xl`.

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -48,7 +48,7 @@
     },
     "../ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.15.0-beta.9",
+      "version": "3.15.0-beta.10",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/store-adapter": "^1.0.0",

--- a/docs/src/examples/QasGridGenerator/UseInline.vue
+++ b/docs/src/examples/QasGridGenerator/UseInline.vue
@@ -1,0 +1,50 @@
+<template>
+  <!-- Usando qas-single-view apenas para recuperar os dados -->
+  <qas-single-view v-model:fields="fields" v-model:result="result" :custom-id="customId" :entity="entity">
+    <template #default>
+      <qas-grid-generator :fields="fields" gutter="md" :result="result" use-inline />
+    </template>
+  </qas-single-view>
+</template>
+
+<script>
+export default {
+  name: 'UsersList',
+
+  data () {
+    return {
+      fields: {},
+      errors: {},
+      result: [],
+      metadata: {}
+    }
+  },
+
+  computed: {
+    entity () {
+      return 'users'
+    },
+
+    breadcrumbs () {
+      return [
+        {
+          label: 'Início',
+          route: { path: '/' }
+        },
+        {
+          label: 'Algum caminho',
+          route: { path: '/' }
+        },
+        {
+          label: 'Users'
+        }
+      ]
+    },
+
+    // USAR SOMENTE SE NECESSÁRIO, AQUI PEGAMOS O ID DO USUÁRIO NO NOSSO MOCK DE DADOS
+    customId () {
+      return '3102fad5-f14c-45d4-98e9-46ef0aa9580e'
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QasGridGenerator/UseInline.vue
+++ b/docs/src/examples/QasGridGenerator/UseInline.vue
@@ -7,44 +7,16 @@
   </qas-single-view>
 </template>
 
-<script>
-export default {
-  name: 'UsersList',
+<script setup>
+import { ref } from 'vue'
 
-  data () {
-    return {
-      fields: {},
-      errors: {},
-      result: [],
-      metadata: {}
-    }
-  },
+defineOptions({ name: 'UsersList' })
 
-  computed: {
-    entity () {
-      return 'users'
-    },
+const fields = ref({})
+const result = ref({})
 
-    breadcrumbs () {
-      return [
-        {
-          label: 'Início',
-          route: { path: '/' }
-        },
-        {
-          label: 'Algum caminho',
-          route: { path: '/' }
-        },
-        {
-          label: 'Users'
-        }
-      ]
-    },
+const entity = 'users'
 
-    // USAR SOMENTE SE NECESSÁRIO, AQUI PEGAMOS O ID DO USUÁRIO NO NOSSO MOCK DE DADOS
-    customId () {
-      return '3102fad5-f14c-45d4-98e9-46ef0aa9580e'
-    }
-  }
-}
+// USAR SOMENTE SE NECESSÁRIO, AQUI PEGAMOS O ID DO USUÁRIO NO NOSSO MOCK DE DADOS
+const customId = '3102fad5-f14c-45d4-98e9-46ef0aa9580e'
 </script>

--- a/docs/src/examples/QasGridGenerator/UseInline.vue
+++ b/docs/src/examples/QasGridGenerator/UseInline.vue
@@ -2,7 +2,7 @@
   <!-- Usando qas-single-view apenas para recuperar os dados -->
   <qas-single-view v-model:fields="fields" v-model:result="result" :custom-id="customId" :entity="entity">
     <template #default>
-      <qas-grid-generator :fields="fields" gutter="md" :result="result" use-inline />
+      <qas-grid-generator :fields="fields" :result="result" use-inline />
     </template>
   </qas-single-view>
 </template>

--- a/docs/src/pages/components/grid-generator.md
+++ b/docs/src/pages/components/grid-generator.md
@@ -6,6 +6,14 @@ Componente para criação de textos dinâmicos.
 
 <doc-api file="grid-generator/QasGridGenerator" name="QasGridGenerator" />
 
+:::info
+Caso os breakpoints dos campos sejam todos iguais, exemplo:
+- Possuo os campos name e phone, e ambos precisam ter os breakpoints `{ xs: 12, lg: 6 }`.
+
+É possível passar o `columns` sem especificar os fields, somente um objeto com os breakpoints, mas
+é necessário utilizar a prop `use-common-columns` para que isso funcione.
+:::
+
 ## Uso
 <doc-example file="QasGridGenerator/Basic" title="Básico" />
 <doc-example file="QasGridGenerator/Slots" title="Slots" />

--- a/docs/src/pages/components/grid-generator.md
+++ b/docs/src/pages/components/grid-generator.md
@@ -9,3 +9,4 @@ Componente para criação de textos dinâmicos.
 ## Uso
 <doc-example file="QasGridGenerator/Basic" title="Básico" />
 <doc-example file="QasGridGenerator/Slots" title="Slots" />
+<doc-example file="QasGridGenerator/UseInline" title="Inline" />

--- a/docs/src/pages/components/grid-generator.md
+++ b/docs/src/pages/components/grid-generator.md
@@ -14,6 +14,10 @@ Caso os breakpoints dos campos sejam todos iguais, exemplo:
 é necessário utilizar a prop `use-common-columns` para que isso funcione.
 :::
 
+:::info
+Ao utilizar a prop `useInline`, o gutter passa a ter o valor `md`.
+:::
+
 ## Uso
 <doc-example file="QasGridGenerator/Basic" title="Básico" />
 <doc-example file="QasGridGenerator/Slots" title="Slots" />

--- a/ui/src/components/form-generator/QasFormGenerator.vue
+++ b/ui/src/components/form-generator/QasFormGenerator.vue
@@ -2,7 +2,7 @@
   <div :class="fieldsetClasses">
     <div v-for="(fieldsetItem, fieldsetItemKey) in normalizedFields" :key="fieldsetItemKey" class="full-width">
       <slot v-if="fieldsetItem.label" :name="`legend-${fieldsetItemKey}`">
-        <qas-label :label="fieldsetItem.label" />
+        <qas-label :label="fieldsetItem.label" :margin="getLabelMargin(fieldsetItem)" />
         <div v-if="fieldsetItem.description" class="q-mb-md text-body1 text-grey-8">{{ fieldsetItem.description }}</div>
       </slot>
 
@@ -179,5 +179,9 @@ function useFieldset ({ props }) {
     fieldsetClasses,
     hasFieldset
   }
+}
+
+function getLabelMargin (fieldsetItem) {
+  return fieldsetItem.description ? 'sm' : 'md'
 }
 </script>

--- a/ui/src/components/form-generator/QasFormGenerator.yml
+++ b/ui/src/components/form-generator/QasFormGenerator.yml
@@ -8,7 +8,7 @@ props:
     desc: Colunas do grid de cada campo.
     default: col-6
     type: [Array, String, Object]
-    examples: ["[{ sm: 6, md: 12 }]", "{ name: { sm: 6, md: 12 } }", "12"]
+    examples: ["[{ sm: 6, md: 12 }]", "{ name: { sm: 6, md: 12 } }", "12", "{ sm: 6, md: 12 }"]
 
   disable:
     desc: Deixa os campos desabilitados enviando a prop "disable" para cada campo.
@@ -62,6 +62,9 @@ props:
     desc: Altera ordem dos campos.
     default: []
     type: Array
+
+  use-common-columns:
+    desc: Utilizado quando passar a estrutura da prop "columns" sendo um objeto onde seus breakpoints serão replicados para todos fields.
 
 slots:
   'field-[nome-da-chave]':

--- a/ui/src/components/grid-generator/QasGridGenerator.vue
+++ b/ui/src/components/grid-generator/QasGridGenerator.vue
@@ -133,8 +133,6 @@ function getFieldsByResult () {
     }
   }
 
-  console.log(fieldsByResult, '<-- fieldsByResult')
-
   return fieldsByResult
 }
 

--- a/ui/src/components/grid-generator/QasGridGenerator.vue
+++ b/ui/src/components/grid-generator/QasGridGenerator.vue
@@ -1,9 +1,6 @@
 <template>
   <div :class="classes">
-    <div
-      v-for="(field, key) in fieldsByResult" :key="key"
-      :class="getFieldClass({ index: key, isGridGenerator: true })"
-    >
+    <div v-for="(field, key) in fieldsByResult" :key="key" :class="getContainerClass({ key })">
       <slot :field="field" :name="`field-${field.name}`">
         <slot :field="field" name="header">
           <header :class="props.headerClass" :data-cy="`grid-generator-${field.name}-field`">
@@ -64,6 +61,10 @@ const props = defineProps({
 
   useEllipsis: {
     default: true,
+    type: Boolean
+  },
+
+  useInline: {
     type: Boolean
   }
 })
@@ -132,10 +133,20 @@ function getFieldsByResult () {
     }
   }
 
+  console.log(fieldsByResult, '<-- fieldsByResult')
+
   return fieldsByResult
 }
 
 function setFieldsByResult () {
   fieldsByResult.value = getFieldsByResult()
+}
+
+function getContainerClass ({ key }) {
+  if (props.useInline) {
+    return 'row justify-between col-12'
+  }
+
+  return getFieldClass({ index: key, isGridGenerator: true })
 }
 </script>

--- a/ui/src/components/grid-generator/QasGridGenerator.vue
+++ b/ui/src/components/grid-generator/QasGridGenerator.vue
@@ -3,13 +3,13 @@
     <div v-for="(field, key) in fieldsByResult" :key="key" :class="getContainerClass({ key })">
       <slot :field="field" :name="`field-${field.name}`">
         <slot :field="field" name="header">
-          <header :class="headerClass" :data-cy="`grid-generator-${field.name}-field`" :title="field.label">
+          <header :class="headerClass" :data-cy="`grid-generator-${field.name}-field`" :title="getTitle(field, 'label')">
             {{ field.label }}
           </header>
         </slot>
 
         <slot :field="field" name="content">
-          <div :class="contentClass" :data-cy="`grid-generator-${field.name}-result`" :title="field.formattedResult">
+          <div :class="contentClass" :data-cy="`grid-generator-${field.name}-result`" :title="getTitle(field, 'formattedResult')">
             {{ field.formattedResult }}
           </div>
         </slot>
@@ -181,5 +181,9 @@ function getContainerClass ({ key }) {
   }
 
   return getFieldClass({ index: key, isGridGenerator: true })
+}
+
+function getTitle (field, key) {
+  return props.useEllipsis ? field[key] : ''
 }
 </script>

--- a/ui/src/components/grid-generator/QasGridGenerator.vue
+++ b/ui/src/components/grid-generator/QasGridGenerator.vue
@@ -1,6 +1,9 @@
 <template>
   <div :class="classes">
-    <div v-for="(field, key) in fieldsByResult" :key="key" :class="getFieldClass({ index: key, isGridGenerator: true })">
+    <div
+      v-for="(field, key) in fieldsByResult" :key="key"
+      :class="getFieldClass({ index: key, isGridGenerator: true })"
+    >
       <slot :field="field" :name="`field-${field.name}`">
         <slot :field="field" name="header">
           <header :class="props.headerClass" :data-cy="`grid-generator-${field.name}-field`">
@@ -9,7 +12,7 @@
         </slot>
 
         <slot :field="field" name="content">
-          <div :class="props.contentClass" :data-cy="`grid-generator-${field.name}-result`">
+          <div :class="contentClass" :data-cy="`grid-generator-${field.name}-result`" :title="field.formattedResult">
             {{ field.formattedResult }}
           </div>
         </slot>
@@ -21,11 +24,14 @@
 <script setup>
 import useGenerator, { baseProps } from '../../composables/private/use-generator'
 import { isEmpty, humanize } from '../../helpers'
+import { useScreen } from '../../composables'
 import { isObject } from 'lodash-es'
 import { ref, computed, watch } from 'vue'
 
 // define component name
 defineOptions({ name: 'QasGridGenerator' })
+
+const screen = useScreen()
 
 // props
 const props = defineProps({
@@ -54,6 +60,11 @@ const props = defineProps({
   useEmptyResult: {
     default: true,
     type: Boolean
+  },
+
+  useEllipsis: {
+    default: true,
+    type: Boolean
   }
 })
 
@@ -63,6 +74,11 @@ const { classes, getFieldClass } = useGenerator({ props })
 // computed
 const hasResult = computed(() => Object.keys(props.result).length)
 const hasFields = computed(() => Object.keys(props.fields).length)
+
+const contentClass = computed(() => ({
+  ...props.contentClass,
+  ellipsis: !screen.isSmall && props.useEllipsis
+}))
 
 const fieldsByResult = ref({})
 

--- a/ui/src/components/grid-generator/QasGridGenerator.vue
+++ b/ui/src/components/grid-generator/QasGridGenerator.vue
@@ -70,7 +70,7 @@ const props = defineProps({
 })
 
 // composables
-const { classes, getFieldClass } = useGenerator({ props })
+const { classes: useGeneratorClasses, getFieldClass } = useGenerator({ props })
 
 // computed
 const hasResult = computed(() => Object.keys(props.result).length)
@@ -108,6 +108,12 @@ const headerClass = computed(() => {
     ...props.headerClass,
     ellipsis: true
   }
+})
+
+const classes = computed(() => {
+  if (props.useInline) return 'row q-col-gutter-md'
+
+  return useGeneratorClasses.value
 })
 
 const fieldsByResult = ref({})

--- a/ui/src/components/grid-generator/QasGridGenerator.vue
+++ b/ui/src/components/grid-generator/QasGridGenerator.vue
@@ -3,7 +3,7 @@
     <div v-for="(field, key) in fieldsByResult" :key="key" :class="getContainerClass({ key })">
       <slot :field="field" :name="`field-${field.name}`">
         <slot :field="field" name="header">
-          <header :class="props.headerClass" :data-cy="`grid-generator-${field.name}-field`">
+          <header :class="headerClass" :data-cy="`grid-generator-${field.name}-field`" :title="field.label">
             {{ field.label }}
           </header>
         </slot>
@@ -76,10 +76,39 @@ const { classes, getFieldClass } = useGenerator({ props })
 const hasResult = computed(() => Object.keys(props.result).length)
 const hasFields = computed(() => Object.keys(props.fields).length)
 
-const contentClass = computed(() => ({
-  ...props.contentClass,
-  ellipsis: !screen.isSmall && props.useEllipsis
-}))
+const contentClass = computed(() => {
+  if (!props.useEllipsis || (screen.isSmall && props.useEllipsis)) return props.contentClass
+
+  if (Array.isArray(props.contentClass)) {
+    return [...props.contentClass, 'ellipsis']
+  }
+
+  if (typeof props.contentClass === 'string') {
+    return `${props.contentClass} ellipsis`
+  }
+
+  return {
+    ...props.contentClass,
+    ellipsis: true
+  }
+})
+
+const headerClass = computed(() => {
+  if (!props.useEllipsis || (screen.isSmall && props.useEllipsis)) return props.headerClass
+
+  if (Array.isArray(props.headerClass)) {
+    return [...props.headerClass, 'ellipsis']
+  }
+
+  if (typeof props.headerClass === 'string') {
+    return `${props.headerClass} ellipsis`
+  }
+
+  return {
+    ...props.headerClass,
+    ellipsis: true
+  }
+})
 
 const fieldsByResult = ref({})
 

--- a/ui/src/components/grid-generator/QasGridGenerator.yml
+++ b/ui/src/components/grid-generator/QasGridGenerator.yml
@@ -48,6 +48,15 @@ props:
     default: true
     type: Boolean
 
+  use-ellipsis:
+    desc: Adiciona a classe "ellipsis" para o elemento do conteúdo.
+    default: true
+    type: Boolean
+
+  use-inline:
+    desc: Adiciona a disposição dos campos por linha, ou seja, header e content ocupando a linha toda.
+    type: Boolean
+
 slots:
   content:
     desc: Slot para o conteúdo (content).

--- a/ui/src/components/grid-generator/QasGridGenerator.yml
+++ b/ui/src/components/grid-generator/QasGridGenerator.yml
@@ -8,7 +8,7 @@ props:
     desc: Colunas do grid de cada campo.
     default: col-6
     type: [Array, String, Object]
-    examples: ["{ name: { sm: 6, md: 12 } }", "[{ sm: 6, md: 12 }]"]
+    examples: ["{ name: { sm: 6, md: 12 } }", "[{ sm: 6, md: 12 }]", "{ sm: 6, md: 12 }"]
 
   content-class:
     desc: Classe de cada "div" pai referente ao resultado.
@@ -56,6 +56,9 @@ props:
   use-inline:
     desc: Adiciona a disposição dos campos por linha, ou seja, header e content ocupando a linha toda.
     type: Boolean
+
+  use-common-columns:
+    desc: Utilizado quando passar a estrutura da prop "columns" sendo um objeto onde seus breakpoints serão replicados para todos fields.
 
 slots:
   content:

--- a/ui/src/components/grid-generator/QasGridGenerator.yml
+++ b/ui/src/components/grid-generator/QasGridGenerator.yml
@@ -58,7 +58,7 @@ props:
     type: Boolean
 
   use-common-columns:
-    desc: Utilizado quando passar a estrutura da prop "columns" sendo um objeto onde seus breakpoints serão replicados para todos fields.
+    desc: Usado quando precisa passar a prop "columns" como objeto sendo que será o valor comum para todos fields
 
 slots:
   content:

--- a/ui/src/composables/private/use-generator.js
+++ b/ui/src/composables/private/use-generator.js
@@ -19,6 +19,10 @@ export const baseProps = {
     default: Spacing.Lg,
     type: [String, Boolean],
     validator: gutterValidator
+  },
+
+  useCommonColumns: {
+    type: Boolean
   }
 }
 
@@ -107,10 +111,23 @@ export default function ({ props = {} }) {
    * @private
   */
   function _handleColumnsByField ({ index, isGridGenerator }) {
+    /*
+     * Quando é passado o columns como um único objeto que será replicado para todos fields.
+     */
+    if (props.useCommonColumns && Object.keys(props.columns).length) {
+      return _getBreakpoint(props.columns)
+    }
+
+    /*
+     * Quando não é passado columns, retornará o default.
+     */
     if (!props.columns[index]) {
       return _getDefaultColumnClass(isGridGenerator)
     }
 
+    /*
+     * Quando é passado um objeto por field.
+     */
     return _getBreakpoint(props.columns[index])
   }
 

--- a/ui/src/composables/private/use-generator.js
+++ b/ui/src/composables/private/use-generator.js
@@ -86,7 +86,11 @@ export default function ({ props = {} }) {
     for (const key in formattedColumns) {
       const value = formattedColumns[key]
 
-      classes.push(IRREGULAR_CLASSES.includes(value) ? value : `${profiles[key]}-${value}`)
+      if (IRREGULAR_CLASSES.includes(value)) {
+        classes.push(value === 'col' ? profiles[key] : value)
+      } else {
+        classes.push(`${profiles[key]}-${value}`)
+      }
     }
 
     return [...classes, renamedClasses]


### PR DESCRIPTION
### Adicionado
- `QasGridGenerator`: Adicionado prop `useEllipsis` que por default é `true`, que irá adicionar a classe `ellipsis` em seu conteúdo.
- `QasGridGenerator`: Adicionado prop `useInline` para mudar a disposição dos campos para ser por linha, ou seja, header e content ocupando a linha toda.
- [`QasFormGenerator`, `QasGridGenerator`]: Adicionado prop `useCommonColumns` onde será possível passar um único objeto com seus breakpoints e será replicado para todos fields.

### Corrigido
- `QasGridGenerator`: Corrigido ao passar `col` na prop columns(`{ lg: 'col' }`).

### Modificado
- `QasFormGenerator`: Alterado valor do margin-bottom da label do fieldset. Quando possuir descrição será `sm`, caso contrário `md`.
## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
