### PR TITLE
QasGridGenerator and QasFormGenerator: added commonColumns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+## BREAKING CHANGES
+- [`QasFormGenerator`, `QasGridGenerator`]: removido a propriedade `useCommonColumns` em favor de utilizar a propriedade `commonColumns`.
+
+### Adicionado
+- [`QasFormGenerator`, `QasGridGenerator`]: adicionado nova propriedade `commonColumns`, esta propriedade vai substituir a necessidade do `useCommonColumns` e dar mais flexibilidade.
+
+### Removido
+- [`QasFormGenerator`, `QasGridGenerator`]: removido a propriedade `useCommonColumns` em favor de utilizar a propriedade `commonColumns`.
+
 ## [3.16.0-beta.0] - 24-05-2024
 ### Corrigido
 - `QasSelect`: Corrigido forma de atribuir as options, já que estava dando problema de endereço de memória em selects dependentes que são lazy-loading dentro de um `QasNestedFields`.

--- a/docs/src/examples/QasFormGenerator/ExFormCommonColumns.vue
+++ b/docs/src/examples/QasFormGenerator/ExFormCommonColumns.vue
@@ -1,0 +1,54 @@
+<template>
+  <!-- Usando qas-single-view apenas para recuperar os dados -->
+  <qas-single-view v-model:fields="viewState.fields" v-model:result="viewState.result" v-bind="singleViewProps">
+    <template #default>
+      <div>
+        <div>
+          <qas-label label="object" />
+
+          <qas-form-generator v-bind="formGeneratorProps" v-model="viewState.values" :fields="viewState.fields" />
+
+          <q-separator class="q-mt-xl" />
+        </div>
+
+        <qas-label class="q-mt-xl" label="string" />
+
+        <qas-form-generator v-bind="formGeneratorStringProps" v-model="viewState.values" :fields="viewState.fields" />
+      </div>
+    </template>
+  </qas-single-view>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+defineOptions({ name: 'ExFormCommonColumns' })
+
+const viewState = ref({
+  fields: {},
+  values: []
+})
+
+const entity = 'users'
+
+const customId = '3102fad5-f14c-45d4-98e9-46ef0aa9580e'
+
+const singleViewProps = {
+  entity,
+  customId
+}
+
+const formGeneratorProps = {
+  commonColumns: { col: 12, sm: 3 },
+  columns: {
+    name: { col: 12, sm: 12 }
+  }
+}
+
+const formGeneratorStringProps = {
+  commonColumns: '3',
+  columns: {
+    name: { col: 12 }
+  }
+}
+</script>

--- a/docs/src/examples/QasGridGenerator/Basic.vue
+++ b/docs/src/examples/QasGridGenerator/Basic.vue
@@ -3,7 +3,7 @@
   <qas-single-view v-model:fields="fields" v-model:result="result" :custom-id="customId" :entity="entity">
     <template #default>
       <div>
-        <qas-grid-generator :fields="fields" :result="result" />
+        <qas-grid-generator :columns="{ name: { col: 12 } }" :fields="fields" :result="result" />
       </div>
     </template>
   </qas-single-view>

--- a/docs/src/examples/QasGridGenerator/ExGridCommonColumns.vue
+++ b/docs/src/examples/QasGridGenerator/ExGridCommonColumns.vue
@@ -1,0 +1,54 @@
+<template>
+  <!-- Usando qas-single-view apenas para recuperar os dados -->
+  <qas-single-view v-model:fields="viewState.fields" v-model:result="viewState.result" v-bind="singleViewProps">
+    <template #default>
+      <div>
+        <div>
+          <qas-label label="object" />
+
+          <qas-grid-generator v-bind="gridGeneratorProps" :fields="viewState.fields" :result="viewState.result" />
+
+          <q-separator class="q-mt-xl" />
+        </div>
+
+        <qas-label class="q-mt-xl" label="string" />
+
+        <qas-grid-generator v-bind="gridGeneratorStringProps" :fields="viewState.fields" :result="viewState.result" />
+      </div>
+    </template>
+  </qas-single-view>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+defineOptions({ name: 'ExGridCommonColumns' })
+
+const viewState = ref({
+  fields: {},
+  result: []
+})
+
+const entity = 'users'
+
+const customId = '3102fad5-f14c-45d4-98e9-46ef0aa9580e'
+
+const singleViewProps = {
+  entity,
+  customId
+}
+
+const gridGeneratorProps = {
+  commonColumns: { col: 12, sm: 3 },
+  columns: {
+    name: { col: 12, sm: 12 }
+  }
+}
+
+const gridGeneratorStringProps = {
+  commonColumns: '3',
+  columns: {
+    name: { col: 12 }
+  }
+}
+</script>

--- a/docs/src/pages/components/form-generator.md
+++ b/docs/src/pages/components/form-generator.md
@@ -43,3 +43,5 @@ Em alguns casos, queremos acessar todo o conteúdo de um campo especifico para f
 <doc-example file="QasFormGenerator/CustomSlot" title="Acessando slots" />
 
 <doc-example file="QasFormGenerator/CustomProps" title="Custom props" />
+
+<doc-example file="QasFormGenerator/ExFormCommonColumns" title="Common columns" />

--- a/docs/src/pages/components/grid-generator.md
+++ b/docs/src/pages/components/grid-generator.md
@@ -20,5 +20,6 @@ Ao utilizar a prop `useInline`, o gutter passa a ter o valor `md`.
 
 ## Uso
 <doc-example file="QasGridGenerator/Basic" title="Básico" />
