### PR TITLE
QasExpansionItem and QasToggleVisibility changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,16 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## [Não publicado]
+## Não publicado
 ### Corrigido
 - `QasHeaderActions`: Corrigido quebra de de layout em casos de ter 2 itens com split usando `QasActionsMenu`.
 - `QasSingleView`: Corrigido exposição de métodos para possibilidade de usar `Template Refs`.
+
+### Modificado
+- `QasExpansionItem`:
+  - Repassando todos eventos do QExpansionItem.
+  - Mudanças de layout quando usado expansion dentro de expansion.
+- `QasToggleVisibility`: adicionado evento `prevent.stop` no botão para não disparar evento de click na tabela.
 
 ## [3.16.0-beta.5] - 04-07-2024
 ### Adicionado

--- a/docs/src/pages/components/expansion-item.md
+++ b/docs/src/pages/components/expansion-item.md
@@ -7,7 +7,8 @@ Componente de card expansivo, wrapper do QExpansionItem(https://quasar.dev/vue-c
 <doc-api file="expansion-item/QasExpansionItem" name="QasExpansionItem" />
 
 :::info
-Quando usado QasExpansionItem dentro de QasExpansionItem, o componente já lida com isto internamente alterando o estilo dos QasExpansionItem interno.
+- Quando usado QasExpansionItem dentro de QasExpansionItem, o componente já lida com isto internamente alterando o estilo dos QasExpansionItem interno.
+- O componente repassa todos os eventos do [QExpansionItem](https://quasar.dev/vue-components/expansion-item#usage).
 :::
 
 :::warning

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -1,7 +1,7 @@
 <template>
-  <div ref="expansionItem" class="qas-expansion-item" :class="errorClasses">
+  <div ref="expansionItem" class="full-width qas-expansion-item" :class="errorClasses">
     <component :is="component.is" class="qas-expansion-item__box">
-      <q-expansion-item header-class="text-bold q-mt-sm q-pa-none" :label="props.label">
+      <q-expansion-item header-class="text-bold q-mt-sm q-pa-none" :label="props.label" v-bind="expansionItemProps">
         <template #header>
           <slot name="header">
             <div class="full-width">
@@ -45,9 +45,12 @@
 <script setup>
 import QasBox from '../box/QasBox.vue'
 
-import { computed, provide, inject, onMounted, ref } from 'vue'
+import { computed, provide, inject, onMounted, ref, useAttrs } from 'vue'
 
-defineOptions({ name: 'QasExpansionItem' })
+defineOptions({
+  name: 'QasExpansionItem',
+  inheritAttrs: false
+})
 
 const props = defineProps({
   badges: {
@@ -75,6 +78,8 @@ const props = defineProps({
   }
 })
 
+const attrs = useAttrs()
+
 provide('isExpansionItem', true)
 
 // slots
@@ -100,6 +105,17 @@ const hasGridGenerator = computed(() => !!Object.keys(props.gridGeneratorProps).
 const hasBottomSeparator = computed(() => isNestedExpansionItem && hasNextSibling.value)
 const hasHeaderBottom = computed(() => !!slots['header-bottom'])
 
+const expansionItemProps = computed(() => {
+  return {
+    onShow: attrs.onShow,
+    onBeforeShow: attrs.onBeforeShow,
+    onBeforeHide: attrs.onBeforeHide,
+    onAfterShow: attrs.onAfterShow,
+    onAfterHide: attrs.onAfterHide,
+    'onUpdate:modelValue': attrs['onUpdate:modelValue']
+  }
+})
+
 // functions
 
 /**
@@ -119,10 +135,6 @@ function setHasNextSibling (value) {
 <style lang="scss">
 .qas-expansion-item {
   $root: &;
-
-  & + & {
-    margin-top: var(--qas-spacing-lg);
-  }
 
   &--error {
     #{$root}__box {

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -1,7 +1,7 @@
 <template>
-  <div ref="expansionItem" class="full-width qas-expansion-item" :class="errorClasses">
+  <div ref="expansionItem" class="full-width qas-expansion-item" :class="errorClasses" v-bind="expansionProps.parent">
     <component :is="component.is" class="qas-expansion-item__box">
-      <q-expansion-item header-class="text-bold q-mt-sm q-pa-none" :label="props.label" v-bind="expansionItemProps">
+      <q-expansion-item header-class="text-bold q-mt-sm q-pa-none" :label="props.label" v-bind="expansionProps.item">
         <template #header>
           <slot name="header">
             <div class="full-width">
@@ -105,14 +105,30 @@ const hasGridGenerator = computed(() => !!Object.keys(props.gridGeneratorProps).
 const hasBottomSeparator = computed(() => isNestedExpansionItem && hasNextSibling.value)
 const hasHeaderBottom = computed(() => !!slots['header-bottom'])
 
-const expansionItemProps = computed(() => {
+const expansionProps = computed(() => {
+  const {
+    'onUpdate:modelValue': onUpdateModelValue,
+    onShow,
+    onBeforeShow,
+    onBeforeHide,
+    onAfterShow,
+    onAfterHide,
+    ...propsPayload
+  } = attrs
+
   return {
-    onShow: attrs.onShow,
-    onBeforeShow: attrs.onBeforeShow,
-    onBeforeHide: attrs.onBeforeHide,
-    onAfterShow: attrs.onAfterShow,
-    onAfterHide: attrs.onAfterHide,
-    'onUpdate:modelValue': attrs['onUpdate:modelValue']
+    parent: {
+      ...propsPayload
+    },
+
+    item: {
+      onUpdateModelValue,
+      onShow,
+      onBeforeShow,
+      onBeforeHide,
+      onAfterShow,
+      onAfterHide
+    }
   }
 })
 

--- a/ui/src/components/toggle-visibility/QasToggleVisibility.vue
+++ b/ui/src/components/toggle-visibility/QasToggleVisibility.vue
@@ -21,7 +21,7 @@
       <qas-btn
         class="q-ml-sm qas-toggle-visibility__button"
         :icon
-        @click="toggleVisibility"
+        @click.prevent.stop="toggleVisibility"
       />
     </div>
   </div>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

### Modificado
- `QasExpansionItem`:
  - Repassando todos eventos do QExpansionItem.
  - Mudanças de layout quando usado expansion dentro de expansion.
- `QasToggleVisibility`: adicionado evento `prevent.stop` no botão para não disparar evento de click na tabela.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
