### PR TITLE
QasTableGenerator changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasTableGenerator`: adicionado nova propriedade `useBox`.
+
 ## [3.16.0-beta.8] - 24-07-2024
 ### Modificado
 - `QasExpansionItem`:

--- a/docs/src/examples/QasTableGenerator/NoBox.vue
+++ b/docs/src/examples/QasTableGenerator/NoBox.vue
@@ -1,0 +1,27 @@
+<template>
+  <!-- Utilizando o list-view apenas para facilitar para recuperar os dados dos dados. -->
+  <qas-list-view v-model:fields="fields" v-model:results="results" :entity="entity" :use-filter="false">
+    <template #default>
+      <qas-table-generator :fields="fields" :results="results" row-key="uuid" :use-box="false" />
+    </template>
+  </qas-list-view>
+</template>
+
+<script>
+export default {
+  name: 'UsersList',
+
+  data () {
+    return {
+      fields: {},
+      results: []
+    }
+  },
+
+  computed: {
+    entity () {
+      return 'users'
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QasTableGenerator/NoBox.vue
+++ b/docs/src/examples/QasTableGenerator/NoBox.vue
@@ -9,7 +9,7 @@
 
 <script>
 export default {
-  name: 'UsersList',
+  name: 'NoBox',
 
   data () {
     return {

--- a/docs/src/pages/components/table-generator.md
+++ b/docs/src/pages/components/table-generator.md
@@ -31,6 +31,7 @@ Componente implementa o `QasBox` repassando todas propriedades.
 ## Uso
 
 <doc-example file="QasTableGenerator/Basic" title="Básico" />
+<doc-example file="QasTableGenerator/NoBox" title="Sem box" />
 
 Este componente renderiza componentes dinamicamente através da prop `fields`, cada field dentro de fields tem um `name`, através dele, você consegue acessar os slots dinâmicos.
 

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -1,5 +1,5 @@
 <template>
-  <qas-box class="q-px-lg q-py-md">
+  <component :is="parentComponent.is" v-bind="parentComponent.props">
     <q-table ref="table" class="bg-white qas-table-generator text-grey-8" v-bind="attributes">
       <template v-for="(_, name) in slots" #[name]="context">
         <slot :name="name" v-bind="context" />
@@ -15,7 +15,7 @@
         </q-td>
       </template>
     </q-table>
-  </qas-box>
+  </component>
 </template>
 
 <script>
@@ -55,6 +55,11 @@ export default {
     emptyResultText: {
       default: '-',
       type: String
+    },
+
+    useBox: {
+      type: Boolean,
+      default: true
     },
 
     useScrollOnGrab: {
@@ -217,6 +222,15 @@ export default {
 
     hasScrollOnGrab () {
       return !!Object.keys(this.scrollOnGrab).length
+    },
+
+    parentComponent () {
+      return {
+        is: this.useBox ? 'qas-box' : 'div',
+        props: {
+          class: this.useBox ? 'q-px-lg q-py-md' : ''
+        }
+      }
     }
   },
 

--- a/ui/src/components/table-generator/QasTableGenerator.yml
+++ b/ui/src/components/table-generator/QasTableGenerator.yml
@@ -36,6 +36,11 @@ props:
     type: Function
     examples: ["(row) => ({ path: 'table-generator', params: { id: row.uuid } })"]
 
+  use-box:
+    desc: Controla se o componente vai usar QasBox ou div.
+    default: true
+    type: Boolean
+
   use-external-link:
     desc: Usado em conjunto com a prop "row-route-fn" quando há a necessidade da rota ser um link externo.
     default: false


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Adicionado
- `QasTableGenerator`: adicionado nova propriedade `useBox`.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