+<doc-example file="QasGridGenerator/ExGridCommonColumns" title="Common Columns" />
 <doc-example file="QasGridGenerator/Slots" title="Slots" />
 <doc-example file="QasGridGenerator/UseInline" title="Inline" />

--- a/ui/src/components/form-generator/QasFormGenerator.yml
+++ b/ui/src/components/form-generator/QasFormGenerator.yml
@@ -10,6 +10,10 @@ props:
     type: [Array, String, Object]
     examples: ["[{ sm: 6, md: 12 }]", "{ name: { sm: 6, md: 12 } }", "12", "{ sm: 6, md: 12 }"]
 
+  common-columns:
+    desc: Usado quando precisa passar o mesmo valor para todas as colunas, sem especificar cada uma, ela é feita como um merge com a prop "columns".
+    examples: ["{ name: { sm: 6, md: 12 } }", "12"]
+
   disable:
     desc: Deixa os campos desabilitados enviando a prop "disable" para cada campo.
     default: "false"
@@ -62,9 +66,6 @@ props:
     desc: Altera ordem dos campos.
     default: []
     type: Array
-
-  use-common-columns:
-    desc: Utilizado quando passar a estrutura da prop "columns" sendo um objeto onde seus breakpoints serão replicados para todos fields.
 
 slots:
   'field-[nome-da-chave]':

--- a/ui/src/components/grid-generator/QasGridGenerator.yml
+++ b/ui/src/components/grid-generator/QasGridGenerator.yml
@@ -10,6 +10,10 @@ props:
     type: [Array, String, Object]
     examples: ["{ name: { sm: 6, md: 12 } }", "[{ sm: 6, md: 12 }]", "{ sm: 6, md: 12 }"]
 
+  common-columns:
+    desc: Usado quando precisa passar o mesmo valor para todas as colunas, sem especificar cada uma, ela é feita como um merge com a prop "columns".
+    examples: ["{ name: { sm: 6, md: 12 } }", "12"]
+
   content-class:
     desc: Classe de cada "div" pai referente ao resultado.
     default: ''
@@ -56,9 +60,6 @@ props:
   use-inline:
     desc: Adiciona a disposição dos campos por linha, ou seja, header e content ocupando a linha toda.
     type: Boolean
-
-  use-common-columns:
-    desc: Usado quando precisa passar a prop "columns" como objeto sendo que será o valor comum para todos fields
 
 slots:
   content:

--- a/ui/src/composables/private/use-generator.js
+++ b/ui/src/composables/private/use-generator.js
@@ -10,6 +10,11 @@ export const baseProps = {
     type: [Array, String, Object]
   },
 
+  commonColumns: {
+    default: () => ({}),
+    type: [Object, String]
+  },
+
   fields: {
     default: () => ({}),
     type: Object
@@ -19,10 +24,6 @@ export const baseProps = {
     default: Spacing.Lg,
     type: [String, Boolean],
     validator: gutterValidator
-  },
-
-  useCommonColumns: {
-    type: Boolean
   }
 }
 
@@ -61,9 +62,7 @@ export default function ({ props = {} }) {
    * @returns {(string|string[])}
    */
   function getFieldClass ({ index, isGridGenerator, fields }) {
-    if (typeof props.columns === 'string') {
-      return IRREGULAR_CLASSES.includes(props.columns) ? props.columns : `col-${props.columns}`
-    }
+    if (typeof props.columns === 'string') return _getStringColumns(props.columns)
 
     return Array.isArray(props.columns)
       ? _handleColumnsByIndex({ index, isGridGenerator, fields })
@@ -72,7 +71,13 @@ export default function ({ props = {} }) {
 
   /**
    * @private
-  */
+   */
+  function _getStringColumns (columns) {
+    return IRREGULAR_CLASSES.includes(columns) ? columns : `col-${columns}`
+  }
+  /**
+   * @private
+   */
   function _getBreakpoint (columns) {
     const classes = []
 
@@ -104,6 +109,10 @@ export default function ({ props = {} }) {
    * @private
   */
   function _getDefaultColumnClass (isGridGenerator) {
+    if (typeof props.commonColumns === 'string') return _getStringColumns(props.commonColumns)
+
+    if (Object.keys(props.commonColumns).length) return _getBreakpoint(props.commonColumns)
+
     return isGridGenerator ? 'col-6 col-xs-12 col-sm-4' : 'col-6'
   }
 
@@ -111,13 +120,6 @@ export default function ({ props = {} }) {
    * @private
   */
   function _handleColumnsByField ({ index, isGridGenerator }) {
-    /*
-     * Quando é passado o columns como um único objeto que será replicado para todos fields.
-     */
-    if (props.useCommonColumns && Object.keys(props.columns).length) {
-      return _getBreakpoint(props.columns)
-    }
-
     /*
      * Quando não é passado columns, retornará o default.
      */


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
## BREAKING CHANGES
- [`QasFormGenerator`, `QasGridGenerator`]: removido a propriedade `useCommonColumns` em favor de utilizar a propriedade `commonColumns`.

### Adicionado
- [`QasFormGenerator`, `QasGridGenerator`]: adicionado nova propriedade `commonColumns`, esta propriedade vai substituir a necessidade do `useCommonColumns` e dar mais flexibilidade.

### Removido
- [`QasFormGenerator`, `QasGridGenerator`]: removido a propriedade `useCommonColumns` em favor de utilizar a propriedade `commonColumns`.


<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [x] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [ ] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
