### PR TITLE
chore: Fix QasExpansionItem spacing and setHasNextSibling function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `QasExpansionItem`: adicionado espaçamento `sm` no conteúdo quando for nested.
+
+### Corrigido
+- `QasExpansionItem`: corrigido função `setHasNextSibling`.
+
 ## [3.16.0-beta.7] - 23-07-2024
 ### Modificado
 - `boot/notifications`: removido notificações em localhost, uma vez que ficava gerando vários errors de conexão no console/network, o que atrapalhava o desenvolvimento local.

--- a/docs/src/examples/QasExpansionItem/Nested.vue
+++ b/docs/src/examples/QasExpansionItem/Nested.vue
@@ -2,29 +2,31 @@
   <div class="container spaced">
     <qas-expansion-item :badges="badges" label="John Doe">
       <template #content>
-        <qas-expansion-item label="Informações 1">
-          <template #content>
-            Meu conteúdo customizado
-          </template>
-        </qas-expansion-item>
+        <div class="q-col-gutter-y-md row">
+          <qas-expansion-item label="Informações 1">
+            <template #content>
+              Meu conteúdo customizado
+            </template>
+          </qas-expansion-item>
 
-        <qas-expansion-item label="Informações 2">
-          <template #content>
-            Meu conteúdo customizado 2
-          </template>
-        </qas-expansion-item>
+          <qas-expansion-item label="Informações 2">
+            <template #content>
+              Meu conteúdo customizado 2
+            </template>
+          </qas-expansion-item>
 
-        <qas-expansion-item label="Informações 3">
-          <template #content>
-            Meu conteúdo customizado 3
-          </template>
-        </qas-expansion-item>
+          <qas-expansion-item label="Informações 3">
+            <template #content>
+              Meu conteúdo customizado 3
+            </template>
+          </qas-expansion-item>
 
-        <qas-expansion-item label="Informações 4">
-          <template #content>
-            Lorem ipsum dolor sit amet consectetur adipisicing elit. Numquam dolore eligendi accusamus placeat laudantium aliquid aspernatur mollitia, expedita id labore ex nulla quam maiores exercitationem et debitis quae corrupti odio.
-          </template>
-        </qas-expansion-item>
+          <qas-expansion-item label="Informações 4">
+            <template #content>
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Numquam dolore eligendi accusamus placeat laudantium aliquid aspernatur mollitia, expedita id labore ex nulla quam maiores exercitationem et debitis quae corrupti odio.
+            </template>
+          </qas-expansion-item>
+        </div>
       </template>
     </qas-expansion-item>
   </div>

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -28,9 +28,11 @@
 
         <q-separator v-if="!isNestedExpansionItem" class="q-my-md" />
 
-        <slot name="content">
-          <qas-grid-generator v-if="hasGridGenerator" v-bind="gridGeneratorProps" use-inline />
-        </slot>
+        <div :class="contentClasses">
+          <slot name="content">
+            <qas-grid-generator v-if="hasGridGenerator" v-bind="gridGeneratorProps" use-inline />
+          </slot>
+        </div>
 
         <q-separator v-if="hasBottomSeparator" class="q-mt-md" />
       </q-expansion-item>
@@ -99,11 +101,12 @@ const component = {
 
 // computed
 const hasError = computed(() => props.error || !!props.errorMessage)
-const errorClasses = computed(() => ({ 'qas-expansion-item--error': hasError.value }))
-
 const hasGridGenerator = computed(() => !!Object.keys(props.gridGeneratorProps).length)
 const hasBottomSeparator = computed(() => isNestedExpansionItem && hasNextSibling.value)
 const hasHeaderBottom = computed(() => !!slots['header-bottom'])
+
+const errorClasses = computed(() => ({ 'qas-expansion-item--error': hasError.value }))
+const contentClasses = computed(() => ({ 'q-mt-sm': isNestedExpansionItem }))
 
 const expansionProps = computed(() => {
   const {
@@ -141,7 +144,7 @@ const expansionProps = computed(() => {
 function setHasNextSibling (value) {
   if (!isNestedExpansionItem) return
 
-  const hasTextContentSibling = !!expansionItem.value.nextSibling.textContent?.trim?.()
+  const hasTextContentSibling = !!expansionItem.value.nextSibling?.textContent?.trim?.()
   const hasElementSibling = !!expansionItem.value.nextElementSibling
 
   hasNextSibling.value = hasElementSibling || hasTextContentSibling


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Modificado
- `QasExpansionItem`: adicionado espaçamento `sm` no conteúdo quando for nested.

### Corrigido
- `QasExpansionItem`: corrigido função `setHasNextSibling`.
<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
