### PR TITLE
QasExpansionItem changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasExpansionItem`: Adicionado nova propriedade `useHeaderSeparator` para forçar o controle do QSeparator.
+
 ## [3.16.0-beta.8] - 24-07-2024
 ### Modificado
 - `QasExpansionItem`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ### Adicionado
 - `QasExpansionItem`: Adicionado nova propriedade `useHeaderSeparator` para forçar o controle do QSeparator.
 
+### Corrigido
+- `QasExpansionItem`: Adicionado classe para z-index, onde corrige o problema de quando usado grid com gutter no conteúdo e sobrepunha o header fazendo com que perdesse o evento de click.
+
 ## [3.16.0-beta.8] - 24-07-2024
 ### Modificado
 - `QasExpansionItem`:

--- a/docs/src/examples/QasExpansionItem/Basic.vue
+++ b/docs/src/examples/QasExpansionItem/Basic.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- Usando qas-single-view apenas para recuperar os dados -->
   <qas-single-view v-model:fields="fields" v-model:result="result" :custom-id="customId" :entity="entity">
-    <qas-expansion-item :badges="badges" :grid-generator-props="gridGeneratorProps" label="John Doe" />
+    <qas-expansion-item :badges="badges" :grid-generator-props="gridGeneratorProps" label="John Doe" :use-header-separator="false" />
   </qas-single-view>
 </template>
 

--- a/docs/src/examples/QasExpansionItem/Basic.vue
+++ b/docs/src/examples/QasExpansionItem/Basic.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- Usando qas-single-view apenas para recuperar os dados -->
   <qas-single-view v-model:fields="fields" v-model:result="result" :custom-id="customId" :entity="entity">
-    <qas-expansion-item :badges="badges" :grid-generator-props="gridGeneratorProps" label="John Doe" :use-header-separator="false" />
+    <qas-expansion-item :badges="badges" :grid-generator-props="gridGeneratorProps" label="John Doe" />
   </qas-single-view>
 </template>
 

--- a/docs/src/pages/components/expansion-item.md
+++ b/docs/src/pages/components/expansion-item.md
@@ -13,7 +13,7 @@ Componente de card expansivo, wrapper do QExpansionItem(https://quasar.dev/vue-c
 
 :::warning
 - Não recomendamos o uso de nested de 3 níveis (QasExpansionItem dentro de QasExpansionItem dentro de QasExpansionItem).
-- Usar a propriedade "useHeader" passando valor "false" somente em casos específicos.
+- O separador no header funciona de forma automática, porém em alguns casos é necessário forçar aparecer/remover, use a propriedade "useHeaderSeparator" nestes casos específicos.
 :::
 
 ## Uso

--- a/docs/src/pages/components/expansion-item.md
+++ b/docs/src/pages/components/expansion-item.md
@@ -12,7 +12,8 @@ Componente de card expansivo, wrapper do QExpansionItem(https://quasar.dev/vue-c
 :::
 
 :::warning
-Não recomendamos o uso de nested de 3 níveis (QasExpansionItem dentro de QasExpansionItem dentro de QasExpansionItem).
+- Não recomendamos o uso de nested de 3 níveis (QasExpansionItem dentro de QasExpansionItem dentro de QasExpansionItem).
+- Usar a propriedade "useHeader" passando valor "false" somente em casos específicos.
 :::
 
 ## Uso

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -26,7 +26,7 @@
           </slot>
         </template>
 
-        <q-separator v-if="!isNestedExpansionItem" class="q-my-md" />
+        <q-separator v-if="hasHeaderSeparator" class="q-my-md" />
 
         <div :class="contentClasses">
           <slot name="content">
@@ -77,6 +77,11 @@ const props = defineProps({
   gridGeneratorProps: {
     type: Object,
     default: () => ({})
+  },
+
+  useHeaderSeparator: {
+    type: Boolean,
+    default: true
   }
 })
 
@@ -105,8 +110,26 @@ const hasGridGenerator = computed(() => !!Object.keys(props.gridGeneratorProps).
 const hasBottomSeparator = computed(() => isNestedExpansionItem && hasNextSibling.value)
 const hasHeaderBottom = computed(() => !!slots['header-bottom'])
 
+const hasHeaderSeparator = computed(() => {
+  // if (props.useHeaderSeparator) return !isNestedExpansionItem
+
+  // return props.useHeaderSeparator
+
+  // true && false
+  // false && false
+  // false && true
+  // true && true
+  return props.useHeaderSeparator && !isNestedExpansionItem
+})
+
 const errorClasses = computed(() => ({ 'qas-expansion-item--error': hasError.value }))
-const contentClasses = computed(() => ({ 'q-mt-sm': isNestedExpansionItem }))
+
+const contentClasses = computed(() => {
+  return {
+    'q-mt-sm': isNestedExpansionItem,
+    'q-mt-md': !isNestedExpansionItem && !props.useHeaderSeparator
+  }
+})
 
 const expansionProps = computed(() => {
   const {

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -81,7 +81,7 @@ const props = defineProps({
 
   useHeaderSeparator: {
     type: Boolean,
-    default: true
+    default: undefined
   }
 })
 
@@ -110,16 +110,19 @@ const hasGridGenerator = computed(() => !!Object.keys(props.gridGeneratorProps).
 const hasBottomSeparator = computed(() => isNestedExpansionItem && hasNextSibling.value)
 const hasHeaderBottom = computed(() => !!slots['header-bottom'])
 
+/**
+ * Verifica se o componente deve adicionar um separador no header.
+ *
+ * - Se a propriedade useHeaderSeparator for true, retorna separador.
+ * - Se a propriedade useHeaderSeparator for undefined, retorna separador apenas se não for um componente aninhado.
+ * - Se a propriedade useHeaderSeparator for false, não retorna separador.
+ */
 const hasHeaderSeparator = computed(() => {
-  // if (props.useHeaderSeparator) return !isNestedExpansionItem
+  if (props.useHeaderSeparator) return true
 
-  // return props.useHeaderSeparator
+  if (typeof props.useHeaderSeparator === 'undefined') return !isNestedExpansionItem
 
-  // true && false
-  // false && false
-  // false && true
-  // true && true
-  return props.useHeaderSeparator && !isNestedExpansionItem
+  return false
 })
 
 const errorClasses = computed(() => ({ 'qas-expansion-item--error': hasError.value }))

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -118,9 +118,7 @@ const hasHeaderBottom = computed(() => !!slots['header-bottom'])
  * - Se a propriedade useHeaderSeparator for false, não retorna separador.
  */
 const hasHeaderSeparator = computed(() => {
-  if (typeof props.useHeaderSeparator === 'undefined') return !isNestedExpansionItem
-
-  return props.useHeaderSeparator
+  return typeof props.useHeaderSeparator === 'undefined' ? !isNestedExpansionItem : props.useHeaderSeparator
 })
 
 const errorClasses = computed(() => ({ 'qas-expansion-item--error': hasError.value }))

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -1,7 +1,7 @@
 <template>
   <div ref="expansionItem" class="full-width qas-expansion-item" :class="errorClasses" v-bind="expansionProps.parent">
     <component :is="component.is" class="qas-expansion-item__box">
-      <q-expansion-item header-class="text-bold q-mt-sm q-pa-none" :label="props.label" v-bind="expansionProps.item">
+      <q-expansion-item header-class="text-bold q-mt-sm q-pa-none qas-expansion-item__header" :label="props.label" v-bind="expansionProps.item">
         <template #header>
           <slot name="header">
             <div class="full-width">
@@ -118,11 +118,9 @@ const hasHeaderBottom = computed(() => !!slots['header-bottom'])
  * - Se a propriedade useHeaderSeparator for false, não retorna separador.
  */
 const hasHeaderSeparator = computed(() => {
-  if (props.useHeaderSeparator) return true
-
   if (typeof props.useHeaderSeparator === 'undefined') return !isNestedExpansionItem
 
-  return false
+  return props.useHeaderSeparator
 })
 
 const errorClasses = computed(() => ({ 'qas-expansion-item--error': hasError.value }))
@@ -180,6 +178,12 @@ function setHasNextSibling (value) {
 <style lang="scss">
 .qas-expansion-item {
   $root: &;
+
+  // em alguns casos quando usado com grid, o espaçamento afetava o header, com z-index o problema é resolvido
+  &__header {
+    position: relative;
+    z-index: 1;
+  }
 
   &--error {
     #{$root}__box {

--- a/ui/src/components/expansion-item/QasExpansionItem.yml
+++ b/ui/src/components/expansion-item/QasExpansionItem.yml
@@ -24,6 +24,11 @@ props:
     desc: Propriedades que serão repassadas para o QasGridGenerator.
     type: Object
 
+  use-header-separator:
+    desc: Propriedade para controlar o QSeparator no header.
+    type: Boolean
+    default: true
+
 slots:
   header:
     desc: 'Slot para substituir o conteúdo do header'

--- a/ui/src/components/expansion-item/QasExpansionItem.yml
+++ b/ui/src/components/expansion-item/QasExpansionItem.yml
@@ -25,9 +25,9 @@ props:
     type: Object
 
   use-header-separator:
-    desc: Propriedade para controlar o QSeparator no header.
+    desc: Propriedade para forçar o QSeparator no header.
     type: Boolean
-    default: true
+    default: undefined
 
 slots:
   header:


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Adicionado
- `QasExpansionItem`: Adicionado nova propriedade `useHeaderSeparator` para forçar o controle do QSeparator.

### Corrigido
- `QasExpansionItem`: Adicionado classe para z-index, onde corrige o problema de quando usado grid com gutter no conteúdo e sobrepunha o header fazendo com que perdesse o evento de click.


<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
