### PR TITLE
QasActionsMenu: fixed default props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasActionsMenu`: Corrigido props defaults que estavam faltando no componente após a refatoração/redesign (`{ useHoverOnWhiteColor: true, useLabelOnSmallScreen: false }`).
+
 ## [3.15.0-beta.12] - 19-04-2024
 ### Adicionado
 - `QasGridGenerator`:

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -139,7 +139,7 @@ const primaryKey = computed(() => {
   return props.splitName in fullList.value ? props.splitName : Object.keys(fullList.value)?.[0]
 })
 
-const btnDropdownProps = computed(() => {
+const defaultButtonPropsList = computed(() => {
   const defaultButtonPropsList = {
     useHoverOnWhiteColor: true,
     useLabelOnSmallScreen: false
@@ -154,8 +154,12 @@ const btnDropdownProps = computed(() => {
     }
   }
 
+  return normalizedButtonPropsList
+})
+
+const btnDropdownProps = computed(() => {
   return {
-    buttonsPropsList: normalizedButtonPropsList,
+    buttonsPropsList: defaultButtonPropsList.value,
     disable: props.disable,
     useSplit: hasSplit.value
   }

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -140,8 +140,22 @@ const primaryKey = computed(() => {
 })
 
 const btnDropdownProps = computed(() => {
+  const defaultButtonPropsList = {
+    useHoverOnWhiteColor: true,
+    useLabelOnSmallScreen: false
+  }
+
+  const normalizedButtonPropsList = {}
+
+  for (const key in formattedList.value.buttonsList) {
+    normalizedButtonPropsList[key] = {
+      ...defaultButtonPropsList,
+      ...formattedList.value.buttonsList[key]
+    }
+  }
+
   return {
-    buttonsPropsList: formattedList.value.buttonsList,
+    buttonsPropsList: normalizedButtonPropsList,
     disable: props.disable,
     useSplit: hasSplit.value
   }

--- a/ui/src/components/actions-menu/composables/use-options-actions.js
+++ b/ui/src/components/actions-menu/composables/use-options-actions.js
@@ -15,7 +15,6 @@ export default function useOptionsActions ({ props, color }) {
       options: {
         color,
         iconRight: 'sym_r_more_vert',
-        useLabelOnSmallScreen: false,
         ...props.buttonProps,
         label: getLabel({ useLabel: props.useLabel, label: 'Opções' }) // label não pode ser sobrescrita.
       }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Corrigido
- `QasActionsMenu`: Corrigido props defaults que estavam faltando no componente após a refatoração/redesign (`{ useHoverOnWhiteColor: true, useLabelOnSmallScreen: false }`).

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
