### PR TITLE
Releasing v3.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasTableGenerator`: adicionado nova propriedade `useBox`.
+
 ## [3.16.0-beta.8] - 24-07-2024
 ### Modificado
 - `QasExpansionItem`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,14 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ## Não publicado
 ### Adicionado
-- `QasExpansionItem`: Adicionado nova propriedade `useHeaderSeparator` para forçar o controle do QSeparator.
+- [`QasFormView`, `QasListView`, `QasSingleView`]: adicionado novo slot chamado `fetch-error` que é disponibilizado quando ocorre o `fetchError`.
+
+### Modificado
+- `QasLabel`: Modificado tag renderizada no componente para ser de acordo com a passada pela prop `typography`.
 
 ### Corrigido
+- `QasGridGenerator`: Corrigido gutter quando se é utilizado a prop `useInline`.
+- `QasExpansionItem`: Adicionado nova propriedade `useHeaderSeparator` para forçar o controle do QSeparator.
 - `QasExpansionItem`: Adicionado classe para z-index, onde corrige o problema de quando usado grid com gutter no conteúdo e sobrepunha o header fazendo com que perdesse o evento de click.
 - `QasTableGenerator`: adicionado nova propriedade `useBox`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ### Adicionado
 - [`QasFormGenerator`, `QasGridGenerator`]: adicionado nova propriedade `commonColumns`, esta propriedade vai substituir a necessidade do `useCommonColumns` e dar mais flexibilidade.
+- `QasAppMenu`: adicionado propriedade `helpChatLink`, para a ação de "Solicitar ajuda".
 
 ### Removido
 - [`QasFormGenerator`, `QasGridGenerator`]: removido a propriedade `useCommonColumns` em favor de utilizar a propriedade `commonColumns`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+## BREAKING CHANGES
+- [`QasFormGenerator`, `QasGridGenerator`]: removido a propriedade `useCommonColumns` em favor de utilizar a propriedade `commonColumns`.
+
+### Adicionado
+- [`QasFormGenerator`, `QasGridGenerator`]: adicionado nova propriedade `commonColumns`, esta propriedade vai substituir a necessidade do `useCommonColumns` e dar mais flexibilidade.
+
+### Removido
+- [`QasFormGenerator`, `QasGridGenerator`]: removido a propriedade `useCommonColumns` em favor de utilizar a propriedade `commonColumns`.
+
 ## [3.16.0-beta.0] - 24-05-2024
 ### Corrigido
 - `QasSelect`: Corrigido forma de atribuir as options, já que estava dando problema de endereço de memória em selects dependentes que são lazy-loading dentro de um `QasNestedFields`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## [Não publicado]
+### Adicionado
+- `QasActionsMenu`: possibilidade de passar a prop `to` para os botões.
+- `QasHeaderActions`: adicionado prop `spacing`.
+
 ## [3.16.0-beta.2] - 31-05-2024
 ### Corrigido
 - `QasAppMenu`: adicionado validações para garantir que não aconteça nenhum erro que trave a aplicação.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## Não publicado
+## [3.16.0-beta.7] - 23-07-2024
 ### Modificado
 - `boot/notifications`: removido notificações em localhost, uma vez que ficava gerando vários errors de conexão no console/network, o que atrapalhava o desenvolvimento local.
 
@@ -2960,3 +2960,4 @@ Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitt
 [3.16.0-beta.4]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.3...v3.16.0-beta.4?expand=1
 [3.16.0-beta.5]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.4...v3.16.0-beta.5?expand=1
 [3.16.0-beta.6]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.5...v3.16.0-beta.6?expand=1
+[3.16.0-beta.7]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.6...v3.16.0-beta.7?expand=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasAppMenu`: adicionado validações para garantir que não aconteça nenhum erro que trave a aplicação.
+
 ## [3.16.0-beta.1] - 31-05-2024
 ## BREAKING CHANGES
 - [`QasFormGenerator`, `QasGridGenerator`]: removido a propriedade `useCommonColumns` em favor de utilizar a propriedade `commonColumns`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ## Não publicado
 ### Adicionado
+- `QasToggleVisibility`: Adicionado novo componente.
 - `QasExpansionItem`: adicionado novo slot `header-bottom`.
 
 ### Modificado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## Não publicado
+## [3.16.0-beta.2] - 31-05-2024
 ### Corrigido
 - `QasAppMenu`: adicionado validações para garantir que não aconteça nenhum erro que trave a aplicação.
 
@@ -2919,3 +2919,4 @@ Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitt
 [3.15.0]: https://github.com/bildvitta/asteroid/compare/v3.14.0...v3.15.0?expand=1
 [3.16.0-beta.0]: https://github.com/bildvitta/asteroid/compare/v3.15.0...v3.16.0-beta.0?expand=1
 [3.16.0-beta.1]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.0...v3.16.0-beta.1?expand=1
+[3.16.0-beta.2]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.1...v3.16.0-beta.2?expand=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## [Não publicado]
+## [3.16.0-beta.3] - 20-06-2024
 ### Adicionado
 - `QasActionsMenu`: possibilidade de passar a prop `to` para os botões.
 - `QasHeaderActions`: adicionado prop `spacing`.
@@ -2925,3 +2925,4 @@ Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitt
 [3.16.0-beta.0]: https://github.com/bildvitta/asteroid/compare/v3.15.0...v3.16.0-beta.0?expand=1
 [3.16.0-beta.1]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.0...v3.16.0-beta.1?expand=1
 [3.16.0-beta.2]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.1...v3.16.0-beta.2?expand=1
+[3.16.0-beta.3]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.2...v3.16.0-beta.3?expand=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## [Não publicado]
+### Corrigido
+- `QasHeaderActions`: Corrigido quebra de de layout em casos de ter 2 itens com split usando `QasActionsMenu`.
+- `QasSingleView`: Corrigido exposição de métodos para possibilidade de usar `Template Refs`.
+
 ## [3.16.0-beta.5] - 04-07-2024
 ### Adicionado
 - `QasToggleVisibility`: Adicionado novo componente.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `QasExpansionItem`:
+  - adicionado espaçamento `sm` no conteúdo quando for nested.
+  - agora é possível sobrescrever a propriedade "useInline" pela `gridGeneratorProps`.
+
+### Corrigido
+- `QasExpansionItem`: corrigido função `setHasNextSibling`.
+
 ## [3.16.0-beta.7] - 23-07-2024
 ### Modificado
 - `boot/notifications`: removido notificações em localhost, uma vez que ficava gerando vários errors de conexão no console/network, o que atrapalhava o desenvolvimento local.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## Não publicado
+## [3.16.0-beta.10] - 01-08-2024
 ## BREAKING CHANGES
 - `QasSingleView`: Possível breaking change ao utilizar o `before-fetch`.
 
@@ -2996,3 +2996,4 @@ Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitt
 [3.16.0-beta.7]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.6...v3.16.0-beta.7?expand=1
 [3.16.0-beta.8]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.7...v3.16.0-beta.8?expand=1
 [3.16.0-beta.9]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.8...v3.16.0-beta.9?expand=1
+[3.16.0-beta.10]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.9...v3.16.0-beta.10?expand=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,49 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+## BREAKING CHANGES
+- [`QasFormGenerator`, `QasGridGenerator`]: removido a propriedade `useCommonColumns` em favor de utilizar a propriedade `commonColumns`.
+- `QasSingleView`: Possível breaking change ao utilizar o `before-fetch`.
+
+### Adicionado
+- [`QasFormGenerator`, `QasGridGenerator`]: adicionado nova propriedade `commonColumns`, esta propriedade vai substituir a necessidade do `useCommonColumns` e dar mais flexibilidade.
+- `QasAppMenu`: adicionado propriedade `helpChatLink`, para a ação de "Solicitar ajuda".
+- `QasActionsMenu`: possibilidade de passar a prop `to` para os botões.
+- `QasHeaderActions`: adicionado prop `spacing`.
+- `QasSingleView`: Adicionado propriedade `use-store` para dar a possibilidade de utilizar o componente sem a store do vuex/pinia.
+- `QasToggleVisibility`: Adicionado novo componente.
+- `QasExpansionItem`: adicionado novo slot `header-bottom`.
+- [`QasFormView`, `QasListView`, `QasSingleView`]: adicionado novo slot chamado `fetch-error` que é disponibilizado quando ocorre o `fetchError`.
+- `QasActions`: adicionado nova opção de ação terciária.
+
+### Corrigido
+- `QasSelect`: Corrigido forma de atribuir as options, já que estava dando problema de endereço de memória em selects dependentes que são lazy-loading dentro de um `QasNestedFields`.
+- `QasAppMenu`: adicionado validações para garantir que não aconteça nenhum erro que trave a aplicação.
+- `QasHeaderActions`: Corrigido quebra de de layout em casos de ter 2 itens com split usando `QasActionsMenu`.
+- `QasExpansionItem`: corrigido função `setHasNextSibling`.
+- `QasGridGenerator`: Corrigido gutter quando se é utilizado a prop `useInline`.
+- `QasExpansionItem`: Adicionado nova propriedade `useHeaderSeparator` para forçar o controle do QSeparator.
+- `QasExpansionItem`: Adicionado classe para z-index, onde corrige o problema de quando usado grid com gutter no conteúdo e sobrepunha o header fazendo com que perdesse o evento de click.
+- `QasTableGenerator`: adicionado nova propriedade `useBox`.
+
+### Modificado
+- `QasSingleView`:
+  - modificado para composition API.
+  - removido obrigatoriedade da propriedade "entity".
+- `QasExpansionItem`: modificado layout do componente quando ele é usado como nested (QasExpansionItem dentro de QasExpansionItem).
+- `QasExpansionItem`:
+  - Repassando todos eventos do QExpansionItem.
+- `QasToggleVisibility`: adicionado evento `prevent.stop` no botão para não disparar evento de click na tabela.
+- `boot/notifications`: removido notificações em localhost, uma vez que ficava gerando vários errors de conexão no console/network, o que atrapalhava o desenvolvimento local.
+- `QasExpansionItem`:
+  - adicionado espaçamento `sm` no conteúdo quando for nested.
+  - agora é possível sobrescrever a propriedade "useInline" pela `gridGeneratorProps`.
+- `QasLabel`: Modificado tag renderizada no componente para ser de acordo com a passada pela prop `typography`.
+
+### Removido
+- [`QasFormGenerator`, `QasGridGenerator`]: removido a propriedade `useCommonColumns` em favor de utilizar a propriedade `commonColumns`.
+
 ## [3.16.0-beta.10] - 01-08-2024
 ## BREAKING CHANGES
 - `QasSingleView`: Possível breaking change ao utilizar o `before-fetch`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## Não publicado
+## [3.16.0-beta.1] - 31-05-2024
 ## BREAKING CHANGES
 - [`QasFormGenerator`, `QasGridGenerator`]: removido a propriedade `useCommonColumns` em favor de utilizar a propriedade `commonColumns`.
 
@@ -2914,3 +2914,4 @@ Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitt
 [3.15.0-beta.15]: https://github.com/bildvitta/asteroid/compare/v3.15.0-beta.14...v3.15.0-beta.15?expand=1
 [3.15.0]: https://github.com/bildvitta/asteroid/compare/v3.14.0...v3.15.0?expand=1
 [3.16.0-beta.0]: https://github.com/bildvitta/asteroid/compare/v3.15.0...v3.16.0-beta.0?expand=1
+[3.16.0-beta.1]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.0...v3.16.0-beta.1?expand=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## Não publicado
+## [3.16.0-beta.6] - 12-07-2024
 ### Corrigido
 - `QasHeaderActions`: Corrigido quebra de de layout em casos de ter 2 itens com split usando `QasActionsMenu`.
 - `QasSingleView`: Corrigido exposição de métodos para possibilidade de usar `Template Refs`.
@@ -2955,3 +2955,4 @@ Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitt
 [3.16.0-beta.3]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.2...v3.16.0-beta.3?expand=1
 [3.16.0-beta.4]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.3...v3.16.0-beta.4?expand=1
 [3.16.0-beta.5]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.4...v3.16.0-beta.5?expand=1
+[3.16.0-beta.6]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.5...v3.16.0-beta.6?expand=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasSingleView`: Adicionado propriedade `use-store` para dar a possibilidade de utilizar o componente sem a store do vuex/pinia.
+
+### Modificado
+- `QasSingleView`:
+  - modificado para composition API.
+  - removido obrigatoriedade da propriedade "entity".
+
 ## [3.16.0-beta.3] - 20-06-2024
 ### Adicionado
 - `QasActionsMenu`: possibilidade de passar a prop `to` para os botões.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ## Não publicado
 ### Adicionado
+- `QasExpansionItem`: Adicionado nova propriedade `useHeaderSeparator` para forçar o controle do QSeparator.
+
+### Corrigido
+- `QasExpansionItem`: Adicionado classe para z-index, onde corrige o problema de quando usado grid com gutter no conteúdo e sobrepunha o header fazendo com que perdesse o evento de click.
 - `QasTableGenerator`: adicionado nova propriedade `useBox`.
 
 ## [3.16.0-beta.8] - 24-07-2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## Não publicado
+## [3.16.0-beta.5] - 04-07-2024
 ### Adicionado
 - `QasToggleVisibility`: Adicionado novo componente.
 - `QasExpansionItem`: adicionado novo slot `header-bottom`.
@@ -2944,3 +2944,4 @@ Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitt
 [3.16.0-beta.2]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.1...v3.16.0-beta.2?expand=1
 [3.16.0-beta.3]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.2...v3.16.0-beta.3?expand=1
 [3.16.0-beta.4]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.3...v3.16.0-beta.4?expand=1
+[3.16.0-beta.5]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.4...v3.16.0-beta.5?expand=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ### Modificado
 - `QasExpansionItem`:
   - Repassando todos eventos do QExpansionItem.
-  - Mudanças de layout quando usado expansion dentro de expansion.
 - `QasToggleVisibility`: adicionado evento `prevent.stop` no botão para não disparar evento de click na tabela.
 
 ## [3.16.0-beta.5] - 04-07-2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ## BREAKING CHANGES
 - `QasSingleView`: Possível breaking change ao utilizar o `before-fetch`.
 
+### Adicionado
+- `QasActions`: adicionado nova opção de ação terciária.
+
 ### Corrigido
 - `QasSingleView`: Corrigido validação do `hasResults` (voltou para a anterior).
 - [`use-view`, `view`]: Corrigido nome do slot na validação para ver se existe ou não o slot de `fetch-error`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## Não publicado
+## [3.16.0-beta.0] - 24-05-2024
 ### Corrigido
 - `QasSelect`: Corrigido forma de atribuir as options, já que estava dando problema de endereço de memória em selects dependentes que são lazy-loading dentro de um `QasNestedFields`.
 
@@ -2902,3 +2902,4 @@ Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitt
 [3.15.0-beta.14]: https://github.com/bildvitta/asteroid/compare/v3.15.0-beta.13...v3.15.0-beta.14?expand=1
 [3.15.0-beta.15]: https://github.com/bildvitta/asteroid/compare/v3.15.0-beta.14...v3.15.0-beta.15?expand=1
 [3.15.0]: https://github.com/bildvitta/asteroid/compare/v3.14.0...v3.15.0?expand=1
+[3.16.0-beta.0]: https://github.com/bildvitta/asteroid/compare/v3.15.0...v3.16.0-beta.0?expand=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,16 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## [Não publicado]
+## Não publicado
 ### Corrigido
 - `QasHeaderActions`: Corrigido quebra de de layout em casos de ter 2 itens com split usando `QasActionsMenu`.
 - `QasSingleView`: Corrigido exposição de métodos para possibilidade de usar `Template Refs`.
+
+### Modificado
+- `QasExpansionItem`:
+  - Repassando todos eventos do QExpansionItem.
+  - Mudanças de layout quando usado expansion dentro de expansion.
+- `QasToggleVisibility`: adicionado evento `prevent.stop` no botão para não disparar evento de click na tabela.
 
 ## [3.16.0-beta.5] - 04-07-2024
 ### Adicionado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## Não publicado
+## [3.16.0-beta.8] - 24-07-2024
 ### Modificado
 - `QasExpansionItem`:
   - adicionado espaçamento `sm` no conteúdo quando for nested.
@@ -2970,3 +2970,4 @@ Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitt
 [3.16.0-beta.5]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.4...v3.16.0-beta.5?expand=1
 [3.16.0-beta.6]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.5...v3.16.0-beta.6?expand=1
 [3.16.0-beta.7]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.6...v3.16.0-beta.7?expand=1
+[3.16.0-beta.8]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.7...v3.16.0-beta.8?expand=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasSelect`: Corrigido forma de atribuir as options, já que estava dando problema de endereço de memória em selects dependentes que são lazy-loading dentro de um `QasNestedFields`.
+
 ## [3.15.0] - 23-05-2024
 ## BREAKING CHANGES
 - `QasCard`: Componente agora se chama `QasCardImage`, pois agora foi criado um novo componente com o nome de `QasCard` (`QasCard <-> QasCardImage`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasExpansionItem`: adicionado novo slot `header-bottom`.
+
+### Modificado
+- `QasExpansionItem`: modificado layout do componente quando ele é usado como nested (QasExpansionItem dentro de QasExpansionItem).
+
 ## [3.16.0-beta.4] - 26-06-2024
 ### Adicionado
 - `QasSingleView`: Adicionado propriedade `use-store` para dar a possibilidade de utilizar o componente sem a store do vuex/pinia.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `boot/notifications`: removido notificações em localhost, uma vez que ficava gerando vários errors de conexão no console/network, o que atrapalhava o desenvolvimento local.
+
 ## [3.16.0-beta.6] - 12-07-2024
 ### Corrigido
 - `QasHeaderActions`: Corrigido quebra de de layout em casos de ter 2 itens com split usando `QasActionsMenu`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+## BREAKING CHANGES
+- `QasSingleView`: Possível breaking change ao utilizar o `before-fetch`.
+
+### Corrigido
+- `QasSingleView`: Corrigido validação do `hasResults` (voltou para a anterior).
+- [`use-view`, `view`]: Corrigido nome do slot na validação para ver se existe ou não o slot de `fetch-error`.
+
 ## [3.16.0-beta.9] - 31-07-2024
 ### Adicionado
 - [`QasFormView`, `QasListView`, `QasSingleView`]: adicionado novo slot chamado `fetch-error` que é disponibilizado quando ocorre o `fetchError`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## Não publicado
+## [3.16.0-beta.9] - 31-07-2024
 ### Adicionado
 - [`QasFormView`, `QasListView`, `QasSingleView`]: adicionado novo slot chamado `fetch-error` que é disponibilizado quando ocorre o `fetchError`.
 
@@ -2984,3 +2984,4 @@ Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitt
 [3.16.0-beta.6]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.5...v3.16.0-beta.6?expand=1
 [3.16.0-beta.7]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.6...v3.16.0-beta.7?expand=1
 [3.16.0-beta.8]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.7...v3.16.0-beta.8?expand=1
+[3.16.0-beta.9]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.8...v3.16.0-beta.9?expand=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## Não publicado
+## [3.16.0-beta.4] - 26-06-2024
 ### Adicionado
 - `QasSingleView`: Adicionado propriedade `use-store` para dar a possibilidade de utilizar o componente sem a store do vuex/pinia.
 
@@ -2935,3 +2935,4 @@ Adicionado suporte para Pinia/Vuex Seguindo os padrões da biblioteca `@bildvitt
 [3.16.0-beta.1]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.0...v3.16.0-beta.1?expand=1
 [3.16.0-beta.2]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.1...v3.16.0-beta.2?expand=1
 [3.16.0-beta.3]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.2...v3.16.0-beta.3?expand=1
+[3.16.0-beta.4]: https://github.com/bildvitta/asteroid/compare/v3.16.0-beta.3...v3.16.0-beta.4?expand=1

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
-  "version": "3.16.0-beta.3",
+  "version": "3.16.0-beta.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-app-extension-asteroid",
-      "version": "3.16.0-beta.3",
+      "version": "3.16.0-beta.4",
       "license": "MIT",
       "dependencies": {
-        "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.3",
+        "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.4",
         "@bildvitta/store-adapter": "^1.0.0",
         "execa": "^7.1.1",
         "fontfaceobserver": "^2.3.0",
@@ -23,6 +23,17 @@
         "yarn": ">= 1.6.0"
       }
     },
+    "node_modules/@babel/parser": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
+      "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.23.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
@@ -34,11 +45,23 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@bildvitta/quasar-ui-asteroid": {
-      "version": "3.16.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.3.tgz",
-      "integrity": "sha512-BfS5NSFq83ytBUTpnAjIXpr/4CGHzUoOdTX8VlB6oMLR3QTOlE1XayVq+fQUMh0i1sFaptqS7xmabA1K7FulIQ==",
+    "node_modules/@bildvitta/composables": {
+      "version": "1.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@bildvitta/composables/-/composables-1.0.0-beta.7.tgz",
+      "integrity": "sha512-LV7GL8w3PE1xYb/z52RoVZn1N+SS1pneqtiJDnMPquBKSBxYgFBoBr4/N4A4gLKIF3B/JRYmUbGLUYaRpL2PVg==",
       "dependencies": {
+        "@vue/compiler-sfc": "^3.4.21",
+        "path": "^0.12.7",
+        "vue": "^3.4.21",
+        "vue-demi": "^0.14.7"
+      }
+    },
+    "node_modules/@bildvitta/quasar-ui-asteroid": {
+      "version": "3.16.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.4.tgz",
+      "integrity": "sha512-3klr6XlIyta7qWyu7094+qvvBr4CAEaGLxBYi/L+x0d5wZSiM0rxJyAvTZscTxq49DT531y975h48J0PjL+yRA==",
+      "dependencies": {
+        "@bildvitta/composables": "^1.0.0-beta.7",
         "@bildvitta/store-adapter": "^1.0.0",
         "autonumeric": "^4.9.0",
         "axios": "^1.4.0",
@@ -73,6 +96,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@microsoft/api-extractor": {
       "version": "7.38.3",
@@ -285,6 +313,97 @@
       "version": "1.0.5",
       "license": "MIT"
     },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.30.tgz",
+      "integrity": "sha512-ZL8y4Xxdh8O6PSwfdZ1IpQ24PjTAieOz3jXb/MDTfDtANcKBMxg1KLm6OX2jofsaQGYfIVzd3BAG22i56/cF1w==",
+      "dependencies": {
+        "@babel/parser": "^7.24.7",
+        "@vue/shared": "3.4.30",
+        "entities": "^4.5.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.30.tgz",
+      "integrity": "sha512-+16Sd8lYr5j/owCbr9dowcNfrHd+pz+w2/b5Lt26Oz/kB90C9yNbxQ3bYOvt7rI2bxk0nqda39hVcwDFw85c2Q==",
+      "dependencies": {
+        "@vue/compiler-core": "3.4.30",
+        "@vue/shared": "3.4.30"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.30.tgz",
+      "integrity": "sha512-8vElKklHn/UY8+FgUFlQrYAPbtiSB2zcgeRKW7HkpSRn/JjMRmZvuOtwDx036D1aqKNSTtXkWRfqx53Qb+HmMg==",
+      "dependencies": {
+        "@babel/parser": "^7.24.7",
+        "@vue/compiler-core": "3.4.30",
+        "@vue/compiler-dom": "3.4.30",
+        "@vue/compiler-ssr": "3.4.30",
+        "@vue/shared": "3.4.30",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.10",
+        "postcss": "^8.4.38",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.30.tgz",
+      "integrity": "sha512-ZJ56YZGXJDd6jky4mmM0rNaNP6kIbQu9LTKZDhcpddGe/3QIalB1WHHmZ6iZfFNyj5mSypTa4+qDJa5VIuxMSg==",
+      "dependencies": {
+        "@vue/compiler-dom": "3.4.30",
+        "@vue/shared": "3.4.30"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.30.tgz",
+      "integrity": "sha512-bVJurnCe3LS0JII8PPoAA63Zd2MBzcKrEzwdQl92eHCcxtIbxD2fhNwJpa+KkM3Y/A4T5FUnmdhgKwOf6BfbcA==",
+      "dependencies": {
+        "@vue/shared": "3.4.30"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.30.tgz",
+      "integrity": "sha512-qaFEbnNpGz+tlnkaualomogzN8vBLkgzK55uuWjYXbYn039eOBZrWxyXWq/7qh9Bz2FPifZqGjVDl/FXiq9L2g==",
+      "dependencies": {
+        "@vue/reactivity": "3.4.30",
+        "@vue/shared": "3.4.30"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.30.tgz",
+      "integrity": "sha512-tV6B4YiZRj5QsaJgw2THCy5C1H+2UeywO9tqgWEc21tn85qHEERndHN/CxlyXvSBFrpmlexCIdnqPuR9RM9thw==",
+      "dependencies": {
+        "@vue/reactivity": "3.4.30",
+        "@vue/runtime-core": "3.4.30",
+        "@vue/shared": "3.4.30",
+        "csstype": "^3.1.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.30.tgz",
+      "integrity": "sha512-TBD3eqR1DeDc0cMrXS/vEs/PWzq1uXxnvjoqQuDGFIEHFIwuDTX/KWAQKIBjyMWLFHEeTDGYVsYci85z2UbTDg==",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.4.30",
+        "@vue/shared": "3.4.30"
+      },
+      "peerDependencies": {
+        "vue": "3.4.30"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.30.tgz",
+      "integrity": "sha512-CLg+f8RQCHQnKvuHY9adMsMaQOcqclh6Z5V9TaoMgy0ut0tz848joZ7/CYFFyF/yZ5i2yaw7Fn498C+CNZVHIg=="
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "license": "MIT",
@@ -393,6 +512,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
     "node_modules/date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -429,6 +553,17 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/esbuild": {
@@ -651,6 +786,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+    },
     "node_modules/is-core-module": {
       "version": "2.13.1",
       "license": "MIT",
@@ -755,6 +895,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.10",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "license": "MIT"
@@ -848,7 +996,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -900,6 +1047,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "license": "MIT"
@@ -928,8 +1084,7 @@
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -942,7 +1097,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
       "funding": [
         {
           "type": "opencollective",
@@ -957,15 +1114,21 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/proxy-from-env": {
@@ -1133,9 +1296,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "license": "BSD-3-Clause",
-      "peer": true,
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1228,6 +1391,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
     "node_modules/validator": {
       "version": "13.11.0",
       "license": "MIT",
@@ -1309,6 +1480,51 @@
         "vite": ">=2.9.0"
       }
     },
+    "node_modules/vue": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.30.tgz",
+      "integrity": "sha512-NcxtKCwkdf1zPsr7Y8+QlDBCGqxvjLXF2EX+yi76rV5rrz90Y6gK1cq0olIhdWGgrlhs9ElHuhi9t3+W5sG5Xw==",
+      "dependencies": {
+        "@vue/compiler-dom": "3.4.30",
+        "@vue/compiler-sfc": "3.4.30",
+        "@vue/runtime-dom": "3.4.30",
+        "@vue/server-renderer": "3.4.30",
+        "@vue/shared": "3.4.30"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-demi": {
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.8.tgz",
+      "integrity": "sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webworkify": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/webworkify/-/webworkify-1.5.0.tgz",
@@ -1351,6 +1567,11 @@
     }
   },
   "dependencies": {
+    "@babel/parser": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
+      "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw=="
+    },
     "@babel/runtime": {
       "version": "7.23.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
@@ -1359,11 +1580,23 @@
         "regenerator-runtime": "^0.14.0"
       }
     },
-    "@bildvitta/quasar-ui-asteroid": {
-      "version": "3.16.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.3.tgz",
-      "integrity": "sha512-BfS5NSFq83ytBUTpnAjIXpr/4CGHzUoOdTX8VlB6oMLR3QTOlE1XayVq+fQUMh0i1sFaptqS7xmabA1K7FulIQ==",
+    "@bildvitta/composables": {
+      "version": "1.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@bildvitta/composables/-/composables-1.0.0-beta.7.tgz",
+      "integrity": "sha512-LV7GL8w3PE1xYb/z52RoVZn1N+SS1pneqtiJDnMPquBKSBxYgFBoBr4/N4A4gLKIF3B/JRYmUbGLUYaRpL2PVg==",
       "requires": {
+        "@vue/compiler-sfc": "^3.4.21",
+        "path": "^0.12.7",
+        "vue": "^3.4.21",
+        "vue-demi": "^0.14.7"
+      }
+    },
+    "@bildvitta/quasar-ui-asteroid": {
+      "version": "3.16.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.4.tgz",
+      "integrity": "sha512-3klr6XlIyta7qWyu7094+qvvBr4CAEaGLxBYi/L+x0d5wZSiM0rxJyAvTZscTxq49DT531y975h48J0PjL+yRA==",
+      "requires": {
+        "@bildvitta/composables": "^1.0.0-beta.7",
         "@bildvitta/store-adapter": "^1.0.0",
         "autonumeric": "^4.9.0",
         "axios": "^1.4.0",
@@ -1388,6 +1621,11 @@
       "version": "0.19.7",
       "optional": true,
       "peer": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "@microsoft/api-extractor": {
       "version": "7.38.3",
@@ -1532,6 +1770,94 @@
     "@types/estree": {
       "version": "1.0.5"
     },
+    "@vue/compiler-core": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.30.tgz",
+      "integrity": "sha512-ZL8y4Xxdh8O6PSwfdZ1IpQ24PjTAieOz3jXb/MDTfDtANcKBMxg1KLm6OX2jofsaQGYfIVzd3BAG22i56/cF1w==",
+      "requires": {
+        "@babel/parser": "^7.24.7",
+        "@vue/shared": "3.4.30",
+        "entities": "^4.5.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "@vue/compiler-dom": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.30.tgz",
+      "integrity": "sha512-+16Sd8lYr5j/owCbr9dowcNfrHd+pz+w2/b5Lt26Oz/kB90C9yNbxQ3bYOvt7rI2bxk0nqda39hVcwDFw85c2Q==",
+      "requires": {
+        "@vue/compiler-core": "3.4.30",
+        "@vue/shared": "3.4.30"
+      }
+    },
+    "@vue/compiler-sfc": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.30.tgz",
+      "integrity": "sha512-8vElKklHn/UY8+FgUFlQrYAPbtiSB2zcgeRKW7HkpSRn/JjMRmZvuOtwDx036D1aqKNSTtXkWRfqx53Qb+HmMg==",
+      "requires": {
+        "@babel/parser": "^7.24.7",
+        "@vue/compiler-core": "3.4.30",
+        "@vue/compiler-dom": "3.4.30",
+        "@vue/compiler-ssr": "3.4.30",
+        "@vue/shared": "3.4.30",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.10",
+        "postcss": "^8.4.38",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "@vue/compiler-ssr": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.30.tgz",
+      "integrity": "sha512-ZJ56YZGXJDd6jky4mmM0rNaNP6kIbQu9LTKZDhcpddGe/3QIalB1WHHmZ6iZfFNyj5mSypTa4+qDJa5VIuxMSg==",
+      "requires": {
+        "@vue/compiler-dom": "3.4.30",
+        "@vue/shared": "3.4.30"
+      }
+    },
+    "@vue/reactivity": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.30.tgz",
+      "integrity": "sha512-bVJurnCe3LS0JII8PPoAA63Zd2MBzcKrEzwdQl92eHCcxtIbxD2fhNwJpa+KkM3Y/A4T5FUnmdhgKwOf6BfbcA==",
+      "requires": {
+        "@vue/shared": "3.4.30"
+      }
+    },
+    "@vue/runtime-core": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.30.tgz",
+      "integrity": "sha512-qaFEbnNpGz+tlnkaualomogzN8vBLkgzK55uuWjYXbYn039eOBZrWxyXWq/7qh9Bz2FPifZqGjVDl/FXiq9L2g==",
+      "requires": {
+        "@vue/reactivity": "3.4.30",
+        "@vue/shared": "3.4.30"
+      }
+    },
+    "@vue/runtime-dom": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.30.tgz",
+      "integrity": "sha512-tV6B4YiZRj5QsaJgw2THCy5C1H+2UeywO9tqgWEc21tn85qHEERndHN/CxlyXvSBFrpmlexCIdnqPuR9RM9thw==",
+      "requires": {
+        "@vue/reactivity": "3.4.30",
+        "@vue/runtime-core": "3.4.30",
+        "@vue/shared": "3.4.30",
+        "csstype": "^3.1.3"
+      }
+    },
+    "@vue/server-renderer": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.30.tgz",
+      "integrity": "sha512-TBD3eqR1DeDc0cMrXS/vEs/PWzq1uXxnvjoqQuDGFIEHFIwuDTX/KWAQKIBjyMWLFHEeTDGYVsYci85z2UbTDg==",
+      "requires": {
+        "@vue/compiler-ssr": "3.4.30",
+        "@vue/shared": "3.4.30"
+      }
+    },
+    "@vue/shared": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.30.tgz",
+      "integrity": "sha512-CLg+f8RQCHQnKvuHY9adMsMaQOcqclh6Z5V9TaoMgy0ut0tz848joZ7/CYFFyF/yZ5i2yaw7Fn498C+CNZVHIg=="
+    },
     "ajv": {
       "version": "6.12.6",
       "requires": {
@@ -1608,6 +1934,11 @@
         "which": "^2.0.1"
       }
     },
+    "csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
     "date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -1626,6 +1957,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
     "esbuild": {
       "version": "0.19.7",
@@ -1766,6 +2102,11 @@
     "import-lazy": {
       "version": "4.0.0"
     },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+    },
     "is-core-module": {
       "version": "2.13.1",
       "requires": {
@@ -1829,6 +2170,14 @@
         "yallist": "^4.0.0"
       }
     },
+    "magic-string": {
+      "version": "0.30.10",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+      "requires": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      }
+    },
     "merge-stream": {
       "version": "2.0.0"
     },
@@ -1880,8 +2229,7 @@
       }
     },
     "nanoid": {
-      "version": "3.3.7",
-      "peer": true
+      "version": "3.3.7"
     },
     "npm-run-path": {
       "version": "5.1.0",
@@ -1905,6 +2253,15 @@
         "mimic-fn": "^4.0.0"
       }
     },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "requires": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "path-browserify": {
       "version": "1.0.1"
     },
@@ -1926,20 +2283,25 @@
       }
     },
     "picocolors": {
-      "version": "1.0.0",
-      "peer": true
+      "version": "1.0.0"
     },
     "picomatch": {
       "version": "2.3.1"
     },
     "postcss": {
-      "version": "8.4.31",
-      "peer": true,
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
       "requires": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       }
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "proxy-from-env": {
       "version": "1.1.0",
@@ -2031,8 +2393,9 @@
       "version": "0.6.1"
     },
     "source-map-js": {
-      "version": "1.0.2",
-      "peer": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg=="
     },
     "sprintf-js": {
       "version": "1.0.3"
@@ -2077,6 +2440,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
     "validator": {
       "version": "13.11.0"
     },
@@ -2102,6 +2473,24 @@
         "kolorist": "^1.6.0",
         "ts-morph": "17.0.1"
       }
+    },
+    "vue": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.30.tgz",
+      "integrity": "sha512-NcxtKCwkdf1zPsr7Y8+QlDBCGqxvjLXF2EX+yi76rV5rrz90Y6gK1cq0olIhdWGgrlhs9ElHuhi9t3+W5sG5Xw==",
+      "requires": {
+        "@vue/compiler-dom": "3.4.30",
+        "@vue/compiler-sfc": "3.4.30",
+        "@vue/runtime-dom": "3.4.30",
+        "@vue/server-renderer": "3.4.30",
+        "@vue/shared": "3.4.30"
+      }
+    },
+    "vue-demi": {
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.8.tgz",
+      "integrity": "sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==",
+      "requires": {}
     },
     "webworkify": {
       "version": "1.5.0",

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
-  "version": "3.16.0-beta.9",
+  "version": "3.16.0-beta.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-app-extension-asteroid",
-      "version": "3.16.0-beta.9",
+      "version": "3.16.0-beta.10",
       "license": "MIT",
       "dependencies": {
-        "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.9",
+        "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.10",
         "@bildvitta/store-adapter": "^1.0.0",
         "execa": "^7.1.1",
         "fontfaceobserver": "^2.3.0",
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@bildvitta/quasar-ui-asteroid": {
-      "version": "3.16.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.9.tgz",
-      "integrity": "sha512-VuiVx8xsOfYuVggtvchQ6CU2u3jYRJtWsiR1kzgY+RTsM5bsvwPXISfPbGtPxz/nbFqvItZ7nbSUkAmfeMtEzw==",
+      "version": "3.16.0-beta.10",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.10.tgz",
+      "integrity": "sha512-U1qP1qejHlTIvs4qLFiL1sZwNqfsq+KUz+1FNFM0fYjg68Ia5lVJals1vsPgJbe3oV9HVDttFWfXR5JulwfWDQ==",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",
         "@bildvitta/store-adapter": "^1.0.0",
@@ -1592,9 +1592,9 @@
       }
     },
     "@bildvitta/quasar-ui-asteroid": {
-      "version": "3.16.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.9.tgz",
-      "integrity": "sha512-VuiVx8xsOfYuVggtvchQ6CU2u3jYRJtWsiR1kzgY+RTsM5bsvwPXISfPbGtPxz/nbFqvItZ7nbSUkAmfeMtEzw==",
+      "version": "3.16.0-beta.10",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.10.tgz",
+      "integrity": "sha512-U1qP1qejHlTIvs4qLFiL1sZwNqfsq+KUz+1FNFM0fYjg68Ia5lVJals1vsPgJbe3oV9HVDttFWfXR5JulwfWDQ==",
       "requires": {
         "@bildvitta/composables": "^1.0.0-beta.7",
         "@bildvitta/store-adapter": "^1.0.0",

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
-  "version": "3.16.0-beta.7",
+  "version": "3.16.0-beta.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-app-extension-asteroid",
-      "version": "3.16.0-beta.7",
+      "version": "3.16.0-beta.8",
       "license": "MIT",
       "dependencies": {
-        "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.7",
+        "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.8",
         "@bildvitta/store-adapter": "^1.0.0",
         "execa": "^7.1.1",
         "fontfaceobserver": "^2.3.0",
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@bildvitta/quasar-ui-asteroid": {
-      "version": "3.16.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.7.tgz",
-      "integrity": "sha512-Y5zh+zanMIdtgisvKnkS72r25oRxJmc9aJrUZ5zfFvPkDy+MgJUnIG6lo3TIGzbfqoN0qIwp3pgYenoNtlBZsA==",
+      "version": "3.16.0-beta.8",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.8.tgz",
+      "integrity": "sha512-rwZtAYIr+X4RVyfCSNsph91aAfnzMilSMZsUnzxdsDb09mpUwv3eWDISV4556qu/GbBbVN0A2lyREBR17D+HPw==",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",
         "@bildvitta/store-adapter": "^1.0.0",
@@ -1592,9 +1592,9 @@
       }
     },
     "@bildvitta/quasar-ui-asteroid": {
-      "version": "3.16.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.7.tgz",
-      "integrity": "sha512-Y5zh+zanMIdtgisvKnkS72r25oRxJmc9aJrUZ5zfFvPkDy+MgJUnIG6lo3TIGzbfqoN0qIwp3pgYenoNtlBZsA==",
+      "version": "3.16.0-beta.8",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.8.tgz",
+      "integrity": "sha512-rwZtAYIr+X4RVyfCSNsph91aAfnzMilSMZsUnzxdsDb09mpUwv3eWDISV4556qu/GbBbVN0A2lyREBR17D+HPw==",
       "requires": {
         "@bildvitta/composables": "^1.0.0-beta.7",
         "@bildvitta/store-adapter": "^1.0.0",

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
-  "version": "3.16.0-beta.1",
+  "version": "3.16.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-app-extension-asteroid",
-      "version": "3.16.0-beta.1",
+      "version": "3.16.0-beta.2",
       "license": "MIT",
       "dependencies": {
-        "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.1",
+        "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.2",
         "@bildvitta/store-adapter": "^1.0.0",
         "execa": "^7.1.1",
         "fontfaceobserver": "^2.3.0",
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@bildvitta/quasar-ui-asteroid": {
-      "version": "3.16.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.1.tgz",
-      "integrity": "sha512-yP7MQL0Kzzz37JYihtLCXGXG63z73U1wjKp9nlK5TAiQ1nrHqt91WSNUnT4jNuvlVLEIH9grACOttPIksKy5Ug==",
+      "version": "3.16.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.2.tgz",
+      "integrity": "sha512-arPsg6hBghXOSyc7UpFI5IOtuQeMYR5OxHi7U2BD/ynJ+VDxJ8AsjMB45TfGrievS6Qt7/Cvw+nB9wqoW2XZdw==",
       "dependencies": {
         "@bildvitta/store-adapter": "^1.0.0",
         "autonumeric": "^4.9.0",
@@ -1360,9 +1360,9 @@
       }
     },
     "@bildvitta/quasar-ui-asteroid": {
-      "version": "3.16.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.1.tgz",
-      "integrity": "sha512-yP7MQL0Kzzz37JYihtLCXGXG63z73U1wjKp9nlK5TAiQ1nrHqt91WSNUnT4jNuvlVLEIH9grACOttPIksKy5Ug==",
+      "version": "3.16.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.2.tgz",
+      "integrity": "sha512-arPsg6hBghXOSyc7UpFI5IOtuQeMYR5OxHi7U2BD/ynJ+VDxJ8AsjMB45TfGrievS6Qt7/Cvw+nB9wqoW2XZdw==",
       "requires": {
         "@bildvitta/store-adapter": "^1.0.0",
         "autonumeric": "^4.9.0",

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
-  "version": "3.16.0-beta.8",
+  "version": "3.16.0-beta.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-app-extension-asteroid",
-      "version": "3.16.0-beta.8",
+      "version": "3.16.0-beta.9",
       "license": "MIT",
       "dependencies": {
-        "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.8",
+        "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.9",
         "@bildvitta/store-adapter": "^1.0.0",
         "execa": "^7.1.1",
         "fontfaceobserver": "^2.3.0",
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@bildvitta/quasar-ui-asteroid": {
-      "version": "3.16.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.8.tgz",
-      "integrity": "sha512-rwZtAYIr+X4RVyfCSNsph91aAfnzMilSMZsUnzxdsDb09mpUwv3eWDISV4556qu/GbBbVN0A2lyREBR17D+HPw==",
+      "version": "3.16.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.9.tgz",
+      "integrity": "sha512-VuiVx8xsOfYuVggtvchQ6CU2u3jYRJtWsiR1kzgY+RTsM5bsvwPXISfPbGtPxz/nbFqvItZ7nbSUkAmfeMtEzw==",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",
         "@bildvitta/store-adapter": "^1.0.0",
@@ -1592,9 +1592,9 @@
       }
     },
     "@bildvitta/quasar-ui-asteroid": {
-      "version": "3.16.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.8.tgz",
-      "integrity": "sha512-rwZtAYIr+X4RVyfCSNsph91aAfnzMilSMZsUnzxdsDb09mpUwv3eWDISV4556qu/GbBbVN0A2lyREBR17D+HPw==",
+      "version": "3.16.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.9.tgz",
+      "integrity": "sha512-VuiVx8xsOfYuVggtvchQ6CU2u3jYRJtWsiR1kzgY+RTsM5bsvwPXISfPbGtPxz/nbFqvItZ7nbSUkAmfeMtEzw==",
       "requires": {
         "@bildvitta/composables": "^1.0.0-beta.7",
         "@bildvitta/store-adapter": "^1.0.0",

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
-  "version": "3.16.0-beta.0",
+  "version": "3.16.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-app-extension-asteroid",
-      "version": "3.16.0-beta.0",
+      "version": "3.16.0-beta.1",
       "license": "MIT",
       "dependencies": {
-        "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.0",
+        "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.1",
         "@bildvitta/store-adapter": "^1.0.0",
         "execa": "^7.1.1",
         "fontfaceobserver": "^2.3.0",
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@bildvitta/quasar-ui-asteroid": {
-      "version": "3.16.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.0.tgz",
-      "integrity": "sha512-JvFkiqBY/Yt6V3A8NlCUbIlS6QEHCUMY0ZxUZrjwteYVagcqNNGRvEUZXUmPFdbjwwn7Jg9611c3HCYU8FUW8w==",
+      "version": "3.16.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.1.tgz",
+      "integrity": "sha512-yP7MQL0Kzzz37JYihtLCXGXG63z73U1wjKp9nlK5TAiQ1nrHqt91WSNUnT4jNuvlVLEIH9grACOttPIksKy5Ug==",
       "dependencies": {
         "@bildvitta/store-adapter": "^1.0.0",
         "autonumeric": "^4.9.0",
@@ -1360,9 +1360,9 @@
       }
     },
     "@bildvitta/quasar-ui-asteroid": {
-      "version": "3.16.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.0.tgz",
-      "integrity": "sha512-JvFkiqBY/Yt6V3A8NlCUbIlS6QEHCUMY0ZxUZrjwteYVagcqNNGRvEUZXUmPFdbjwwn7Jg9611c3HCYU8FUW8w==",
+      "version": "3.16.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.1.tgz",
+      "integrity": "sha512-yP7MQL0Kzzz37JYihtLCXGXG63z73U1wjKp9nlK5TAiQ1nrHqt91WSNUnT4jNuvlVLEIH9grACOttPIksKy5Ug==",
       "requires": {
         "@bildvitta/store-adapter": "^1.0.0",
         "autonumeric": "^4.9.0",

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
-  "version": "3.16.0-beta.5",
+  "version": "3.16.0-beta.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-app-extension-asteroid",
-      "version": "3.16.0-beta.5",
+      "version": "3.16.0-beta.6",
       "license": "MIT",
       "dependencies": {
-        "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.5",
+        "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.6",
         "@bildvitta/store-adapter": "^1.0.0",
         "execa": "^7.1.1",
         "fontfaceobserver": "^2.3.0",
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@bildvitta/quasar-ui-asteroid": {
-      "version": "3.16.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.5.tgz",
-      "integrity": "sha512-AqexNrPLxgH0Jl75wbnxNSXeOWWMHU22TidC5yRDfAYXqNKw9Rk7ORd3lxI3mnw3vrhi2lxEuM73cwwFmaWsVA==",
+      "version": "3.16.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.6.tgz",
+      "integrity": "sha512-clvefzJzM0sUT/U99DQuRDWIe6WfVLE1/T9eUCmQ7NNGc8UkHmJszQxyeWdP7VqMZARGEkuQENfo2PbM3XWnyA==",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",
         "@bildvitta/store-adapter": "^1.0.0",
@@ -1592,9 +1592,9 @@
       }
     },
     "@bildvitta/quasar-ui-asteroid": {
-      "version": "3.16.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.5.tgz",
-      "integrity": "sha512-AqexNrPLxgH0Jl75wbnxNSXeOWWMHU22TidC5yRDfAYXqNKw9Rk7ORd3lxI3mnw3vrhi2lxEuM73cwwFmaWsVA==",
+      "version": "3.16.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.6.tgz",
+      "integrity": "sha512-clvefzJzM0sUT/U99DQuRDWIe6WfVLE1/T9eUCmQ7NNGc8UkHmJszQxyeWdP7VqMZARGEkuQENfo2PbM3XWnyA==",
       "requires": {
         "@bildvitta/composables": "^1.0.0-beta.7",
         "@bildvitta/store-adapter": "^1.0.0",

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
-  "version": "3.16.0-beta.6",
+  "version": "3.16.0-beta.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-app-extension-asteroid",
-      "version": "3.16.0-beta.6",
+      "version": "3.16.0-beta.7",
       "license": "MIT",
       "dependencies": {
-        "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.6",
+        "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.7",
         "@bildvitta/store-adapter": "^1.0.0",
         "execa": "^7.1.1",
         "fontfaceobserver": "^2.3.0",
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@bildvitta/quasar-ui-asteroid": {
-      "version": "3.16.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.6.tgz",
-      "integrity": "sha512-clvefzJzM0sUT/U99DQuRDWIe6WfVLE1/T9eUCmQ7NNGc8UkHmJszQxyeWdP7VqMZARGEkuQENfo2PbM3XWnyA==",
+      "version": "3.16.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.7.tgz",
+      "integrity": "sha512-Y5zh+zanMIdtgisvKnkS72r25oRxJmc9aJrUZ5zfFvPkDy+MgJUnIG6lo3TIGzbfqoN0qIwp3pgYenoNtlBZsA==",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",
         "@bildvitta/store-adapter": "^1.0.0",
@@ -1592,9 +1592,9 @@
       }
     },
     "@bildvitta/quasar-ui-asteroid": {
-      "version": "3.16.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.6.tgz",
-      "integrity": "sha512-clvefzJzM0sUT/U99DQuRDWIe6WfVLE1/T9eUCmQ7NNGc8UkHmJszQxyeWdP7VqMZARGEkuQENfo2PbM3XWnyA==",
+      "version": "3.16.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.7.tgz",
+      "integrity": "sha512-Y5zh+zanMIdtgisvKnkS72r25oRxJmc9aJrUZ5zfFvPkDy+MgJUnIG6lo3TIGzbfqoN0qIwp3pgYenoNtlBZsA==",
       "requires": {
         "@bildvitta/composables": "^1.0.0-beta.7",
         "@bildvitta/store-adapter": "^1.0.0",

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
-  "version": "3.16.0-beta.2",
+  "version": "3.16.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-app-extension-asteroid",
-      "version": "3.16.0-beta.2",
+      "version": "3.16.0-beta.3",
       "license": "MIT",
       "dependencies": {
-        "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.2",
+        "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.3",
         "@bildvitta/store-adapter": "^1.0.0",
         "execa": "^7.1.1",
         "fontfaceobserver": "^2.3.0",
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@bildvitta/quasar-ui-asteroid": {
-      "version": "3.16.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.2.tgz",
-      "integrity": "sha512-arPsg6hBghXOSyc7UpFI5IOtuQeMYR5OxHi7U2BD/ynJ+VDxJ8AsjMB45TfGrievS6Qt7/Cvw+nB9wqoW2XZdw==",
+      "version": "3.16.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.3.tgz",
+      "integrity": "sha512-BfS5NSFq83ytBUTpnAjIXpr/4CGHzUoOdTX8VlB6oMLR3QTOlE1XayVq+fQUMh0i1sFaptqS7xmabA1K7FulIQ==",
       "dependencies": {
         "@bildvitta/store-adapter": "^1.0.0",
         "autonumeric": "^4.9.0",
@@ -1360,9 +1360,9 @@
       }
     },
     "@bildvitta/quasar-ui-asteroid": {
-      "version": "3.16.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.2.tgz",
-      "integrity": "sha512-arPsg6hBghXOSyc7UpFI5IOtuQeMYR5OxHi7U2BD/ynJ+VDxJ8AsjMB45TfGrievS6Qt7/Cvw+nB9wqoW2XZdw==",
+      "version": "3.16.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.3.tgz",
+      "integrity": "sha512-BfS5NSFq83ytBUTpnAjIXpr/4CGHzUoOdTX8VlB6oMLR3QTOlE1XayVq+fQUMh0i1sFaptqS7xmabA1K7FulIQ==",
       "requires": {
         "@bildvitta/store-adapter": "^1.0.0",
         "autonumeric": "^4.9.0",

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
-  "version": "3.16.0-beta.4",
+  "version": "3.16.0-beta.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-app-extension-asteroid",
-      "version": "3.16.0-beta.4",
+      "version": "3.16.0-beta.5",
       "license": "MIT",
       "dependencies": {
-        "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.4",
+        "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.5",
         "@bildvitta/store-adapter": "^1.0.0",
         "execa": "^7.1.1",
         "fontfaceobserver": "^2.3.0",
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@bildvitta/quasar-ui-asteroid": {
-      "version": "3.16.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.4.tgz",
-      "integrity": "sha512-3klr6XlIyta7qWyu7094+qvvBr4CAEaGLxBYi/L+x0d5wZSiM0rxJyAvTZscTxq49DT531y975h48J0PjL+yRA==",
+      "version": "3.16.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.5.tgz",
+      "integrity": "sha512-AqexNrPLxgH0Jl75wbnxNSXeOWWMHU22TidC5yRDfAYXqNKw9Rk7ORd3lxI3mnw3vrhi2lxEuM73cwwFmaWsVA==",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",
         "@bildvitta/store-adapter": "^1.0.0",
@@ -1592,9 +1592,9 @@
       }
     },
     "@bildvitta/quasar-ui-asteroid": {
-      "version": "3.16.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.4.tgz",
-      "integrity": "sha512-3klr6XlIyta7qWyu7094+qvvBr4CAEaGLxBYi/L+x0d5wZSiM0rxJyAvTZscTxq49DT531y975h48J0PjL+yRA==",
+      "version": "3.16.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.5.tgz",
+      "integrity": "sha512-AqexNrPLxgH0Jl75wbnxNSXeOWWMHU22TidC5yRDfAYXqNKw9Rk7ORd3lxI3mnw3vrhi2lxEuM73cwwFmaWsVA==",
       "requires": {
         "@bildvitta/composables": "^1.0.0-beta.7",
         "@bildvitta/store-adapter": "^1.0.0",

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
-  "version": "3.15.0",
+  "version": "3.16.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-app-extension-asteroid",
-      "version": "3.15.0",
+      "version": "3.16.0-beta.0",
       "license": "MIT",
       "dependencies": {
-        "@bildvitta/quasar-ui-asteroid": "3.15.0",
+        "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.0",
         "@bildvitta/store-adapter": "^1.0.0",
         "execa": "^7.1.1",
         "fontfaceobserver": "^2.3.0",
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@bildvitta/quasar-ui-asteroid": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.15.0.tgz",
-      "integrity": "sha512-6SGajI6CpgWnelStB5oXVgDv8G3j7kFQxKLlWvdM/9hucyFKRlRDd67N50UFeN1WhaYf4rM5nterpOqAEY4Scw==",
+      "version": "3.16.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.0.tgz",
+      "integrity": "sha512-JvFkiqBY/Yt6V3A8NlCUbIlS6QEHCUMY0ZxUZrjwteYVagcqNNGRvEUZXUmPFdbjwwn7Jg9611c3HCYU8FUW8w==",
       "dependencies": {
         "@bildvitta/store-adapter": "^1.0.0",
         "autonumeric": "^4.9.0",
@@ -1360,9 +1360,9 @@
       }
     },
     "@bildvitta/quasar-ui-asteroid": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.15.0.tgz",
-      "integrity": "sha512-6SGajI6CpgWnelStB5oXVgDv8G3j7kFQxKLlWvdM/9hucyFKRlRDd67N50UFeN1WhaYf4rM5nterpOqAEY4Scw==",
+      "version": "3.16.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.16.0-beta.0.tgz",
+      "integrity": "sha512-JvFkiqBY/Yt6V3A8NlCUbIlS6QEHCUMY0ZxUZrjwteYVagcqNNGRvEUZXUmPFdbjwwn7Jg9611c3HCYU8FUW8w==",
       "requires": {
         "@bildvitta/store-adapter": "^1.0.0",
         "autonumeric": "^4.9.0",

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.3",
+  "version": "3.16.0-beta.4",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "src/index.js",
@@ -29,7 +29,7 @@
     "yarn": ">= 1.6.0"
   },
   "dependencies": {
-    "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.3",
+    "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.4",
     "@bildvitta/store-adapter": "^1.0.0",
     "execa": "^7.1.1",
     "fontfaceobserver": "^2.3.0",

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.9",
+  "version": "3.16.0-beta.10",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "src/index.js",
@@ -29,7 +29,7 @@
     "yarn": ">= 1.6.0"
   },
   "dependencies": {
-    "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.9",
+    "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.10",
     "@bildvitta/store-adapter": "^1.0.0",
     "execa": "^7.1.1",
     "fontfaceobserver": "^2.3.0",

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.0",
+  "version": "3.16.0-beta.1",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "src/index.js",
@@ -29,7 +29,7 @@
     "yarn": ">= 1.6.0"
   },
   "dependencies": {
-    "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.0",
+    "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.1",
     "@bildvitta/store-adapter": "^1.0.0",
     "execa": "^7.1.1",
     "fontfaceobserver": "^2.3.0",

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.2",
+  "version": "3.16.0-beta.3",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "src/index.js",
@@ -29,7 +29,7 @@
     "yarn": ">= 1.6.0"
   },
   "dependencies": {
-    "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.2",
+    "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.3",
     "@bildvitta/store-adapter": "^1.0.0",
     "execa": "^7.1.1",
     "fontfaceobserver": "^2.3.0",

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.5",
+  "version": "3.16.0-beta.6",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "src/index.js",
@@ -29,7 +29,7 @@
     "yarn": ">= 1.6.0"
   },
   "dependencies": {
-    "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.5",
+    "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.6",
     "@bildvitta/store-adapter": "^1.0.0",
     "execa": "^7.1.1",
     "fontfaceobserver": "^2.3.0",

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
   "description": "Asteroid",
-  "version": "3.15.0",
+  "version": "3.16.0-beta.0",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "src/index.js",
@@ -29,7 +29,7 @@
     "yarn": ">= 1.6.0"
   },
   "dependencies": {
-    "@bildvitta/quasar-ui-asteroid": "3.15.0",
+    "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.0",
     "@bildvitta/store-adapter": "^1.0.0",
     "execa": "^7.1.1",
     "fontfaceobserver": "^2.3.0",

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.8",
+  "version": "3.16.0-beta.9",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "src/index.js",
@@ -29,7 +29,7 @@
     "yarn": ">= 1.6.0"
   },
   "dependencies": {
-    "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.8",
+    "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.9",
     "@bildvitta/store-adapter": "^1.0.0",
     "execa": "^7.1.1",
     "fontfaceobserver": "^2.3.0",

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.7",
+  "version": "3.16.0-beta.8",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "src/index.js",
@@ -29,7 +29,7 @@
     "yarn": ">= 1.6.0"
   },
   "dependencies": {
-    "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.7",
+    "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.8",
     "@bildvitta/store-adapter": "^1.0.0",
     "execa": "^7.1.1",
     "fontfaceobserver": "^2.3.0",

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.4",
+  "version": "3.16.0-beta.5",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "src/index.js",
@@ -29,7 +29,7 @@
     "yarn": ">= 1.6.0"
   },
   "dependencies": {
-    "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.4",
+    "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.5",
     "@bildvitta/store-adapter": "^1.0.0",
     "execa": "^7.1.1",
     "fontfaceobserver": "^2.3.0",

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.6",
+  "version": "3.16.0-beta.7",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "src/index.js",
@@ -29,7 +29,7 @@
     "yarn": ">= 1.6.0"
   },
   "dependencies": {
-    "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.6",
+    "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.7",
     "@bildvitta/store-adapter": "^1.0.0",
     "execa": "^7.1.1",
     "fontfaceobserver": "^2.3.0",

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.1",
+  "version": "3.16.0-beta.2",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "src/index.js",
@@ -29,7 +29,7 @@
     "yarn": ">= 1.6.0"
   },
   "dependencies": {
-    "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.1",
+    "@bildvitta/quasar-ui-asteroid": "3.16.0-beta.2",
     "@bildvitta/store-adapter": "^1.0.0",
     "execa": "^7.1.1",
     "fontfaceobserver": "^2.3.0",

--- a/app-extension/src/boot/notifications.js
+++ b/app-extension/src/boot/notifications.js
@@ -3,6 +3,8 @@
  * "asteroidConfig.framework.featureToggle.useNotifications" esteja ativada.
  */
 
+import { isLocalDevelopment } from '@bildvitta/quasar-ui-asteroid/src/helpers'
+
 import onLeaderElectionChannel from '../helpers/on-leader-election-channel'
 import { setLaravelEcho, setLaravelEchoListener } from '../helpers/laravel-echo'
 import { setNotificationsChannelListener, setNotificationsUtilsChannel } from '../helpers/notifications-channels'
@@ -11,6 +13,11 @@ import { LocalStorage } from 'quasar'
 import { boot } from 'quasar/wrappers'
 
 export default boot(() => {
+  /**
+   * Se estivermos em desenvolvimento local, não vamos estabelecer conexão com o servidor.
+   */
+  if (isLocalDevelopment()) return
+
   window.addEventListener('message', ({ data }) => {
     if (data.type !== 'updateUser') return
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid-docs",
-  "version": "3.16.0-beta.9",
+  "version": "3.16.0-beta.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid-docs",
-      "version": "3.16.0-beta.9",
+      "version": "3.16.0-beta.10",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-js": "^1.9.2",
@@ -48,7 +48,7 @@
     },
     "../ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.8",
+      "version": "3.16.0-beta.9",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid-docs",
-  "version": "3.16.0-beta.7",
+  "version": "3.16.0-beta.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid-docs",
-      "version": "3.16.0-beta.7",
+      "version": "3.16.0-beta.8",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-js": "^1.9.2",
@@ -48,7 +48,7 @@
     },
     "../ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.6",
+      "version": "3.16.0-beta.7",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid-docs",
-  "version": "3.16.0-beta.2",
+  "version": "3.16.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid-docs",
-      "version": "3.16.0-beta.2",
+      "version": "3.16.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-js": "^1.9.2",
@@ -48,7 +48,7 @@
     },
     "../ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.1",
+      "version": "3.16.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/store-adapter": "^1.0.0",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid-docs",
-  "version": "3.16.0-beta.5",
+  "version": "3.16.0-beta.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid-docs",
-      "version": "3.16.0-beta.5",
+      "version": "3.16.0-beta.6",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-js": "^1.9.2",
@@ -48,7 +48,7 @@
     },
     "../ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.4",
+      "version": "3.16.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid-docs",
-  "version": "3.16.0-beta.6",
+  "version": "3.16.0-beta.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid-docs",
-      "version": "3.16.0-beta.6",
+      "version": "3.16.0-beta.7",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-js": "^1.9.2",
@@ -48,7 +48,7 @@
     },
     "../ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.5",
+      "version": "3.16.0-beta.6",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid-docs",
-  "version": "3.15.0",
+  "version": "3.16.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid-docs",
-      "version": "3.15.0",
+      "version": "3.16.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-js": "^1.9.2",
@@ -48,7 +48,7 @@
     },
     "../ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.15.0-beta.15",
+      "version": "3.15.0",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/store-adapter": "^1.0.0",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid-docs",
-  "version": "3.16.0-beta.1",
+  "version": "3.16.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid-docs",
-      "version": "3.16.0-beta.1",
+      "version": "3.16.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-js": "^1.9.2",
@@ -48,7 +48,7 @@
     },
     "../ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.0",
+      "version": "3.16.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/store-adapter": "^1.0.0",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid-docs",
-  "version": "3.16.0-beta.8",
+  "version": "3.16.0-beta.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid-docs",
-      "version": "3.16.0-beta.8",
+      "version": "3.16.0-beta.9",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-js": "^1.9.2",
@@ -48,7 +48,7 @@
     },
     "../ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.7",
+      "version": "3.16.0-beta.8",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid-docs",
-  "version": "3.16.0-beta.3",
+  "version": "3.16.0-beta.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid-docs",
-      "version": "3.16.0-beta.3",
+      "version": "3.16.0-beta.4",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-js": "^1.9.2",
@@ -51,6 +51,7 @@
       "version": "3.16.0-beta.3",
       "license": "MIT",
       "dependencies": {
+        "@bildvitta/composables": "^1.0.0-beta.7",
         "@bildvitta/store-adapter": "^1.0.0",
         "autonumeric": "^4.9.0",
         "axios": "^1.4.0",
@@ -19030,6 +19031,7 @@
     "@bildvitta/quasar-ui-asteroid": {
       "version": "file:../ui",
       "requires": {
+        "@bildvitta/composables": "^1.0.0-beta.7",
         "@bildvitta/store-adapter": "^1.0.0",
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-replace": "^5.0.2",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid-docs",
-  "version": "3.16.0-beta.4",
+  "version": "3.16.0-beta.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid-docs",
-      "version": "3.16.0-beta.4",
+      "version": "3.16.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-js": "^1.9.2",
@@ -48,7 +48,7 @@
     },
     "../ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.3",
+      "version": "3.16.0-beta.4",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid-docs",
-  "version": "3.16.0-beta.0",
+  "version": "3.16.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid-docs",
-      "version": "3.16.0-beta.0",
+      "version": "3.16.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-js": "^1.9.2",
@@ -48,7 +48,7 @@
     },
     "../ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.15.0",
+      "version": "3.16.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/store-adapter": "^1.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid-docs",
   "description": "Asteroid",
-  "version": "3.16.0-beta.2",
+  "version": "3.16.0-beta.3",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "productName": "Asteroid Docs",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid-docs",
   "description": "Asteroid",
-  "version": "3.16.0-beta.7",
+  "version": "3.16.0-beta.8",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "productName": "Asteroid Docs",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid-docs",
   "description": "Asteroid",
-  "version": "3.16.0-beta.3",
+  "version": "3.16.0-beta.4",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "productName": "Asteroid Docs",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid-docs",
   "description": "Asteroid",
-  "version": "3.16.0-beta.5",
+  "version": "3.16.0-beta.6",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "productName": "Asteroid Docs",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid-docs",
   "description": "Asteroid",
-  "version": "3.16.0-beta.9",
+  "version": "3.16.0-beta.10",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "productName": "Asteroid Docs",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid-docs",
   "description": "Asteroid",
-  "version": "3.16.0-beta.8",
+  "version": "3.16.0-beta.9",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "productName": "Asteroid Docs",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid-docs",
   "description": "Asteroid",
-  "version": "3.16.0-beta.6",
+  "version": "3.16.0-beta.7",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "productName": "Asteroid Docs",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid-docs",
   "description": "Asteroid",
-  "version": "3.16.0-beta.1",
+  "version": "3.16.0-beta.2",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "productName": "Asteroid Docs",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid-docs",
   "description": "Asteroid",
-  "version": "3.15.0",
+  "version": "3.16.0-beta.0",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "productName": "Asteroid Docs",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid-docs",
   "description": "Asteroid",
-  "version": "3.16.0-beta.0",
+  "version": "3.16.0-beta.1",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "productName": "Asteroid Docs",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid-docs",
   "description": "Asteroid",
-  "version": "3.16.0-beta.4",
+  "version": "3.16.0-beta.5",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "productName": "Asteroid Docs",

--- a/docs/src/assets/menu.js
+++ b/docs/src/assets/menu.js
@@ -312,6 +312,10 @@ module.exports = [
         path: '/components/text-truncate'
       },
       {
+        name: 'ToggleVisibility',
+        path: '/components/toggle-visibility'
+      },
+      {
         name: 'Timeline',
         path: '/components/timeline'
       },

--- a/docs/src/examples/QasActions/WithTertiary.vue
+++ b/docs/src/examples/QasActions/WithTertiary.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="container q-py-lg">
+    <qas-actions>
+      <template #primary>
+        <qas-btn label="Primeiro" variant="primary" />
+      </template>
+
+      <template #secondary>
+        <qas-btn label="Segundo" variant="secondary" />
+      </template>
+
+      <template #tertiary>
+        <qas-btn label="Terciário" variant="tertiary" />
+      </template>
+    </qas-actions>
+  </div>
+</template>
+
+<script setup>
+defineOptions({ name: 'WithTertiary' })
+</script>

--- a/docs/src/examples/QasExpansionItem/Basic.vue
+++ b/docs/src/examples/QasExpansionItem/Basic.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- Usando qas-single-view apenas para recuperar os dados -->
   <qas-single-view v-model:fields="fields" v-model:result="result" :custom-id="customId" :entity="entity">
-    <qas-expansion-item :badges="badges" :grid-generator-props="gridGeneratorProps" label="Cleyton" />
+    <qas-expansion-item :badges="badges" :grid-generator-props="gridGeneratorProps" label="John Doe" />
   </qas-single-view>
 </template>
 

--- a/docs/src/examples/QasExpansionItem/Error.vue
+++ b/docs/src/examples/QasExpansionItem/Error.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- Usando qas-single-view apenas para recuperar os dados -->
   <qas-single-view v-model:fields="fields" v-model:result="result" :custom-id="customId" :entity="entity">
-    <qas-expansion-item :badges="badges" error error-message="Card com mensagem de erro" :grid-generator-props="gridGeneratorProps" label="Cleyton" />
+    <qas-expansion-item :badges="badges" error error-message="Card com mensagem de erro" :grid-generator-props="gridGeneratorProps" label="John Doe" />
   </qas-single-view>
 </template>
 

--- a/docs/src/examples/QasExpansionItem/HeaderBottomSlot.vue
+++ b/docs/src/examples/QasExpansionItem/HeaderBottomSlot.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="container spaced">
     <qas-expansion-item :badges="badges" label="John Doe">
+      <template #header-bottom>
+        <qas-badge>Header bottom</qas-badge>
+      </template>
+
       <template #content>
         Meu conteúdo customizado
       </template>
@@ -9,8 +13,6 @@
 </template>
 
 <script setup>
-defineOptions({ name: 'UsersList' })
-
 const badges = [
   {
     color: 'green-14',

--- a/docs/src/examples/QasExpansionItem/Nested.vue
+++ b/docs/src/examples/QasExpansionItem/Nested.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class="container spaced">
+    <qas-expansion-item :badges="badges" label="John Doe">
+      <template #content>
+        <qas-expansion-item label="Informações 1">
+          <template #content>
+            Meu conteúdo customizado
+          </template>
+        </qas-expansion-item>
+
+        <qas-expansion-item label="Informações 2">
+          <template #content>
+            Meu conteúdo customizado 2
+          </template>
+        </qas-expansion-item>
+
+        <qas-expansion-item label="Informações 3">
+          <template #content>
+            Meu conteúdo customizado 3
+          </template>
+        </qas-expansion-item>
+
+        <qas-expansion-item label="Informações 4">
+          <template #content>
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Numquam dolore eligendi accusamus placeat laudantium aliquid aspernatur mollitia, expedita id labore ex nulla quam maiores exercitationem et debitis quae corrupti odio.
+          </template>
+        </qas-expansion-item>
+      </template>
+    </qas-expansion-item>
+  </div>
+</template>
+
+<script setup>
+const badges = [
+  {
+    color: 'green-14',
+    label: 'Aprovado',
+    textColor: 'white'
+  },
+  {
+    color: 'red-14',
+    label: 'Reprovado',
+    textColor: 'white'
+  }
+]
+</script>

--- a/docs/src/examples/QasExpansionItem/Nested.vue
+++ b/docs/src/examples/QasExpansionItem/Nested.vue
@@ -2,29 +2,31 @@
   <div class="container spaced">
     <qas-expansion-item :badges="badges" label="John Doe">
       <template #content>
-        <qas-expansion-item label="Informações 1">
-          <template #content>
-            Meu conteúdo customizado
-          </template>
-        </qas-expansion-item>
+        <div class="q-col-gutter-y-md row">
+          <qas-expansion-item label="Informações 1">
+            <template #content>
+              Meu conteúdo customizado
+            </template>
+          </qas-expansion-item>
 
-        <qas-expansion-item label="Informações 2">
-          <template #content>
-            Meu conteúdo customizado 2
-          </template>
-        </qas-expansion-item>
+          <qas-expansion-item label="Informações 2">
+            <template #content>
+              Meu conteúdo customizado 2
+            </template>
+          </qas-expansion-item>
 
-        <qas-expansion-item label="Informações 3">
-          <template #content>
-            Meu conteúdo customizado 3
-          </template>
-        </qas-expansion-item>
+          <qas-expansion-item label="Informações 3">
+            <template #content>
+              Meu conteúdo customizado 3
+            </template>
+          </qas-expansion-item>
 
-        <qas-expansion-item label="Informações 4">
-          <template #content>
-            Lorem ipsum dolor sit amet consectetur adipisicing elit. Numquam dolore eligendi accusamus placeat laudantium aliquid aspernatur mollitia, expedita id labore ex nulla quam maiores exercitationem et debitis quae corrupti odio.
-          </template>
-        </qas-expansion-item>
+          <qas-expansion-item label="Informações 4">
+            <template #content>
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Numquam dolore eligendi accusamus placeat laudantium aliquid aspernatur mollitia, expedita id labore ex nulla quam maiores exercitationem et debitis quae corrupti odio.
+            </template>
+          </qas-expansion-item>
+        </div>
       </template>
     </qas-expansion-item>
   </div>

--- a/docs/src/examples/QasFormGenerator/ExFormCommonColumns.vue
+++ b/docs/src/examples/QasFormGenerator/ExFormCommonColumns.vue
@@ -1,0 +1,54 @@
+<template>
+  <!-- Usando qas-single-view apenas para recuperar os dados -->
+  <qas-single-view v-model:fields="viewState.fields" v-model:result="viewState.result" v-bind="singleViewProps">
+    <template #default>
+      <div>
+        <div>
+          <qas-label label="object" />
+
+          <qas-form-generator v-bind="formGeneratorProps" v-model="viewState.values" :fields="viewState.fields" />
+
+          <q-separator class="q-mt-xl" />
+        </div>
+
+        <qas-label class="q-mt-xl" label="string" />
+
+        <qas-form-generator v-bind="formGeneratorStringProps" v-model="viewState.values" :fields="viewState.fields" />
+      </div>
+    </template>
+  </qas-single-view>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+defineOptions({ name: 'ExFormCommonColumns' })
+
+const viewState = ref({
+  fields: {},
+  values: []
+})
+
+const entity = 'users'
+
+const customId = '3102fad5-f14c-45d4-98e9-46ef0aa9580e'
+
+const singleViewProps = {
+  entity,
+  customId
+}
+
+const formGeneratorProps = {
+  commonColumns: { col: 12, sm: 3 },
+  columns: {
+    name: { col: 12, sm: 12 }
+  }
+}
+
+const formGeneratorStringProps = {
+  commonColumns: '3',
+  columns: {
+    name: { col: 12 }
+  }
+}
+</script>

--- a/docs/src/examples/QasGridGenerator/Basic.vue
+++ b/docs/src/examples/QasGridGenerator/Basic.vue
@@ -3,7 +3,7 @@
   <qas-single-view v-model:fields="fields" v-model:result="result" :custom-id="customId" :entity="entity">
     <template #default>
       <div>
-        <qas-grid-generator :fields="fields" :result="result" />
+        <qas-grid-generator :columns="{ name: { col: 12 } }" :fields="fields" :result="result" />
       </div>
     </template>
   </qas-single-view>

--- a/docs/src/examples/QasGridGenerator/ExGridCommonColumns.vue
+++ b/docs/src/examples/QasGridGenerator/ExGridCommonColumns.vue
@@ -1,0 +1,54 @@
+<template>
+  <!-- Usando qas-single-view apenas para recuperar os dados -->
+  <qas-single-view v-model:fields="viewState.fields" v-model:result="viewState.result" v-bind="singleViewProps">
+    <template #default>
+      <div>
+        <div>
+          <qas-label label="object" />
+
+          <qas-grid-generator v-bind="gridGeneratorProps" :fields="viewState.fields" :result="viewState.result" />
+
+          <q-separator class="q-mt-xl" />
+        </div>
+
+        <qas-label class="q-mt-xl" label="string" />
+
+        <qas-grid-generator v-bind="gridGeneratorStringProps" :fields="viewState.fields" :result="viewState.result" />
+      </div>
+    </template>
+  </qas-single-view>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+defineOptions({ name: 'ExGridCommonColumns' })
+
+const viewState = ref({
+  fields: {},
+  result: []
+})
+
+const entity = 'users'
+
+const customId = '3102fad5-f14c-45d4-98e9-46ef0aa9580e'
+
+const singleViewProps = {
+  entity,
+  customId
+}
+
+const gridGeneratorProps = {
+  commonColumns: { col: 12, sm: 3 },
+  columns: {
+    name: { col: 12, sm: 12 }
+  }
+}
+
+const gridGeneratorStringProps = {
+  commonColumns: '3',
+  columns: {
+    name: { col: 12 }
+  }
+}
+</script>

--- a/docs/src/examples/QasHeaderActions/HeaderActionsWithButton.vue
+++ b/docs/src/examples/QasHeaderActions/HeaderActionsWithButton.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container spaced">
-    <qas-header-actions class="q-mb-sm" v-bind="headerActionsProps" />
+    <qas-header-actions v-bind="headerActionsProps" />
   </div>
 </template>
 

--- a/docs/src/examples/QasTableGenerator/NoBox.vue
+++ b/docs/src/examples/QasTableGenerator/NoBox.vue
@@ -1,0 +1,27 @@
+<template>
+  <!-- Utilizando o list-view apenas para facilitar para recuperar os dados dos dados. -->
+  <qas-list-view v-model:fields="fields" v-model:results="results" :entity="entity" :use-filter="false">
+    <template #default>
+      <qas-table-generator :fields="fields" :results="results" row-key="uuid" :use-box="false" />
+    </template>
+  </qas-list-view>
+</template>
+
+<script>
+export default {
+  name: 'NoBox',
+
+  data () {
+    return {
+      fields: {},
+      results: []
+    }
+  },
+
+  computed: {
+    entity () {
+      return 'users'
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QasToggleVisibility/Basic.vue
+++ b/docs/src/examples/QasToggleVisibility/Basic.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="container q-py-lg">
+    <qas-toggle-visibility text="64.829.511/0001-01" />
+
+    <qas-toggle-visibility text="888.888.888-88" />
+
+    <qas-toggle-visibility text="777.777.777-77" />
+  </div>
+</template>

--- a/docs/src/examples/QasToggleVisibility/MultipleGroup.vue
+++ b/docs/src/examples/QasToggleVisibility/MultipleGroup.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="container q-py-lg">
+    <qas-box>
+      <qas-label label="Employees" />
+
+      <qas-toggle-visibility group="employees" text="999.999.999-99" />
+
+      <qas-toggle-visibility group="employees" text="888.888.888-88" />
+
+      <qas-toggle-visibility group="employees" text="777.777.777-77" />
+    </qas-box>
+
+    <qas-box class="q-mt-xl">
+      <qas-label label="Customers" />
+
+      <qas-toggle-visibility group="customers" text="999.999.999-99.999.999.999-99.999.999.999-99e" />
+
+      <qas-toggle-visibility group="customers" text="888.888.888-88" />
+
+      <qas-toggle-visibility group="customers" text="777.777.777-77" />
+    </qas-box>
+
+    <qas-box class="q-mt-xl">
+      <qas-label label="Customers" />
+
+      <div class="q-col-gutter-md row">
+        <qas-toggle-visibility class="col-4" group="customers" text="999.999.999-99.999.999.999-99.999.999.999-99e" width="100%" />
+
+        <qas-toggle-visibility class="col-4" group="customers" text="888.888.888-88" width="100%" />
+
+        <qas-toggle-visibility class="col-4" group="customers" text="777.777.777-77" width="100%" />
+      </div>
+    </qas-box>
+  </div>
+</template>

--- a/docs/src/examples/QasToggleVisibility/Slot.vue
+++ b/docs/src/examples/QasToggleVisibility/Slot.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="container q-py-lg">
+    <qas-toggle-visibility>
+      <qas-label label="999.999.999-99" />
+    </qas-toggle-visibility>
+
+    <qas-toggle-visibility class="q-mt-md">
+      <qas-label label="888.888.888-88" />
+    </qas-toggle-visibility>
+
+    <qas-toggle-visibility class="q-mt-md">
+      <qas-label label="777.777.777-77" />
+    </qas-toggle-visibility>
+  </div>
+</template>

--- a/docs/src/pages/components/actions.md
+++ b/docs/src/pages/components/actions.md
@@ -9,5 +9,4 @@ title: QasActions
 ## Uso
 
 <doc-example file="QasActions/Basic" title="Básico" />
-
-
+<doc-example file="QasActions/WithTertiary" title="Terciário" />

--- a/docs/src/pages/components/expansion-item.md
+++ b/docs/src/pages/components/expansion-item.md
@@ -7,7 +7,8 @@ Componente de card expansivo, wrapper do QExpansionItem(https://quasar.dev/vue-c
 <doc-api file="expansion-item/QasExpansionItem" name="QasExpansionItem" />
 
 :::info
-Quando usado QasExpansionItem dentro de QasExpansionItem, o componente já lida com isto internamente alterando o estilo dos QasExpansionItem interno.
+- Quando usado QasExpansionItem dentro de QasExpansionItem, o componente já lida com isto internamente alterando o estilo dos QasExpansionItem interno.
+- O componente repassa todos os eventos do [QExpansionItem](https://quasar.dev/vue-components/expansion-item#usage).
 :::
 
 :::warning

--- a/docs/src/pages/components/expansion-item.md
+++ b/docs/src/pages/components/expansion-item.md
@@ -12,7 +12,8 @@ Componente de card expansivo, wrapper do QExpansionItem(https://quasar.dev/vue-c
 :::
 
 :::warning
-Não recomendamos o uso de nested de 3 níveis (QasExpansionItem dentro de QasExpansionItem dentro de QasExpansionItem).
+- Não recomendamos o uso de nested de 3 níveis (QasExpansionItem dentro de QasExpansionItem dentro de QasExpansionItem).
+- O separador no header funciona de forma automática, porém em alguns casos é necessário forçar aparecer/remover, use a propriedade "useHeaderSeparator" nestes casos específicos.
 :::
 
 ## Uso

--- a/docs/src/pages/components/expansion-item.md
+++ b/docs/src/pages/components/expansion-item.md
@@ -6,8 +6,18 @@ Componente de card expansivo, wrapper do QExpansionItem(https://quasar.dev/vue-c
 
 <doc-api file="expansion-item/QasExpansionItem" name="QasExpansionItem" />
 
+:::info
+Quando usado QasExpansionItem dentro de QasExpansionItem, o componente já lida com isto internamente alterando o estilo dos QasExpansionItem interno.
+:::
+
+:::warning
+Não recomendamos o uso de nested de 3 níveis (QasExpansionItem dentro de QasExpansionItem dentro de QasExpansionItem).
+:::
+
 ## Uso
 
 <doc-example file="QasExpansionItem/Basic" title="Básico" />
 <doc-example file="QasExpansionItem/Slot" title="Slot" />
+<doc-example file="QasExpansionItem/Nested" title="Nested" />
+<doc-example file="QasExpansionItem/HeaderBottomSlot" title="HeaderBottomSlot" />
 <doc-example file="QasExpansionItem/Error" title="Com erro" />

--- a/docs/src/pages/components/form-generator.md
+++ b/docs/src/pages/components/form-generator.md
@@ -43,3 +43,5 @@ Em alguns casos, queremos acessar todo o conteúdo de um campo especifico para f
 <doc-example file="QasFormGenerator/CustomSlot" title="Acessando slots" />
 
 <doc-example file="QasFormGenerator/CustomProps" title="Custom props" />
+
+<doc-example file="QasFormGenerator/ExFormCommonColumns" title="Common columns" />

--- a/docs/src/pages/components/grid-generator.md
+++ b/docs/src/pages/components/grid-generator.md
@@ -20,5 +20,6 @@ Ao utilizar a prop `useInline`, o gutter passa a ter o valor `md`.
 
 ## Uso
 <doc-example file="QasGridGenerator/Basic" title="Básico" />
+<doc-example file="QasGridGenerator/ExGridCommonColumns" title="Common Columns" />
 <doc-example file="QasGridGenerator/Slots" title="Slots" />
 <doc-example file="QasGridGenerator/UseInline" title="Inline" />

--- a/docs/src/pages/components/single-view.md
+++ b/docs/src/pages/components/single-view.md
@@ -6,8 +6,14 @@ Componente para C.R.U.D. responsável pela visualização (Read) ou conhecido ta
 
 <doc-api file="single-view/QasSingleView" name="QasSingleView" />
 
+:::danger
+#### useStore
+- Utilize esta propriedade como "false" apenas em casos específicos como quando precisar utilizar este componente dentro de um dialog.
+- Caso esteja usando "useStore" como "false", e esteja passando a propriedade "entity", o componente tentará criar uma url automaticamente transformando entity em `kebab-case` e concatenando com o id da URL caso exista, é possível sobrescrever passando a prop "url".
+:::
+
 :::warning
-Este componente depende do `Vuex`, utiliza módulos com actions, state e getters para manipular/recuperar os dados. Por exemplo, para você utilizar em uma entidade de show de usuários, você **deve** ter um modulo de `users` e dentro de dele ter os seguinte requisitos:
+Este componente depende do `Vuex` ou `Pinia` caso esteja utilizando a propriedade `useStore: true`, utiliza módulos com actions, state e getters para manipular/recuperar os dados. Por exemplo, para você utilizar em uma entidade de show de usuários, você **deve** ter um modulo de `users` e dentro de dele ter os seguinte requisitos:
 - state: list.
 - getters: list e byId.
 - actions: fetchSingle.

--- a/docs/src/pages/components/single-view.md
+++ b/docs/src/pages/components/single-view.md
@@ -28,6 +28,12 @@ Para fazer esses exemplos na documentação, estamos utilizando o `VuexOffline`,
 Estamos utilizando nos exemplos um `custom-id` pois é necessario para conseguir utilizar os mocks de dados, **não** significa que você precisa sempre utiliza-lo para lidar com o id, na verdade na maioria das vezes você não vai precisar do `custom-id`, ele é para quando precisa de um caso de uso mais específico.
 :::
 
+:::warning
+Devido este componente estar em Composition API, foi necessário definir quais métodos estarão expostos para se utilizar com [Template Refs](https://vuejs.org/guide/essentials/template-refs.html). Os métodos expostos foram:
+- fetchSingle
+- fetchHandler
+:::
+
 :::tip
 Este componente serve para lidar com **visualização unica**, se você precisar de um componente para lidar com listagem, use o componente `QasListView`.
 :::

--- a/docs/src/pages/components/table-generator.md
+++ b/docs/src/pages/components/table-generator.md
@@ -31,6 +31,7 @@ Componente implementa o `QasBox` repassando todas propriedades.
 ## Uso
 
 <doc-example file="QasTableGenerator/Basic" title="Básico" />
+<doc-example file="QasTableGenerator/NoBox" title="Sem box" />
 
 Este componente renderiza componentes dinamicamente através da prop `fields`, cada field dentro de fields tem um `name`, através dele, você consegue acessar os slots dinâmicos.
 

--- a/docs/src/pages/components/toggle-visibility.md
+++ b/docs/src/pages/components/toggle-visibility.md
@@ -1,0 +1,18 @@
+---
+title: QasToggleVisibility
+---
+
+Componente para ocultar e exibir conteúdo, utilizado para dados sensíveis.
+
+<doc-api file="toggle-visibility/QasToggleVisibility" name="QasToggleVisibility" />
+
+:::info
+##### group
+Ao **não** utilizar a propriedade `group`, um grupo padrão é criado chamado `default`. Todos os componentes associados a este grupo padrão farão parte do mesmo bloco.
+:::
+
+## Uso
+
+<doc-example file="QasToggleVisibility/Basic" title="Básico" />
+<doc-example file="QasToggleVisibility/MultipleGroup" title="Múltiplos grupos" />
+<doc-example file="QasToggleVisibility/Slot" title="Customizando com slot" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid",
-  "version": "3.16.0-beta.0",
+  "version": "3.16.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid",
-      "version": "3.16.0-beta.0",
+      "version": "3.16.0-beta.1",
       "license": "MIT",
       "devDependencies": {
         "@bildvitta/quasar-ui-asteroid": "file:ui",
@@ -5443,7 +5443,7 @@
     },
     "ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.15.0",
+      "version": "3.16.0-beta.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid",
-  "version": "3.16.0-beta.5",
+  "version": "3.16.0-beta.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid",
-      "version": "3.16.0-beta.5",
+      "version": "3.16.0-beta.6",
       "license": "MIT",
       "devDependencies": {
         "@bildvitta/quasar-ui-asteroid": "file:ui",
@@ -5636,7 +5636,7 @@
     },
     "ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.4",
+      "version": "3.16.0-beta.5",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid",
-  "version": "3.16.0-beta.3",
+  "version": "3.16.0-beta.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid",
-      "version": "3.16.0-beta.3",
+      "version": "3.16.0-beta.4",
       "license": "MIT",
       "devDependencies": {
         "@bildvitta/quasar-ui-asteroid": "file:ui",
@@ -78,15 +78,174 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.5",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
+      "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@bildvitta/composables": {
+      "version": "1.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@bildvitta/composables/-/composables-1.0.0-beta.7.tgz",
+      "integrity": "sha512-LV7GL8w3PE1xYb/z52RoVZn1N+SS1pneqtiJDnMPquBKSBxYgFBoBr4/N4A4gLKIF3B/JRYmUbGLUYaRpL2PVg==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-sfc": "^3.4.21",
+        "path": "^0.12.7",
+        "vue": "^3.4.21",
+        "vue-demi": "^0.14.7"
+      }
+    },
+    "node_modules/@bildvitta/composables/node_modules/@vue/compiler-core": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.30.tgz",
+      "integrity": "sha512-ZL8y4Xxdh8O6PSwfdZ1IpQ24PjTAieOz3jXb/MDTfDtANcKBMxg1KLm6OX2jofsaQGYfIVzd3BAG22i56/cF1w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.24.7",
+        "@vue/shared": "3.4.30",
+        "entities": "^4.5.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/@bildvitta/composables/node_modules/@vue/compiler-dom": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.30.tgz",
+      "integrity": "sha512-+16Sd8lYr5j/owCbr9dowcNfrHd+pz+w2/b5Lt26Oz/kB90C9yNbxQ3bYOvt7rI2bxk0nqda39hVcwDFw85c2Q==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-core": "3.4.30",
+        "@vue/shared": "3.4.30"
+      }
+    },
+    "node_modules/@bildvitta/composables/node_modules/@vue/compiler-sfc": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.30.tgz",
+      "integrity": "sha512-8vElKklHn/UY8+FgUFlQrYAPbtiSB2zcgeRKW7HkpSRn/JjMRmZvuOtwDx036D1aqKNSTtXkWRfqx53Qb+HmMg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.24.7",
+        "@vue/compiler-core": "3.4.30",
+        "@vue/compiler-dom": "3.4.30",
+        "@vue/compiler-ssr": "3.4.30",
+        "@vue/shared": "3.4.30",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.10",
+        "postcss": "^8.4.38",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/@bildvitta/composables/node_modules/@vue/compiler-ssr": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.30.tgz",
+      "integrity": "sha512-ZJ56YZGXJDd6jky4mmM0rNaNP6kIbQu9LTKZDhcpddGe/3QIalB1WHHmZ6iZfFNyj5mSypTa4+qDJa5VIuxMSg==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.4.30",
+        "@vue/shared": "3.4.30"
+      }
+    },
+    "node_modules/@bildvitta/composables/node_modules/@vue/reactivity": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.30.tgz",
+      "integrity": "sha512-bVJurnCe3LS0JII8PPoAA63Zd2MBzcKrEzwdQl92eHCcxtIbxD2fhNwJpa+KkM3Y/A4T5FUnmdhgKwOf6BfbcA==",
+      "dev": true,
+      "dependencies": {
+        "@vue/shared": "3.4.30"
+      }
+    },
+    "node_modules/@bildvitta/composables/node_modules/@vue/runtime-core": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.30.tgz",
+      "integrity": "sha512-qaFEbnNpGz+tlnkaualomogzN8vBLkgzK55uuWjYXbYn039eOBZrWxyXWq/7qh9Bz2FPifZqGjVDl/FXiq9L2g==",
+      "dev": true,
+      "dependencies": {
+        "@vue/reactivity": "3.4.30",
+        "@vue/shared": "3.4.30"
+      }
+    },
+    "node_modules/@bildvitta/composables/node_modules/@vue/runtime-dom": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.30.tgz",
+      "integrity": "sha512-tV6B4YiZRj5QsaJgw2THCy5C1H+2UeywO9tqgWEc21tn85qHEERndHN/CxlyXvSBFrpmlexCIdnqPuR9RM9thw==",
+      "dev": true,
+      "dependencies": {
+        "@vue/reactivity": "3.4.30",
+        "@vue/runtime-core": "3.4.30",
+        "@vue/shared": "3.4.30",
+        "csstype": "^3.1.3"
+      }
+    },
+    "node_modules/@bildvitta/composables/node_modules/@vue/server-renderer": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.30.tgz",
+      "integrity": "sha512-TBD3eqR1DeDc0cMrXS/vEs/PWzq1uXxnvjoqQuDGFIEHFIwuDTX/KWAQKIBjyMWLFHEeTDGYVsYci85z2UbTDg==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-ssr": "3.4.30",
+        "@vue/shared": "3.4.30"
+      },
+      "peerDependencies": {
+        "vue": "3.4.30"
+      }
+    },
+    "node_modules/@bildvitta/composables/node_modules/@vue/shared": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.30.tgz",
+      "integrity": "sha512-CLg+f8RQCHQnKvuHY9adMsMaQOcqclh6Z5V9TaoMgy0ut0tz848joZ7/CYFFyF/yZ5i2yaw7Fn498C+CNZVHIg==",
+      "dev": true
+    },
+    "node_modules/@bildvitta/composables/node_modules/vue": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.30.tgz",
+      "integrity": "sha512-NcxtKCwkdf1zPsr7Y8+QlDBCGqxvjLXF2EX+yi76rV5rrz90Y6gK1cq0olIhdWGgrlhs9ElHuhi9t3+W5sG5Xw==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.4.30",
+        "@vue/compiler-sfc": "3.4.30",
+        "@vue/runtime-dom": "3.4.30",
+        "@vue/server-renderer": "3.4.30",
+        "@vue/shared": "3.4.30"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@bildvitta/composables/node_modules/vue-demi": {
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.8.tgz",
+      "integrity": "sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@bildvitta/quasar-ui-asteroid": {
@@ -1282,10 +1441,10 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true
     },
     "node_modules/data-urls": {
       "version": "4.0.0",
@@ -2170,8 +2329,7 @@
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -3470,14 +3628,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.0",
+      "version": "0.30.10",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
-      },
-      "engines": {
-        "node": ">=12"
+        "@jridgewell/sourcemap-codec": "^1.4.15"
       }
     },
     "node_modules/md5-hex": {
@@ -3570,7 +3726,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "dev": true,
       "funding": [
         {
@@ -3578,7 +3736,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -3885,6 +4042,16 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "dev": true,
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "dev": true,
@@ -3969,7 +4136,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.24",
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
       "dev": true,
       "funding": [
         {
@@ -3985,11 +4154,10 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -4067,6 +4235,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/proto-list": {
@@ -4558,9 +4735,10 @@
       "license": "ISC"
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4976,10 +5154,25 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/util/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "dev": true
     },
     "node_modules/vite": {
       "version": "4.3.9",
@@ -5447,6 +5640,7 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@bildvitta/composables": "^1.0.0-beta.7",
         "@bildvitta/store-adapter": "^1.0.0",
         "autonumeric": "^4.9.0",
         "axios": "^1.4.0",
@@ -5474,17 +5668,6 @@
         "rollup-plugin-scss": "^4.0.0",
         "rollup-plugin-vue": "^6.0.0",
         "sass": "^1.62.1"
-      }
-    },
-    "ui/node_modules/@babel/parser": {
-      "version": "7.22.5",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "ui/node_modules/@babel/runtime": {
@@ -6712,23 +6895,6 @@
         "object-assign": "^4.1.1"
       }
     },
-    "ui/node_modules/nanoid": {
-      "version": "3.3.6",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "ui/node_modules/node-releases": {
       "version": "2.0.12",
       "dev": true,
@@ -6798,33 +6964,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
-    },
-    "ui/node_modules/postcss": {
-      "version": "8.4.24",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
     },
     "ui/node_modules/postcss-value-parser": {
       "version": "4.2.0",
@@ -7050,14 +7189,6 @@
     },
     "ui/node_modules/source-map": {
       "version": "0.6.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "ui/node_modules/source-map-js": {
-      "version": "1.0.2",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -7460,13 +7591,146 @@
   },
   "dependencies": {
     "@babel/parser": {
-      "version": "7.22.5",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
+      "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
+      "dev": true
+    },
+    "@bildvitta/composables": {
+      "version": "1.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@bildvitta/composables/-/composables-1.0.0-beta.7.tgz",
+      "integrity": "sha512-LV7GL8w3PE1xYb/z52RoVZn1N+SS1pneqtiJDnMPquBKSBxYgFBoBr4/N4A4gLKIF3B/JRYmUbGLUYaRpL2PVg==",
       "dev": true,
-      "peer": true
+      "requires": {
+        "@vue/compiler-sfc": "^3.4.21",
+        "path": "^0.12.7",
+        "vue": "^3.4.21",
+        "vue-demi": "^0.14.7"
+      },
+      "dependencies": {
+        "@vue/compiler-core": {
+          "version": "3.4.30",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.30.tgz",
+          "integrity": "sha512-ZL8y4Xxdh8O6PSwfdZ1IpQ24PjTAieOz3jXb/MDTfDtANcKBMxg1KLm6OX2jofsaQGYfIVzd3BAG22i56/cF1w==",
+          "dev": true,
+          "requires": {
+            "@babel/parser": "^7.24.7",
+            "@vue/shared": "3.4.30",
+            "entities": "^4.5.0",
+            "estree-walker": "^2.0.2",
+            "source-map-js": "^1.2.0"
+          }
+        },
+        "@vue/compiler-dom": {
+          "version": "3.4.30",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.30.tgz",
+          "integrity": "sha512-+16Sd8lYr5j/owCbr9dowcNfrHd+pz+w2/b5Lt26Oz/kB90C9yNbxQ3bYOvt7rI2bxk0nqda39hVcwDFw85c2Q==",
+          "dev": true,
+          "requires": {
+            "@vue/compiler-core": "3.4.30",
+            "@vue/shared": "3.4.30"
+          }
+        },
+        "@vue/compiler-sfc": {
+          "version": "3.4.30",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.30.tgz",
+          "integrity": "sha512-8vElKklHn/UY8+FgUFlQrYAPbtiSB2zcgeRKW7HkpSRn/JjMRmZvuOtwDx036D1aqKNSTtXkWRfqx53Qb+HmMg==",
+          "dev": true,
+          "requires": {
+            "@babel/parser": "^7.24.7",
+            "@vue/compiler-core": "3.4.30",
+            "@vue/compiler-dom": "3.4.30",
+            "@vue/compiler-ssr": "3.4.30",
+            "@vue/shared": "3.4.30",
+            "estree-walker": "^2.0.2",
+            "magic-string": "^0.30.10",
+            "postcss": "^8.4.38",
+            "source-map-js": "^1.2.0"
+          }
+        },
+        "@vue/compiler-ssr": {
+          "version": "3.4.30",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.30.tgz",
+          "integrity": "sha512-ZJ56YZGXJDd6jky4mmM0rNaNP6kIbQu9LTKZDhcpddGe/3QIalB1WHHmZ6iZfFNyj5mSypTa4+qDJa5VIuxMSg==",
+          "dev": true,
+          "requires": {
+            "@vue/compiler-dom": "3.4.30",
+            "@vue/shared": "3.4.30"
+          }
+        },
+        "@vue/reactivity": {
+          "version": "3.4.30",
+          "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.30.tgz",
+          "integrity": "sha512-bVJurnCe3LS0JII8PPoAA63Zd2MBzcKrEzwdQl92eHCcxtIbxD2fhNwJpa+KkM3Y/A4T5FUnmdhgKwOf6BfbcA==",
+          "dev": true,
+          "requires": {
+            "@vue/shared": "3.4.30"
+          }
+        },
+        "@vue/runtime-core": {
+          "version": "3.4.30",
+          "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.30.tgz",
+          "integrity": "sha512-qaFEbnNpGz+tlnkaualomogzN8vBLkgzK55uuWjYXbYn039eOBZrWxyXWq/7qh9Bz2FPifZqGjVDl/FXiq9L2g==",
+          "dev": true,
+          "requires": {
+            "@vue/reactivity": "3.4.30",
+            "@vue/shared": "3.4.30"
+          }
+        },
+        "@vue/runtime-dom": {
+          "version": "3.4.30",
+          "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.30.tgz",
+          "integrity": "sha512-tV6B4YiZRj5QsaJgw2THCy5C1H+2UeywO9tqgWEc21tn85qHEERndHN/CxlyXvSBFrpmlexCIdnqPuR9RM9thw==",
+          "dev": true,
+          "requires": {
+            "@vue/reactivity": "3.4.30",
+            "@vue/runtime-core": "3.4.30",
+            "@vue/shared": "3.4.30",
+            "csstype": "^3.1.3"
+          }
+        },
+        "@vue/server-renderer": {
+          "version": "3.4.30",
+          "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.30.tgz",
+          "integrity": "sha512-TBD3eqR1DeDc0cMrXS/vEs/PWzq1uXxnvjoqQuDGFIEHFIwuDTX/KWAQKIBjyMWLFHEeTDGYVsYci85z2UbTDg==",
+          "dev": true,
+          "requires": {
+            "@vue/compiler-ssr": "3.4.30",
+            "@vue/shared": "3.4.30"
+          }
+        },
+        "@vue/shared": {
+          "version": "3.4.30",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.30.tgz",
+          "integrity": "sha512-CLg+f8RQCHQnKvuHY9adMsMaQOcqclh6Z5V9TaoMgy0ut0tz848joZ7/CYFFyF/yZ5i2yaw7Fn498C+CNZVHIg==",
+          "dev": true
+        },
+        "vue": {
+          "version": "3.4.30",
+          "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.30.tgz",
+          "integrity": "sha512-NcxtKCwkdf1zPsr7Y8+QlDBCGqxvjLXF2EX+yi76rV5rrz90Y6gK1cq0olIhdWGgrlhs9ElHuhi9t3+W5sG5Xw==",
+          "dev": true,
+          "requires": {
+            "@vue/compiler-dom": "3.4.30",
+            "@vue/compiler-sfc": "3.4.30",
+            "@vue/runtime-dom": "3.4.30",
+            "@vue/server-renderer": "3.4.30",
+            "@vue/shared": "3.4.30"
+          }
+        },
+        "vue-demi": {
+          "version": "0.14.8",
+          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.8.tgz",
+          "integrity": "sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==",
+          "dev": true,
+          "requires": {}
+        }
+      }
     },
     "@bildvitta/quasar-ui-asteroid": {
       "version": "file:ui",
       "requires": {
+        "@bildvitta/composables": "^1.0.0-beta.7",
         "@bildvitta/store-adapter": "^1.0.0",
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-replace": "^5.0.2",
@@ -7494,10 +7758,6 @@
         "sortablejs": "^1.15.0"
       },
       "dependencies": {
-        "@babel/parser": {
-          "version": "7.22.5",
-          "dev": true
-        },
         "@babel/runtime": {
           "version": "7.22.5",
           "dev": true,
@@ -8268,10 +8528,6 @@
             "object-assign": "^4.1.1"
           }
         },
-        "nanoid": {
-          "version": "3.3.6",
-          "dev": true
-        },
         "node-releases": {
           "version": "2.0.12",
           "dev": true
@@ -8317,15 +8573,6 @@
         "picocolors": {
           "version": "1.0.0",
           "dev": true
-        },
-        "postcss": {
-          "version": "8.4.24",
-          "dev": true,
-          "requires": {
-            "nanoid": "^3.3.6",
-            "picocolors": "^1.0.0",
-            "source-map-js": "^1.0.2"
-          }
         },
         "postcss-value-parser": {
           "version": "4.2.0",
@@ -8447,10 +8694,6 @@
         },
         "source-map": {
           "version": "0.6.1",
-          "dev": true
-        },
-        "source-map-js": {
-          "version": "1.0.2",
           "dev": true
         },
         "sprintf-js": {
@@ -9426,9 +9669,10 @@
       }
     },
     "csstype": {
-      "version": "3.1.2",
-      "dev": true,
-      "peer": true
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true
     },
     "data-urls": {
       "version": "4.0.0",
@@ -10012,8 +10256,7 @@
     },
     "estree-walker": {
       "version": "2.0.2",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
@@ -10773,10 +11016,12 @@
       "dev": true
     },
     "magic-string": {
-      "version": "0.30.0",
+      "version": "0.30.10",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
       "dev": true,
       "requires": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
+        "@jridgewell/sourcemap-codec": "^1.4.15"
       }
     },
     "md5-hex": {
@@ -10835,7 +11080,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.6",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "dev": true
     },
     "natural-compare": {
@@ -11007,6 +11254,16 @@
         "entities": "^4.4.0"
       }
     },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "dev": true,
+      "requires": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "path-exists": {
       "version": "4.0.0",
       "dev": true
@@ -11057,12 +11314,14 @@
       }
     },
     "postcss": {
-      "version": "8.4.24",
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       }
     },
     "postcss-html": {
@@ -11108,6 +11367,12 @@
           "dev": true
         }
       }
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true
     },
     "proto-list": {
       "version": "1.2.4",
@@ -11383,7 +11648,9 @@
       "dev": true
     },
     "source-map-js": {
-      "version": "1.0.2",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "dev": true
     },
     "stackback": {
@@ -11638,6 +11905,23 @@
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+          "dev": true
+        }
       }
     },
     "util-deprecate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid",
-  "version": "3.16.0-beta.6",
+  "version": "3.16.0-beta.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid",
-      "version": "3.16.0-beta.6",
+      "version": "3.16.0-beta.7",
       "license": "MIT",
       "devDependencies": {
         "@bildvitta/quasar-ui-asteroid": "file:ui",
@@ -5636,7 +5636,7 @@
     },
     "ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.5",
+      "version": "3.16.0-beta.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid",
-  "version": "3.16.0-beta.4",
+  "version": "3.16.0-beta.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid",
-      "version": "3.16.0-beta.4",
+      "version": "3.16.0-beta.5",
       "license": "MIT",
       "devDependencies": {
         "@bildvitta/quasar-ui-asteroid": "file:ui",
@@ -5636,7 +5636,7 @@
     },
     "ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.3",
+      "version": "3.16.0-beta.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid",
-  "version": "3.16.0-beta.9",
+  "version": "3.16.0-beta.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid",
-      "version": "3.16.0-beta.9",
+      "version": "3.16.0-beta.10",
       "license": "MIT",
       "devDependencies": {
         "@bildvitta/quasar-ui-asteroid": "file:ui",
@@ -5636,7 +5636,7 @@
     },
     "ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.8",
+      "version": "3.16.0-beta.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid",
-  "version": "3.15.0",
+  "version": "3.16.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid",
-      "version": "3.15.0",
+      "version": "3.16.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@bildvitta/quasar-ui-asteroid": "file:ui",
@@ -5443,7 +5443,7 @@
     },
     "ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.15.0-beta.15",
+      "version": "3.15.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid",
-  "version": "3.16.0-beta.7",
+  "version": "3.16.0-beta.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid",
-      "version": "3.16.0-beta.7",
+      "version": "3.16.0-beta.8",
       "license": "MIT",
       "devDependencies": {
         "@bildvitta/quasar-ui-asteroid": "file:ui",
@@ -5636,7 +5636,7 @@
     },
     "ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.6",
+      "version": "3.16.0-beta.7",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid",
-  "version": "3.16.0-beta.2",
+  "version": "3.16.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid",
-      "version": "3.16.0-beta.2",
+      "version": "3.16.0-beta.3",
       "license": "MIT",
       "devDependencies": {
         "@bildvitta/quasar-ui-asteroid": "file:ui",
@@ -5443,7 +5443,7 @@
     },
     "ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.1",
+      "version": "3.16.0-beta.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid",
-  "version": "3.16.0-beta.1",
+  "version": "3.16.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid",
-      "version": "3.16.0-beta.1",
+      "version": "3.16.0-beta.2",
       "license": "MIT",
       "devDependencies": {
         "@bildvitta/quasar-ui-asteroid": "file:ui",
@@ -5443,7 +5443,7 @@
     },
     "ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.0",
+      "version": "3.16.0-beta.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid",
-  "version": "3.16.0-beta.8",
+  "version": "3.16.0-beta.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid",
-      "version": "3.16.0-beta.8",
+      "version": "3.16.0-beta.9",
       "license": "MIT",
       "devDependencies": {
         "@bildvitta/quasar-ui-asteroid": "file:ui",
@@ -5636,7 +5636,7 @@
     },
     "ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.7",
+      "version": "3.16.0-beta.8",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.5",
+  "version": "3.16.0-beta.6",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.3",
+  "version": "3.16.0-beta.4",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.6",
+  "version": "3.16.0-beta.7",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.4",
+  "version": "3.16.0-beta.5",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.8",
+  "version": "3.16.0-beta.9",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.0",
+  "version": "3.16.0-beta.1",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.7",
+  "version": "3.16.0-beta.8",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.9",
+  "version": "3.16.0-beta.10",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.2",
+  "version": "3.16.0-beta.3",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.1",
+  "version": "3.16.0-beta.2",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid",
   "description": "Asteroid",
-  "version": "3.15.0",
+  "version": "3.16.0-beta.0",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "scripts": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
-  "version": "3.16.0-beta.4",
+  "version": "3.16.0-beta.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.4",
+      "version": "3.16.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.16.0-beta.3",
       "license": "MIT",
       "dependencies": {
+        "@bildvitta/composables": "^1.0.0-beta.7",
         "@bildvitta/store-adapter": "^1.0.0",
         "autonumeric": "^4.9.0",
         "axios": "^1.4.0",
@@ -39,10 +40,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
-      "integrity": "sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==",
-      "dev": true,
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
+      "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -59,6 +59,17 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bildvitta/composables": {
+      "version": "1.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@bildvitta/composables/-/composables-1.0.0-beta.7.tgz",
+      "integrity": "sha512-LV7GL8w3PE1xYb/z52RoVZn1N+SS1pneqtiJDnMPquBKSBxYgFBoBr4/N4A4gLKIF3B/JRYmUbGLUYaRpL2PVg==",
+      "dependencies": {
+        "@vue/compiler-sfc": "^3.4.21",
+        "path": "^0.12.7",
+        "vue": "^3.4.21",
+        "vue-demi": "^0.14.7"
       }
     },
     "node_modules/@bildvitta/store-adapter": {
@@ -442,8 +453,7 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@microsoft/api-extractor": {
       "version": "7.36.0",
@@ -785,97 +795,103 @@
       "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
-      "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
-      "dev": true,
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.30.tgz",
+      "integrity": "sha512-ZL8y4Xxdh8O6PSwfdZ1IpQ24PjTAieOz3jXb/MDTfDtANcKBMxg1KLm6OX2jofsaQGYfIVzd3BAG22i56/cF1w==",
       "dependencies": {
-        "@babel/parser": "^7.21.3",
-        "@vue/shared": "3.3.4",
+        "@babel/parser": "^7.24.7",
+        "@vue/shared": "3.4.30",
+        "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
-      "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
-      "dev": true,
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.30.tgz",
+      "integrity": "sha512-+16Sd8lYr5j/owCbr9dowcNfrHd+pz+w2/b5Lt26Oz/kB90C9yNbxQ3bYOvt7rI2bxk0nqda39hVcwDFw85c2Q==",
       "dependencies": {
-        "@vue/compiler-core": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-core": "3.4.30",
+        "@vue/shared": "3.4.30"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz",
-      "integrity": "sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==",
-      "dev": true,
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.30.tgz",
+      "integrity": "sha512-8vElKklHn/UY8+FgUFlQrYAPbtiSB2zcgeRKW7HkpSRn/JjMRmZvuOtwDx036D1aqKNSTtXkWRfqx53Qb+HmMg==",
       "dependencies": {
-        "@babel/parser": "^7.20.15",
-        "@vue/compiler-core": "3.3.4",
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/compiler-ssr": "3.3.4",
-        "@vue/reactivity-transform": "3.3.4",
-        "@vue/shared": "3.3.4",
+        "@babel/parser": "^7.24.7",
+        "@vue/compiler-core": "3.4.30",
+        "@vue/compiler-dom": "3.4.30",
+        "@vue/compiler-ssr": "3.4.30",
+        "@vue/shared": "3.4.30",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.0",
-        "postcss": "^8.1.10",
-        "source-map-js": "^1.0.2"
+        "magic-string": "^0.30.10",
+        "postcss": "^8.4.38",
+        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@vue/compiler-sfc/node_modules/magic-string": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
-      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
-      "dev": true,
+      "version": "0.30.10",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
-      },
-      "engines": {
-        "node": ">=12"
+        "@jridgewell/sourcemap-codec": "^1.4.15"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz",
-      "integrity": "sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==",
-      "dev": true,
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.30.tgz",
+      "integrity": "sha512-ZJ56YZGXJDd6jky4mmM0rNaNP6kIbQu9LTKZDhcpddGe/3QIalB1WHHmZ6iZfFNyj5mSypTa4+qDJa5VIuxMSg==",
       "dependencies": {
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-dom": "3.4.30",
+        "@vue/shared": "3.4.30"
       }
     },
-    "node_modules/@vue/reactivity-transform": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.4.tgz",
-      "integrity": "sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==",
-      "dev": true,
+    "node_modules/@vue/reactivity": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.30.tgz",
+      "integrity": "sha512-bVJurnCe3LS0JII8PPoAA63Zd2MBzcKrEzwdQl92eHCcxtIbxD2fhNwJpa+KkM3Y/A4T5FUnmdhgKwOf6BfbcA==",
       "dependencies": {
-        "@babel/parser": "^7.20.15",
-        "@vue/compiler-core": "3.3.4",
-        "@vue/shared": "3.3.4",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.0"
+        "@vue/shared": "3.4.30"
       }
     },
-    "node_modules/@vue/reactivity-transform/node_modules/magic-string": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
-      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
-      "dev": true,
+    "node_modules/@vue/runtime-core": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.30.tgz",
+      "integrity": "sha512-qaFEbnNpGz+tlnkaualomogzN8vBLkgzK55uuWjYXbYn039eOBZrWxyXWq/7qh9Bz2FPifZqGjVDl/FXiq9L2g==",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
+        "@vue/reactivity": "3.4.30",
+        "@vue/shared": "3.4.30"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.30.tgz",
+      "integrity": "sha512-tV6B4YiZRj5QsaJgw2THCy5C1H+2UeywO9tqgWEc21tn85qHEERndHN/CxlyXvSBFrpmlexCIdnqPuR9RM9thw==",
+      "dependencies": {
+        "@vue/reactivity": "3.4.30",
+        "@vue/runtime-core": "3.4.30",
+        "@vue/shared": "3.4.30",
+        "csstype": "^3.1.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.30.tgz",
+      "integrity": "sha512-TBD3eqR1DeDc0cMrXS/vEs/PWzq1uXxnvjoqQuDGFIEHFIwuDTX/KWAQKIBjyMWLFHEeTDGYVsYci85z2UbTDg==",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.4.30",
+        "@vue/shared": "3.4.30"
       },
-      "engines": {
-        "node": ">=12"
+      "peerDependencies": {
+        "vue": "3.4.30"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
-      "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
-      "dev": true
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.30.tgz",
+      "integrity": "sha512-CLg+f8RQCHQnKvuHY9adMsMaQOcqclh6Z5V9TaoMgy0ut0tz848joZ7/CYFFyF/yZ5i2yaw7Fn498C+CNZVHIg=="
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -1182,6 +1198,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
     "node_modules/date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -1238,6 +1259,17 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.17.19",
@@ -1513,6 +1545,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -1779,9 +1816,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "funding": [
         {
           "type": "github",
@@ -1825,6 +1862,15 @@
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
       }
     },
     "node_modules/path-browserify": {
@@ -1890,9 +1936,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
       "funding": [
         {
           "type": "opencollective",
@@ -1908,9 +1954,9 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -1921,6 +1967,14 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -2188,9 +2242,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2404,6 +2458,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
     "node_modules/validator": {
       "version": "13.9.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
@@ -2479,6 +2541,51 @@
       },
       "peerDependencies": {
         "vite": ">=2.9.0"
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.30.tgz",
+      "integrity": "sha512-NcxtKCwkdf1zPsr7Y8+QlDBCGqxvjLXF2EX+yi76rV5rrz90Y6gK1cq0olIhdWGgrlhs9ElHuhi9t3+W5sG5Xw==",
+      "dependencies": {
+        "@vue/compiler-dom": "3.4.30",
+        "@vue/compiler-sfc": "3.4.30",
+        "@vue/runtime-dom": "3.4.30",
+        "@vue/server-renderer": "3.4.30",
+        "@vue/shared": "3.4.30"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-demi": {
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.8.tgz",
+      "integrity": "sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
       }
     },
     "node_modules/webworkify": {
@@ -2619,10 +2726,9 @@
   },
   "dependencies": {
     "@babel/parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
-      "integrity": "sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==",
-      "dev": true
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
+      "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw=="
     },
     "@babel/runtime": {
       "version": "7.22.5",
@@ -2630,6 +2736,17 @@
       "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
       "requires": {
         "regenerator-runtime": "^0.13.11"
+      }
+    },
+    "@bildvitta/composables": {
+      "version": "1.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@bildvitta/composables/-/composables-1.0.0-beta.7.tgz",
+      "integrity": "sha512-LV7GL8w3PE1xYb/z52RoVZn1N+SS1pneqtiJDnMPquBKSBxYgFBoBr4/N4A4gLKIF3B/JRYmUbGLUYaRpL2PVg==",
+      "requires": {
+        "@vue/compiler-sfc": "^3.4.21",
+        "path": "^0.12.7",
+        "vue": "^3.4.21",
+        "vue-demi": "^0.14.7"
       }
     },
     "@bildvitta/store-adapter": {
@@ -2812,8 +2929,7 @@
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "@microsoft/api-extractor": {
       "version": "7.36.0",
@@ -3066,95 +3182,102 @@
       "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
     },
     "@vue/compiler-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
-      "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
-      "dev": true,
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.30.tgz",
+      "integrity": "sha512-ZL8y4Xxdh8O6PSwfdZ1IpQ24PjTAieOz3jXb/MDTfDtANcKBMxg1KLm6OX2jofsaQGYfIVzd3BAG22i56/cF1w==",
       "requires": {
-        "@babel/parser": "^7.21.3",
-        "@vue/shared": "3.3.4",
+        "@babel/parser": "^7.24.7",
+        "@vue/shared": "3.4.30",
+        "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       }
     },
     "@vue/compiler-dom": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
-      "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
-      "dev": true,
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.30.tgz",
+      "integrity": "sha512-+16Sd8lYr5j/owCbr9dowcNfrHd+pz+w2/b5Lt26Oz/kB90C9yNbxQ3bYOvt7rI2bxk0nqda39hVcwDFw85c2Q==",
       "requires": {
-        "@vue/compiler-core": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-core": "3.4.30",
+        "@vue/shared": "3.4.30"
       }
     },
     "@vue/compiler-sfc": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz",
-      "integrity": "sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==",
-      "dev": true,
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.30.tgz",
+      "integrity": "sha512-8vElKklHn/UY8+FgUFlQrYAPbtiSB2zcgeRKW7HkpSRn/JjMRmZvuOtwDx036D1aqKNSTtXkWRfqx53Qb+HmMg==",
       "requires": {
-        "@babel/parser": "^7.20.15",
-        "@vue/compiler-core": "3.3.4",
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/compiler-ssr": "3.3.4",
-        "@vue/reactivity-transform": "3.3.4",
-        "@vue/shared": "3.3.4",
+        "@babel/parser": "^7.24.7",
+        "@vue/compiler-core": "3.4.30",
+        "@vue/compiler-dom": "3.4.30",
+        "@vue/compiler-ssr": "3.4.30",
+        "@vue/shared": "3.4.30",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.0",
-        "postcss": "^8.1.10",
-        "source-map-js": "^1.0.2"
+        "magic-string": "^0.30.10",
+        "postcss": "^8.4.38",
+        "source-map-js": "^1.2.0"
       },
       "dependencies": {
         "magic-string": {
-          "version": "0.30.0",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
-          "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
-          "dev": true,
+          "version": "0.30.10",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+          "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
           "requires": {
-            "@jridgewell/sourcemap-codec": "^1.4.13"
+            "@jridgewell/sourcemap-codec": "^1.4.15"
           }
         }
       }
     },
     "@vue/compiler-ssr": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz",
-      "integrity": "sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==",
-      "dev": true,
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.30.tgz",
+      "integrity": "sha512-ZJ56YZGXJDd6jky4mmM0rNaNP6kIbQu9LTKZDhcpddGe/3QIalB1WHHmZ6iZfFNyj5mSypTa4+qDJa5VIuxMSg==",
       "requires": {
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-dom": "3.4.30",
+        "@vue/shared": "3.4.30"
       }
     },
-    "@vue/reactivity-transform": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.4.tgz",
-      "integrity": "sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==",
-      "dev": true,
+    "@vue/reactivity": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.30.tgz",
+      "integrity": "sha512-bVJurnCe3LS0JII8PPoAA63Zd2MBzcKrEzwdQl92eHCcxtIbxD2fhNwJpa+KkM3Y/A4T5FUnmdhgKwOf6BfbcA==",
       "requires": {
-        "@babel/parser": "^7.20.15",
-        "@vue/compiler-core": "3.3.4",
-        "@vue/shared": "3.3.4",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.0"
-      },
-      "dependencies": {
-        "magic-string": {
-          "version": "0.30.0",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
-          "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
-          "dev": true,
-          "requires": {
-            "@jridgewell/sourcemap-codec": "^1.4.13"
-          }
-        }
+        "@vue/shared": "3.4.30"
+      }
+    },
+    "@vue/runtime-core": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.30.tgz",
+      "integrity": "sha512-qaFEbnNpGz+tlnkaualomogzN8vBLkgzK55uuWjYXbYn039eOBZrWxyXWq/7qh9Bz2FPifZqGjVDl/FXiq9L2g==",
+      "requires": {
+        "@vue/reactivity": "3.4.30",
+        "@vue/shared": "3.4.30"
+      }
+    },
+    "@vue/runtime-dom": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.30.tgz",
+      "integrity": "sha512-tV6B4YiZRj5QsaJgw2THCy5C1H+2UeywO9tqgWEc21tn85qHEERndHN/CxlyXvSBFrpmlexCIdnqPuR9RM9thw==",
+      "requires": {
+        "@vue/reactivity": "3.4.30",
+        "@vue/runtime-core": "3.4.30",
+        "@vue/shared": "3.4.30",
+        "csstype": "^3.1.3"
+      }
+    },
+    "@vue/server-renderer": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.30.tgz",
+      "integrity": "sha512-TBD3eqR1DeDc0cMrXS/vEs/PWzq1uXxnvjoqQuDGFIEHFIwuDTX/KWAQKIBjyMWLFHEeTDGYVsYci85z2UbTDg==",
+      "requires": {
+        "@vue/compiler-ssr": "3.4.30",
+        "@vue/shared": "3.4.30"
       }
     },
     "@vue/shared": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
-      "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
-      "dev": true
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.30.tgz",
+      "integrity": "sha512-CLg+f8RQCHQnKvuHY9adMsMaQOcqclh6Z5V9TaoMgy0ut0tz848joZ7/CYFFyF/yZ5i2yaw7Fn498C+CNZVHIg=="
     },
     "ajv": {
       "version": "6.12.6",
@@ -3348,6 +3471,11 @@
         "which": "^2.0.1"
       }
     },
+    "csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
     "date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -3386,6 +3514,11 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
     "esbuild": {
       "version": "0.17.19",
@@ -3584,6 +3717,11 @@
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
       "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw=="
     },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -3777,9 +3915,9 @@
       }
     },
     "nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
     },
     "node-releases": {
       "version": "2.0.12",
@@ -3803,6 +3941,15 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+    },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "requires": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
     },
     "path-browserify": {
       "version": "1.0.1",
@@ -3852,13 +3999,13 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "postcss": {
-      "version": "8.4.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
       "requires": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       }
     },
     "postcss-value-parser": {
@@ -3866,6 +4013,11 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "proxy-from-env": {
       "version": "1.1.0",
@@ -4039,9 +4191,9 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg=="
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -4179,6 +4331,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
     "validator": {
       "version": "13.9.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
@@ -4210,6 +4370,24 @@
         "kolorist": "^1.6.0",
         "ts-morph": "17.0.1"
       }
+    },
+    "vue": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.30.tgz",
+      "integrity": "sha512-NcxtKCwkdf1zPsr7Y8+QlDBCGqxvjLXF2EX+yi76rV5rrz90Y6gK1cq0olIhdWGgrlhs9ElHuhi9t3+W5sG5Xw==",
+      "requires": {
+        "@vue/compiler-dom": "3.4.30",
+        "@vue/compiler-sfc": "3.4.30",
+        "@vue/runtime-dom": "3.4.30",
+        "@vue/server-renderer": "3.4.30",
+        "@vue/shared": "3.4.30"
+      }
+    },
+    "vue-demi": {
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.8.tgz",
+      "integrity": "sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==",
+      "requires": {}
     },
     "webworkify": {
       "version": "1.5.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
-  "version": "3.16.0-beta.1",
+  "version": "3.16.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.1",
+      "version": "3.16.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/store-adapter": "^1.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
-  "version": "3.16.0-beta.6",
+  "version": "3.16.0-beta.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.6",
+      "version": "3.16.0-beta.7",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
-  "version": "3.16.0-beta.0",
+  "version": "3.16.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.0",
+      "version": "3.16.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/store-adapter": "^1.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
-  "version": "3.16.0-beta.7",
+  "version": "3.16.0-beta.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.7",
+      "version": "3.16.0-beta.8",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
-  "version": "3.16.0-beta.2",
+  "version": "3.16.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.2",
+      "version": "3.16.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/store-adapter": "^1.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
-  "version": "3.15.0",
+  "version": "3.16.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.15.0",
+      "version": "3.16.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/store-adapter": "^1.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
-  "version": "3.16.0-beta.9",
+  "version": "3.16.0-beta.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.9",
+      "version": "3.16.0-beta.10",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
-  "version": "3.16.0-beta.5",
+  "version": "3.16.0-beta.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.5",
+      "version": "3.16.0-beta.6",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
-  "version": "3.16.0-beta.3",
+  "version": "3.16.0-beta.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.3",
+      "version": "3.16.0-beta.4",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
-  "version": "3.16.0-beta.8",
+  "version": "3.16.0-beta.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.16.0-beta.8",
+      "version": "3.16.0-beta.9",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.8",
+  "version": "3.16.0-beta.9",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "dist/asteroid.cjs.min.js",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.7",
+  "version": "3.16.0-beta.8",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "dist/asteroid.cjs.min.js",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.1",
+  "version": "3.16.0-beta.2",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "dist/asteroid.cjs.min.js",

--- a/ui/package.json
+++ b/ui/package.json
@@ -43,6 +43,7 @@
     "sass": "^1.62.1"
   },
   "dependencies": {
+    "@bildvitta/composables": "^1.0.0-beta.7",
     "@bildvitta/store-adapter": "^1.0.0",
     "autonumeric": "^4.9.0",
     "axios": "^1.4.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.3",
+  "version": "3.16.0-beta.4",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "dist/asteroid.cjs.min.js",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.6",
+  "version": "3.16.0-beta.7",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "dist/asteroid.cjs.min.js",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.2",
+  "version": "3.16.0-beta.3",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "dist/asteroid.cjs.min.js",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.9",
+  "version": "3.16.0-beta.10",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "dist/asteroid.cjs.min.js",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.4",
+  "version": "3.16.0-beta.5",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "dist/asteroid.cjs.min.js",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
   "description": "Asteroid",
-  "version": "3.15.0",
+  "version": "3.16.0-beta.0",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "dist/asteroid.cjs.min.js",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.0",
+  "version": "3.16.0-beta.1",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "dist/asteroid.cjs.min.js",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
   "description": "Asteroid",
-  "version": "3.16.0-beta.5",
+  "version": "3.16.0-beta.6",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "dist/asteroid.cjs.min.js",

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -3,7 +3,7 @@
     <qas-btn-dropdown v-bind="btnDropdownProps">
       <q-list data-cy="actions-menu-list">
         <slot v-for="(item, key) in formattedList.dropdownList" :item="item" :name="key">
-          <q-item v-bind="getItemProps(item)" :key="key" clickable data-cy="actions-menu-list-item" @click="setClickHandler(item)">
+          <q-item v-bind="getItemProps(item)" :key="key" active-class="primary" clickable data-cy="actions-menu-list-item" @click="setClickHandler(item)">
             <q-item-section avatar>
               <q-icon :name="item.icon" />
             </q-item-section>
@@ -240,10 +240,11 @@ const { showTooltip, tooltipLabels } = useTooltips({ formattedList, fullList, pr
 
 // functions
 function getItemProps (item) {
-  const { disable, props: itemProps } = item
+  const { disable, props: itemProps, to } = item
 
   return {
     disable,
+    to,
     ...itemProps
   }
 }

--- a/ui/src/components/actions/QasActions.vue
+++ b/ui/src/components/actions/QasActions.vue
@@ -1,5 +1,9 @@
 <template>
   <div class="q-mt-sm" :class="classes">
+    <div v-if="hasTertiarySlot" :class="columnClasses">
+      <slot name="tertiary" />
+    </div>
+
     <div v-if="hasSecondarySlot" :class="columnClasses">
       <slot name="secondary" />
     </div>
@@ -52,6 +56,8 @@ const classes = computed(() => {
   const isSmallOrFullWidth = screen.isSmall || props.useFullWidth
 
   return [
+    'items-center',
+
     // alinhamento
     `justify-${props.align}`,
 
@@ -71,4 +77,5 @@ const columnClasses = computed(() => {
 
 const hasPrimarySlot = computed(() => !!slots.primary)
 const hasSecondarySlot = computed(() => !!slots.secondary)
+const hasTertiarySlot = computed(() => !!slots.tertiary)
 </script>

--- a/ui/src/components/app-menu/QasAppMenu.vue
+++ b/ui/src/components/app-menu/QasAppMenu.vue
@@ -30,7 +30,7 @@
           </div>
 
           <!-- List -->
-          <q-list v-if="props.items.length" class="q-mt-xl qas-app-menu__menu text-grey-10">
+          <q-list v-if="props.items.length" class="q-mt-xl qas-app-menu__menu text-grey-10" :class="menuClasses">
             <template v-for="(menuItem, index) in props.items">
               <div v-if="hasChildren(menuItem)" :key="`children-${index}`" class="qas-app-menu__content" :class="classes.content">
                 <q-item class="ellipsis items-center q-py-none qas-app-menu__item qas-app-menu__item--label-mini text-weight-bold">
@@ -75,9 +75,30 @@
           </q-list>
         </div>
 
-        <!-- User -->
-        <div v-if="showAppUser" class="full-width q-pb-lg q-px-lg">
-          <qas-app-user v-bind="defaultAppUserProps" />
+        <div v-if="showAppUser">
+          <!-- Chat Ajuda -->
+          <q-list v-if="helpChatLink" class="q-mt-xl">
+            <q-item class="q-mb-md text-primary" clickable>
+              <q-item-section avatar>
+                <q-icon name="sym_r_chat" />
+              </q-item-section>
+
+              <q-item-section>
+                <q-item-label>
+                  <div class="ellipsis text-subtitle2">
+                    Solicitar ajuda
+                  </div>
+                </q-item-label>
+              </q-item-section>
+
+              <pv-app-menu-help-chat :link="props.helpChatLink" :mini-brand="props.miniBrand" @update:model-value="setHasOpenedHelpChat" />
+            </q-item>
+          </q-list>
+
+          <!-- User -->
+          <div class="full-width q-pb-lg q-px-lg">
+            <qas-app-user v-bind="defaultAppUserProps" />
+          </div>
         </div>
       </div>
     </q-drawer>
@@ -85,6 +106,7 @@
 </template>
 
 <script setup>
+import PvAppMenuHelpChat from './private/PvAppMenuHelpChat.vue'
 import PvAppMenuDropdown from './private/PvAppMenuDropdown.vue'
 import QasAppUser from '../app-user/QasAppUser.vue'
 
@@ -112,6 +134,11 @@ const props = defineProps({
     default: '',
     required: true,
     type: String
+  },
+
+  helpChatLink: {
+    type: String,
+    default: ''
   },
 
   items: {
@@ -154,6 +181,7 @@ const router = useRouter()
 const rootRoute = router.hasRoute('Root') ? { name: 'Root' } : { path: '/' }
 
 const hasOpenedMenu = ref(false)
+const hasOpenedHelpChat = ref(false)
 const isMini = ref(screen.isLarge)
 const reRenderCount = ref(0)
 
@@ -180,8 +208,13 @@ const model = computed({
 
 const behavior = computed(() => screen.untilLarge ? 'mobile' : 'desktop')
 const drawerWidth = computed(() => screen.untilLarge ? 320 : 280)
-const isMiniMode = computed(() => screen.isLarge && isMini.value && !hasOpenedMenu.value)
 const normalizedBrand = computed(() => isMini.value ? props.miniBrand : props.brand)
+
+const isMiniMode = computed(() => {
+  return screen.isLarge && isMini.value && !hasOpenedMenu.value && !hasOpenedHelpChat.value
+})
+
+const menuClasses = computed(() => ({ 'qas-app-menu__menu--spaced': !props.helpChatLink }))
 
 const classes = computed(() => {
   return {
@@ -262,6 +295,10 @@ function onMouseEvent ({ type }) {
 function setHasOpenedMenu (value) {
   hasOpenedMenu.value = value
 }
+
+function setHasOpenedHelpChat (value) {
+  hasOpenedHelpChat.value = value
+}
 </script>
 
 <style lang="scss" scoped>
@@ -335,8 +372,15 @@ function setHasOpenedMenu (value) {
   // Media: untilLarge
   @media (min-width: $breakpoint-sm-max) {
     &__menu {
+      overflow-x: hidden;
+
+      &:not(&--spaced) {
+        max-height: calc(100vh - 365px);
+      }
+    }
+
+    &__menu--spaced {
       max-height: calc(100vh - 310px);
-      overflow-x: auto;
     }
   }
 }

--- a/ui/src/components/app-menu/QasAppMenu.yml
+++ b/ui/src/components/app-menu/QasAppMenu.yml
@@ -15,6 +15,11 @@ props:
     type: String
     required: true
 
+  help-chat-link:
+    desc: Link para ser usado no iframe do chat, caso não passe nada, o chat não será exibido.
+    type: String
+    default: ''
+
   items:
     desc: Itens do menu.
     type: Array

--- a/ui/src/components/app-menu/private/PvAppMenuHelpChat.vue
+++ b/ui/src/components/app-menu/private/PvAppMenuHelpChat.vue
@@ -106,10 +106,12 @@ onUnmounted(() => {
  * Define o estilo do iframe de acordo com a posição do "chatContent" dentro
  * do QMenu.
  */
-function setIframeStyle () {
+async function setIframeStyle () {
+  await nextTick()
+
   const iframe = getIframe()
 
-  if (!iframe) return
+  if (!iframe || !chatContent.value) return
 
   const { bottom, left, top } = chatContent.value.getBoundingClientRect()
 

--- a/ui/src/components/app-menu/private/PvAppMenuHelpChat.vue
+++ b/ui/src/components/app-menu/private/PvAppMenuHelpChat.vue
@@ -1,0 +1,220 @@
+<!-- O chat em si é renderizado em um iframe, o que QMenu, toda vez que fecha se auto destroy, então não podemos usar o
+iframe dentro do QMenu, pois toda vez que um iframe é destruído ele perde o seu estado, e teria que iniciar um novo chat,
+pra isto é criado um iframe no body, e posicionado com JS + CSS para ficar sobre o QMenu. -->
+
+<template>
+  <q-menu class="pv-app-menu-help-chat shadow-2" v-bind="menuProps">
+    <header class="q-pa-md">
+      <q-img class="q-mb-md" :src="props.miniBrand" width="36px" />
+
+      <h3 class="text-h3">
+        Bem-vindo!
+      </h3>
+
+      <div class="text-body1">
+        Deixe a sua mensagem para o suporte técnico da Nave.
+      </div>
+    </header>
+
+    <qas-box class="full-width pv-app-menu-help-chat__content relative-position" :class="boxClasses">
+      <div v-if="showIframe" ref="chatContent" class="full-width" />
+
+      <div v-else class="full-width self-end">
+        <div class="q-mb-sm text-subtitle2">
+          Estamos conectados
+        </div>
+
+        <div class="text-body2">
+          Normalmente responde em alguns minutos
+        </div>
+
+        <qas-btn class="full-width q-mt-lg" label="Iniciar conversa" variant="primary" @click="initializeChat" />
+      </div>
+
+      <q-inner-loading :showing="showInnerLoading">
+        <q-spinner color="grey" size="2rem" />
+      </q-inner-loading>
+    </qas-box>
+  </q-menu>
+</template>
+
+<script setup>
+import { useScreen } from '../../../composables'
+
+import { onMounted, onUnmounted, ref, nextTick, computed } from 'vue'
+
+defineOptions({ name: 'PvAppMenuHelpChat' })
+
+const props = defineProps({
+  link: {
+    type: String,
+    default: ''
+  },
+
+  miniBrand: {
+    type: String,
+    default: ''
+  }
+})
+
+const screen = useScreen()
+
+// refs
+const chatContent = ref(null)
+const isOpened = ref(false)
+const showIframe = ref(false)
+const showInnerLoading = ref(false)
+
+// computed
+const boxClasses = computed(() => {
+  return {
+    flex: !showIframe.value,
+    'pv-app-menu-help-chat__content--is-opened': showIframe.value
+  }
+})
+
+const menuProps = computed(() => {
+  return {
+    anchor: screen.isSmall ? 'top middle' : 'top right',
+    maxWidth: screen.isSmall ? '300px' : '400px',
+    self: screen.isSmall ? 'bottom middle' : 'top left',
+    touchPosition: !screen.isSmall,
+
+    onBeforeHide: hideIframe,
+    onShow
+  }
+})
+
+// hooks
+
+/**
+ * Toda vez que a prop "behavior" do componente "QasAppMenu" é alterada, este componente
+ * é renderizado novamente, então é necessário esconder o iframe caso ele ja esteja aberto.
+ */
+onMounted(hideIframe)
+
+onUnmounted(() => {
+  if (showIframe.value) {
+    window.removeEventListener('scroll', onScroll)
+    window.removeEventListener('resize', onScroll)
+  }
+})
+
+// functions
+
+/**
+ * Define o estilo do iframe de acordo com a posição do "chatContent" dentro
+ * do QMenu.
+ */
+function setIframeStyle () {
+  const iframe = getIframe()
+
+  if (!iframe) return
+
+  const { bottom, left, top } = chatContent.value.getBoundingClientRect()
+
+  const width = chatContent.value.offsetWidth
+
+  const styles = {
+    display: 'block',
+    top: `${bottom + window.scrollY}px`,
+    left: `${left + window.scrollX}px`,
+    bottom: `${top}px`,
+    width: `${width}px`
+  }
+
+  Object.assign(iframe.style, styles)
+}
+
+function onShow () {
+  isOpened.value = true
+
+  if (showIframe.value) setIframeStyle()
+}
+
+function hideIframe () {
+  isOpened.value = false
+
+  const iframe = getIframe()
+
+  if (!iframe) return
+
+  iframe.style.display = 'none'
+}
+
+function onScroll () {
+  if (isOpened.value) setIframeStyle()
+}
+
+function createIframe () {
+  const iframe = document.createElement('iframe')
+
+  iframe.id = 'chat-iframe'
+  iframe.className = 'pv-app-menu-help-chat__iframe'
+  iframe.style.display = 'none'
+  iframe.src = props.link
+
+  document.body.appendChild(iframe)
+}
+
+function getIframe () {
+  return document.getElementById('chat-iframe')
+}
+
+function initializeChat () {
+  createIframe()
+
+  window.addEventListener('scroll', onScroll)
+  window.addEventListener('resize', onScroll)
+
+  toggleIframe()
+}
+
+function toggleIframe () {
+  showIframe.value = !showIframe.value
+
+  showInnerLoading.value = true
+
+  /**
+   * É adicionado um loading por 3 motivos:
+   * - o iframe demora um pouco para ser carregado
+   * - o loading é um feedback visual para o usuário enquanto o iframe é carregado
+   * - não é possível adicionar uma animação aparecendo o iframe, então desta
+   * forma fica suavizado
+   */
+  setTimeout(async () => {
+    showInnerLoading.value = false
+
+    await nextTick()
+
+    onShow()
+  }, 2000)
+}
+</script>
+
+<style lang="scss">
+.pv-app-menu-help-chat {
+  overflow-y: hidden;
+
+  &__content {
+    height: 260px;
+    background-color: var(--qas-background-color) !important;
+  }
+
+  &__iframe {
+    border: 0;
+    border-radius: var(--qas-generic-border-radius);
+    outline: none;
+    position: absolute;
+    height: calc(260px - calc(var(--qas-spacing-md) * 2));
+    z-index: 9999;
+  }
+
+  // Media: isSmall
+  @media (max-width: $breakpoint-sm-min) {
+    &__content--is-opened {
+      padding: var(--qas-spacing-sm) !important;
+    }
+  }
+}
+</style>

--- a/ui/src/components/btn-dropdown/QasBtnDropdown.vue
+++ b/ui/src/components/btn-dropdown/QasBtnDropdown.vue
@@ -2,8 +2,8 @@
   <div class="qas-btn-dropdown" :class="classes.parent">
     <div v-if="hasButtons" :class="classes.list">
       <div v-for="(buttonProps, key, index) in props.buttonsPropsList" :key="key">
-        <div class="flex">
-          <qas-btn :disable="props.disable" v-bind="buttonProps" variant="tertiary" @click="onClick">
+        <div class="flex no-wrap">
+          <qas-btn :disable="props.disable" v-bind="buttonProps" no-wrap variant="tertiary" @click="onClick">
             <q-menu v-if="hasMenuOnLeftSide" v-model="isMenuOpened" anchor="bottom right" auto-close self="top right" @update:model-value="onUpdateMenuValue">
               <div :class="classes.menuContent">
                 <slot />
@@ -91,7 +91,7 @@ const classes = computed(() => {
     },
 
     list: {
-      flex: !isSingleButton.value
+      'flex no-wrap': !isSingleButton.value
     }
   }
 })

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -1,7 +1,7 @@
 <template>
   <div ref="expansionItem" class="full-width qas-expansion-item" :class="errorClasses" v-bind="expansionProps.parent">
     <component :is="component.is" class="qas-expansion-item__box">
-      <q-expansion-item header-class="text-bold q-mt-sm q-pa-none" :label="props.label" v-bind="expansionProps.item">
+      <q-expansion-item header-class="text-bold q-mt-sm q-pa-none qas-expansion-item__header" :label="props.label" v-bind="expansionProps.item">
         <template #header>
           <slot name="header">
             <div class="full-width">
@@ -26,7 +26,7 @@
           </slot>
         </template>
 
-        <q-separator v-if="!isNestedExpansionItem" class="q-my-md" />
+        <q-separator v-if="hasHeaderSeparator" class="q-my-md" />
 
         <div :class="contentClasses">
           <slot name="content">
@@ -77,6 +77,11 @@ const props = defineProps({
   gridGeneratorProps: {
     type: Object,
     default: () => ({})
+  },
+
+  useHeaderSeparator: {
+    type: Boolean,
+    default: undefined
   }
 })
 
@@ -105,8 +110,25 @@ const hasGridGenerator = computed(() => !!Object.keys(props.gridGeneratorProps).
 const hasBottomSeparator = computed(() => isNestedExpansionItem && hasNextSibling.value)
 const hasHeaderBottom = computed(() => !!slots['header-bottom'])
 
+/**
+ * Verifica se o componente deve adicionar um separador no header.
+ *
+ * - Se a propriedade useHeaderSeparator for true, retorna separador.
+ * - Se a propriedade useHeaderSeparator for undefined, retorna separador apenas se não for um componente aninhado.
+ * - Se a propriedade useHeaderSeparator for false, não retorna separador.
+ */
+const hasHeaderSeparator = computed(() => {
+  return typeof props.useHeaderSeparator === 'undefined' ? !isNestedExpansionItem : props.useHeaderSeparator
+})
+
 const errorClasses = computed(() => ({ 'qas-expansion-item--error': hasError.value }))
-const contentClasses = computed(() => ({ 'q-mt-sm': isNestedExpansionItem }))
+
+const contentClasses = computed(() => {
+  return {
+    'q-mt-sm': isNestedExpansionItem,
+    'q-mt-md': !isNestedExpansionItem && !props.useHeaderSeparator
+  }
+})
 
 const expansionProps = computed(() => {
   const {
@@ -154,6 +176,12 @@ function setHasNextSibling (value) {
 <style lang="scss">
 .qas-expansion-item {
   $root: &;
+
+  // em alguns casos quando usado com grid, o espaçamento afetava o header, com z-index o problema é resolvido
+  &__header {
+    position: relative;
+    z-index: 1;
+  }
 
   &--error {
     #{$root}__box {

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -28,9 +28,11 @@
 
         <q-separator v-if="!isNestedExpansionItem" class="q-my-md" />
 
-        <slot name="content">
-          <qas-grid-generator v-if="hasGridGenerator" v-bind="gridGeneratorProps" use-inline />
-        </slot>
+        <div :class="contentClasses">
+          <slot name="content">
+            <qas-grid-generator v-if="hasGridGenerator" use-inline v-bind="gridGeneratorProps" />
+          </slot>
+        </div>
 
         <q-separator v-if="hasBottomSeparator" class="q-mt-md" />
       </q-expansion-item>
@@ -99,11 +101,12 @@ const component = {
 
 // computed
 const hasError = computed(() => props.error || !!props.errorMessage)
-const errorClasses = computed(() => ({ 'qas-expansion-item--error': hasError.value }))
-
 const hasGridGenerator = computed(() => !!Object.keys(props.gridGeneratorProps).length)
 const hasBottomSeparator = computed(() => isNestedExpansionItem && hasNextSibling.value)
 const hasHeaderBottom = computed(() => !!slots['header-bottom'])
+
+const errorClasses = computed(() => ({ 'qas-expansion-item--error': hasError.value }))
+const contentClasses = computed(() => ({ 'q-mt-sm': isNestedExpansionItem }))
 
 const expansionProps = computed(() => {
   const {
@@ -141,7 +144,7 @@ const expansionProps = computed(() => {
 function setHasNextSibling (value) {
   if (!isNestedExpansionItem) return
 
-  const hasTextContentSibling = !!expansionItem.value.nextSibling.textContent?.trim?.()
+  const hasTextContentSibling = !!expansionItem.value.nextSibling?.textContent?.trim?.()
   const hasElementSibling = !!expansionItem.value.nextElementSibling
 
   hasNextSibling.value = hasElementSibling || hasTextContentSibling

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -1,7 +1,7 @@
 <template>
-  <div ref="expansionItem" class="qas-expansion-item" :class="errorClasses">
+  <div ref="expansionItem" class="full-width qas-expansion-item" :class="errorClasses" v-bind="expansionProps.parent">
     <component :is="component.is" class="qas-expansion-item__box">
-      <q-expansion-item header-class="text-bold q-mt-sm q-pa-none" :label="props.label">
+      <q-expansion-item header-class="text-bold q-mt-sm q-pa-none" :label="props.label" v-bind="expansionProps.item">
         <template #header>
           <slot name="header">
             <div class="full-width">
@@ -45,9 +45,12 @@
 <script setup>
 import QasBox from '../box/QasBox.vue'
 
-import { computed, provide, inject, onMounted, ref } from 'vue'
+import { computed, provide, inject, onMounted, ref, useAttrs } from 'vue'
 
-defineOptions({ name: 'QasExpansionItem' })
+defineOptions({
+  name: 'QasExpansionItem',
+  inheritAttrs: false
+})
 
 const props = defineProps({
   badges: {
@@ -75,6 +78,8 @@ const props = defineProps({
   }
 })
 
+const attrs = useAttrs()
+
 provide('isExpansionItem', true)
 
 // slots
@@ -100,6 +105,33 @@ const hasGridGenerator = computed(() => !!Object.keys(props.gridGeneratorProps).
 const hasBottomSeparator = computed(() => isNestedExpansionItem && hasNextSibling.value)
 const hasHeaderBottom = computed(() => !!slots['header-bottom'])
 
+const expansionProps = computed(() => {
+  const {
+    'onUpdate:modelValue': onUpdateModelValue,
+    onShow,
+    onBeforeShow,
+    onBeforeHide,
+    onAfterShow,
+    onAfterHide,
+    ...propsPayload
+  } = attrs
+
+  return {
+    parent: {
+      ...propsPayload
+    },
+
+    item: {
+      onUpdateModelValue,
+      onShow,
+      onBeforeShow,
+      onBeforeHide,
+      onAfterShow,
+      onAfterHide
+    }
+  }
+})
+
 // functions
 
 /**
@@ -119,10 +151,6 @@ function setHasNextSibling (value) {
 <style lang="scss">
 .qas-expansion-item {
   $root: &;
-
-  & + & {
-    margin-top: var(--qas-spacing-lg);
-  }
 
   &--error {
     #{$root}__box {

--- a/ui/src/components/expansion-item/QasExpansionItem.yml
+++ b/ui/src/components/expansion-item/QasExpansionItem.yml
@@ -24,6 +24,11 @@ props:
     desc: Propriedades que serão repassadas para o QasGridGenerator.
     type: Object
 
+  use-header-separator:
+    desc: Propriedade para forçar o QSeparator no header.
+    type: Boolean
+    default: undefined
+
 slots:
   header:
     desc: 'Slot para substituir o conteúdo do header'

--- a/ui/src/components/expansion-item/QasExpansionItem.yml
+++ b/ui/src/components/expansion-item/QasExpansionItem.yml
@@ -28,6 +28,9 @@ slots:
   header:
     desc: 'Slot para substituir o conteúdo do header'
 
+  header-bottom:
+    desc: 'Slot para acessar o conteúdo que fica abaixo do header.'
+
   label:
     desc: 'Slot para substituir o conteúdo da label do header.'
 

--- a/ui/src/components/form-generator/QasFormGenerator.yml
+++ b/ui/src/components/form-generator/QasFormGenerator.yml
@@ -10,6 +10,10 @@ props:
     type: [Array, String, Object]
     examples: ["[{ sm: 6, md: 12 }]", "{ name: { sm: 6, md: 12 } }", "12", "{ sm: 6, md: 12 }"]
 
+  common-columns:
+    desc: Usado quando precisa passar o mesmo valor para todas as colunas, sem especificar cada uma, ela é feita como um merge com a prop "columns".
+    examples: ["{ name: { sm: 6, md: 12 } }", "12"]
+
   disable:
     desc: Deixa os campos desabilitados enviando a prop "disable" para cada campo.
     default: "false"
@@ -62,9 +66,6 @@ props:
     desc: Altera ordem dos campos.
     default: []
     type: Array
-
-  use-common-columns:
-    desc: Utilizado quando passar a estrutura da prop "columns" sendo um objeto onde seus breakpoints serão replicados para todos fields.
 
 slots:
   'field-[nome-da-chave]':

--- a/ui/src/components/form-view/QasFormView.vue
+++ b/ui/src/components/form-view/QasFormView.vue
@@ -5,7 +5,9 @@
     </header>
 
     <q-form ref="form" v-bind="defaultFormProps">
-      <slot />
+      <slot v-if="mx_canShowFetchErrorSlot" name="fetch-error" />
+
+      <slot v-else />
 
       <slot v-if="useActions" name="actions">
         <qas-actions>

--- a/ui/src/components/form-view/QasFormView.yml
+++ b/ui/src/components/form-view/QasFormView.yml
@@ -155,6 +155,9 @@ slots:
   default:
     desc: Slot para ter o conteúdo principal (dentro do main).
 
+  fetch-error:
+    desc: Slot disponibilizado em caso de fetchError.
+
   footer:
     desc: Slot para acessar o footer.
 

--- a/ui/src/components/grid-generator/QasGridGenerator.vue
+++ b/ui/src/components/grid-generator/QasGridGenerator.vue
@@ -70,7 +70,7 @@ const props = defineProps({
 })
 
 // composables
-const { classes: useGeneratorClasses, getFieldClass } = useGenerator({ props })
+const { classes, getFieldClass } = useGenerator({ props })
 
 // computed
 const hasResult = computed(() => Object.keys(props.result).length)
@@ -95,12 +95,6 @@ const headerClass = computed(() => {
       'text-bold': screen.isSmall || !props.useInline
     }
   ]
-})
-
-const classes = computed(() => {
-  if (props.useInline) return 'row q-col-gutter-md'
-
-  return useGeneratorClasses.value
 })
 
 const fieldsByResult = ref({})
@@ -163,9 +157,7 @@ function setFieldsByResult () {
 }
 
 function getContainerClass ({ key }) {
-  if (props.useInline) {
-    return 'row justify-between col-12'
-  }
+  if (props.useInline) return 'row justify-between col-12'
 
   return getFieldClass({ index: key, isGridGenerator: true })
 }

--- a/ui/src/components/grid-generator/QasGridGenerator.yml
+++ b/ui/src/components/grid-generator/QasGridGenerator.yml
@@ -10,6 +10,10 @@ props:
     type: [Array, String, Object]
     examples: ["{ name: { sm: 6, md: 12 } }", "[{ sm: 6, md: 12 }]", "{ sm: 6, md: 12 }"]
 
+  common-columns:
+    desc: Usado quando precisa passar o mesmo valor para todas as colunas, sem especificar cada uma, ela é feita como um merge com a prop "columns".
+    examples: ["{ name: { sm: 6, md: 12 } }", "12"]
+
   content-class:
     desc: Classe de cada "div" pai referente ao resultado.
     default: ''
@@ -56,9 +60,6 @@ props:
   use-inline:
     desc: Adiciona a disposição dos campos por linha, ou seja, header e content ocupando a linha toda.
     type: Boolean
-
-  use-common-columns:
-    desc: Usado quando precisa passar a prop "columns" como objeto sendo que será o valor comum para todos fields
 
 slots:
   content:

--- a/ui/src/components/header-actions/QasHeaderActions.vue
+++ b/ui/src/components/header-actions/QasHeaderActions.vue
@@ -6,7 +6,7 @@
       </slot>
     </div>
 
-    <div v-if="hasRightSide" class="col-3 col-md-3 col-sm-4 justify-end row">
+    <div v-if="hasRightSide" class="justify-end row">
       <slot name="right">
         <qas-actions-menu v-if="hasDefaultActionsMenu" v-bind="props.actionsMenuProps" />
 
@@ -59,7 +59,11 @@ const slots = useSlots()
 // computed
 const containerClass = computed(() => `items-${props.alignColumns} q-mb-${props.spacing}`)
 
-const leftClass = computed(() => hasRightSide.value ? 'col-9 col-md-9 col-sm-8' : 'col-12')
+const leftClass = computed(() => {
+  return {
+    'col-12': !hasRightSide.value
+  }
+})
 
 const hasDefaultButton = computed(() => !!Object.keys(props.buttonProps).length)
 const hasDefaultActionsMenu = computed(() => !!Object.keys(props.actionsMenuProps).length)

--- a/ui/src/components/header-actions/QasHeaderActions.vue
+++ b/ui/src/components/header-actions/QasHeaderActions.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="justify-between no-wrap q-col-gutter-x-md q-mb-xl row text-body1 text-grey-8" :class="containerClass">
+  <div class="justify-between no-wrap q-col-gutter-x-md row text-body1 text-grey-8" :class="containerClass">
     <div :class="leftClass">
       <slot name="left">
         {{ props.text }}
@@ -18,6 +18,8 @@
 
 <script setup>
 import { FlexAlign } from '../../enums/Align'
+import { Spacing } from '../../enums/Spacing'
+import { gutterValidator } from '../../helpers/private/gutter-validator'
 
 import { computed, useSlots } from 'vue'
 
@@ -43,13 +45,20 @@ const props = defineProps({
   text: {
     type: String,
     default: ''
+  },
+
+  spacing: {
+    default: Spacing.Xl,
+    type: String,
+    validator: gutterValidator
   }
 })
 
 const slots = useSlots()
 
 // computed
-const containerClass = computed(() => `items-${props.alignColumns}`)
+const containerClass = computed(() => `items-${props.alignColumns} q-mb-${props.spacing}`)
+
 const leftClass = computed(() => hasRightSide.value ? 'col-9 col-md-9 col-sm-8' : 'col-12')
 
 const hasDefaultButton = computed(() => !!Object.keys(props.buttonProps).length)

--- a/ui/src/components/header-actions/QasHeaderActions.yml
+++ b/ui/src/components/header-actions/QasHeaderActions.yml
@@ -24,6 +24,12 @@ props:
     desc: Descrição da seção a esquerda.
     type: String
 
+  spacing:
+    desc: Espaçamento entre o componente e o conteúdo abaixo.
+    default: xl
+    type: String
+    examples: [none, xs, sm, md, lg, xl, '2xl', '3xl', '4xl', '5xl']
+
 slots:
   left:
     desc: slot para acessar seção da esquerda (descrição).

--- a/ui/src/components/label/QasLabel.vue
+++ b/ui/src/components/label/QasLabel.vue
@@ -1,7 +1,7 @@
 <template>
-  <div :class="classes">
+  <component :is="props.typography" :class="classes">
     <slot :label-with-suffix="formattedLabel">{{ formattedLabel }}</slot>
-  </div>
+  </component>
 </template>
 
 <script setup>

--- a/ui/src/components/list-view/QasListView.vue
+++ b/ui/src/components/list-view/QasListView.vue
@@ -15,7 +15,9 @@
         </div>
 
         <div v-else-if="!mx_isFetching">
-          <slot name="empty-results">
+          <slot v-if="mx_canShowFetchErrorSlot" name="fetch-error" />
+
+          <slot v-else name="empty-results">
             <qas-empty-result-text />
           </slot>
         </div>

--- a/ui/src/components/list-view/QasListView.yml
+++ b/ui/src/components/list-view/QasListView.yml
@@ -97,6 +97,9 @@ slots:
   empty-results:
     desc: 'Slot acessar quando a listagem está vazia.'
 
+  fetch-error:
+    desc: Slot disponibilizado em caso de fetchError.
+
   filter:
     desc: 'Slot para acessar o filtro.'
 

--- a/ui/src/components/select/QasSelect.vue
+++ b/ui/src/components/select/QasSelect.vue
@@ -194,7 +194,7 @@ export default {
 
         if (this.fuse || this.hasFuse) this.setFuse()
 
-        this.mx_filteredOptions = this.options
+        this.mx_filteredOptions = [...this.options]
       },
 
       immediate: true

--- a/ui/src/components/single-view/QasSingleView.vue
+++ b/ui/src/components/single-view/QasSingleView.vue
@@ -8,7 +8,11 @@
       <slot />
     </template>
 
-    <qas-empty-result-text v-else-if="!viewState.fetching" class="q-my-xl" />
+    <div v-else-if="!viewState.fetching">
+      <slot v-if="canShowFetchErrorSlot" name="fetch-error" />
+
+      <qas-empty-result-text v-else class="q-my-xl" />
+    </div>
 
     <footer v-if="hasFooterSlot">
       <slot name="footer" />
@@ -71,6 +75,7 @@ const {
   componentClass,
   hasHeaderSlot,
   hasFooterSlot,
+  canShowFetchErrorSlot,
 
   // functions
   errorHandler,
@@ -94,7 +99,7 @@ const resultModel = computed(() => {
   return viewState.value.result || {}
 })
 
-const hasResult = computed(() => !!resultModel.value)
+const hasResult = computed(() => !!Object.keys(resultModel.value).length)
 
 // watch
 watch(() => route, (to, from) => {

--- a/ui/src/components/single-view/QasSingleView.vue
+++ b/ui/src/components/single-view/QasSingleView.vue
@@ -82,6 +82,9 @@ const {
   updateModels
 } = useView({ emit, props, slots, mode: 'single' })
 
+// Expose
+defineExpose({ fetchSingle, fetchHandler })
+
 // computed
 const id = computed(() => props.customId || route.params.id)
 

--- a/ui/src/components/single-view/QasSingleView.vue
+++ b/ui/src/components/single-view/QasSingleView.vue
@@ -4,14 +4,14 @@
       <slot name="header" />
     </header>
 
-    <template v-if="hasResult">
+    <slot v-if="canShowFetchErrorSlot" name="fetch-error" />
+
+    <template v-else-if="hasResult">
       <slot />
     </template>
 
     <div v-else-if="!viewState.fetching">
-      <slot v-if="canShowFetchErrorSlot" name="fetch-error" />
-
-      <qas-empty-result-text v-else class="q-my-xl" />
+      <qas-empty-result-text class="q-my-xl" />
     </div>
 
     <footer v-if="hasFooterSlot">
@@ -99,7 +99,7 @@ const resultModel = computed(() => {
   return viewState.value.result || {}
 })
 
-const hasResult = computed(() => !!Object.keys(resultModel.value).length)
+const hasResult = computed(() => !!resultModel.value)
 
 // watch
 watch(() => route, (to, from) => {

--- a/ui/src/components/single-view/QasSingleView.yml
+++ b/ui/src/components/single-view/QasSingleView.yml
@@ -71,6 +71,9 @@ slots:
   default:
     desc: 'Slot para ter o conteúdo principal (dentro do main).'
 
+  fetch-error:
+    desc: Slot disponibilizado em caso de fetchError.
+
   footer:
     desc: 'Slot para acessar o footer.'
 

--- a/ui/src/components/single-view/QasSingleView.yml
+++ b/ui/src/components/single-view/QasSingleView.yml
@@ -62,6 +62,11 @@ props:
     default: true
     type: Boolean
 
+  use-route:
+    desc: Controla se o componente usará internamente uma store do vuex/pinia ou se vai ser utilizado o axios diretamente.
+    default: true
+    type: Boolean
+
 slots:
   default:
     desc: 'Slot para ter o conteúdo principal (dentro do main).'

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -1,5 +1,5 @@
 <template>
-  <qas-box class="q-px-lg q-py-md">
+  <component :is="parentComponent.is" v-bind="parentComponent.props">
     <q-table ref="table" class="bg-white qas-table-generator text-grey-8" v-bind="attributes">
       <template v-for="(_, name) in slots" #[name]="context">
         <slot :name="name" v-bind="context" />
@@ -15,7 +15,7 @@
         </q-td>
       </template>
     </q-table>
-  </qas-box>
+  </component>
 </template>
 
 <script>
@@ -55,6 +55,11 @@ export default {
     emptyResultText: {
       default: '-',
       type: String
+    },
+
+    useBox: {
+      type: Boolean,
+      default: true
     },
 
     useScrollOnGrab: {
@@ -217,6 +222,15 @@ export default {
 
     hasScrollOnGrab () {
       return !!Object.keys(this.scrollOnGrab).length
+    },
+
+    parentComponent () {
+      return {
+        is: this.useBox ? 'qas-box' : 'div',
+        props: {
+          class: this.useBox ? 'q-px-lg q-py-md' : ''
+        }
+      }
     }
   },
 

--- a/ui/src/components/table-generator/QasTableGenerator.yml
+++ b/ui/src/components/table-generator/QasTableGenerator.yml
@@ -36,6 +36,11 @@ props:
     type: Function
     examples: ["(row) => ({ path: 'table-generator', params: { id: row.uuid } })"]
 
+  use-box:
+    desc: Controla se o componente vai usar QasBox ou div.
+    default: true
+    type: Boolean
+
   use-external-link:
     desc: Usado em conjunto com a prop "row-route-fn" quando há a necessidade da rota ser um link externo.
     default: false

--- a/ui/src/components/toggle-visibility/QasToggleVisibility.vue
+++ b/ui/src/components/toggle-visibility/QasToggleVisibility.vue
@@ -21,7 +21,7 @@
       <qas-btn
         class="q-ml-sm qas-toggle-visibility__button"
         :icon
-        @click="toggleVisibility"
+        @click.prevent.stop="toggleVisibility"
       />
     </div>
   </div>

--- a/ui/src/components/toggle-visibility/QasToggleVisibility.vue
+++ b/ui/src/components/toggle-visibility/QasToggleVisibility.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="qas-toggle-visibility">
+    <div class="items-center no-wrap row" :style>
+      <div class="ellipsis qas-toggle-visibility__content">
+        <div
+          v-if="isVisible"
+          class="ellipsis full-width"
+          :title="props.text"
+        >
+          <slot>
+            {{ props.text }}
+          </slot>
+        </div>
+
+        <q-separator
+          v-else
+          size="4px"
+        />
+      </div>
+
+      <qas-btn
+        class="q-ml-sm qas-toggle-visibility__button"
+        :icon
+        @click="toggleVisibility"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { useToggleVisibility } from '../../composables/private'
+
+import { uid } from 'quasar'
+import { computed } from 'vue'
+
+defineOptions({ name: 'QasToggleVisibility' })
+
+const props = defineProps({
+  group: {
+    type: String,
+    default: ''
+  },
+
+  text: {
+    type: String,
+    default: ''
+  },
+
+  uuid: {
+    type: String,
+    default: ''
+  },
+
+  width: {
+    type: String,
+    default: '140px'
+  }
+})
+
+const {
+  isVisible,
+  toggleVisibility
+} = useToggleVisibility({ group: props.group, uuid: props.uuid || uid() })
+
+const icon = computed(() => isVisible.value ? 'sym_r_visibility' : 'sym_r_visibility_off')
+const style = computed(() => ({ width: props.width }))
+</script>
+
+<style lang="scss">
+.qas-toggle-visibility {
+  &__content {
+    flex-grow: 1;
+  }
+
+  &__button {
+    flex-grow: 0;
+  }
+}
+</style>

--- a/ui/src/components/toggle-visibility/QasToggleVisibility.yml
+++ b/ui/src/components/toggle-visibility/QasToggleVisibility.yml
@@ -1,0 +1,30 @@
+type: component
+
+meta:
+  desc: Componente para ocultar e exibir conteúdo, utilizado para dados sensíveis.
+
+props:
+  group:
+    desc: Propriedade para criar grupos de separação.
+    default: ''
+    type: String
+    examples: ["name", "document", "users"]
+
+  text:
+    desc: Texto a ser oculto/exibido.
+    default: ''
+    type: String
+
+  uuid:
+    desc: É criado um uuid random para cada componente, para que possa ser feito o controle interno, porém é possível sobrescrever por esta propriedade.
+    default: ''
+    type: String
+
+  width:
+    desc: Tamanho do conteúdo a ser oculto/exibido.
+    default: '140px'
+    type: String
+
+slots:
+  default:
+    desc: Slot para inserir conteúdo a ser oculto/exibido.

--- a/ui/src/composables/private/index.js
+++ b/ui/src/composables/private/index.js
@@ -1,2 +1,3 @@
 export { default as useView } from './use-view'
 export { default as useGenerator } from './use-generator'
+export { default as useToggleVisibility } from './use-toggle-visibility'

--- a/ui/src/composables/private/index.js
+++ b/ui/src/composables/private/index.js
@@ -1,0 +1,2 @@
+export { default as useView } from './use-view'
+export { default as useGenerator } from './use-generator'

--- a/ui/src/composables/private/use-generator.js
+++ b/ui/src/composables/private/use-generator.js
@@ -10,6 +10,11 @@ export const baseProps = {
     type: [Array, String, Object]
   },
 
+  commonColumns: {
+    default: () => ({}),
+    type: [Object, String]
+  },
+
   fields: {
     default: () => ({}),
     type: Object
@@ -19,10 +24,6 @@ export const baseProps = {
     default: Spacing.Lg,
     type: [String, Boolean],
     validator: gutterValidator
-  },
-
-  useCommonColumns: {
-    type: Boolean
   }
 }
 
@@ -61,9 +62,7 @@ export default function ({ props = {} }) {
    * @returns {(string|string[])}
    */
   function getFieldClass ({ index, isGridGenerator, fields }) {
-    if (typeof props.columns === 'string') {
-      return IRREGULAR_CLASSES.includes(props.columns) ? props.columns : `col-${props.columns}`
-    }
+    if (typeof props.columns === 'string') return _getStringColumns(props.columns)
 
     return Array.isArray(props.columns)
       ? _handleColumnsByIndex({ index, isGridGenerator, fields })
@@ -72,7 +71,13 @@ export default function ({ props = {} }) {
 
   /**
    * @private
-  */
+   */
+  function _getStringColumns (columns) {
+    return IRREGULAR_CLASSES.includes(columns) ? columns : `col-${columns}`
+  }
+  /**
+   * @private
+   */
   function _getBreakpoint (columns) {
     const classes = []
 
@@ -104,6 +109,10 @@ export default function ({ props = {} }) {
    * @private
   */
   function _getDefaultColumnClass (isGridGenerator) {
+    if (typeof props.commonColumns === 'string') return _getStringColumns(props.commonColumns)
+
+    if (Object.keys(props.commonColumns).length) return _getBreakpoint(props.commonColumns)
+
     return isGridGenerator ? 'col-6 col-xs-12 col-sm-4' : 'col-6'
   }
 
@@ -111,13 +120,6 @@ export default function ({ props = {} }) {
    * @private
   */
   function _handleColumnsByField ({ index, isGridGenerator }) {
-    /*
-     * Quando é passado o columns como um único objeto que será replicado para todos fields.
-     */
-    if (props.useCommonColumns && Object.keys(props.columns).length) {
-      return _getBreakpoint(props.columns)
-    }
-
     /*
      * Quando não é passado columns, retornará o default.
      */

--- a/ui/src/composables/private/use-generator.js
+++ b/ui/src/composables/private/use-generator.js
@@ -21,7 +21,7 @@ export const baseProps = {
   },
 
   gutter: {
-    default: Spacing.Lg,
+    default: undefined,
     type: [String, Boolean],
     validator: gutterValidator
   }
@@ -46,11 +46,17 @@ export default function ({ props = {} }) {
   const classes = computed(() => {
     const classesList = ['row']
 
-    if (props.gutter) {
-      classesList.push(`q-col-gutter-${props.gutter}`)
+    if (defaultGutter.value) {
+      classesList.push(`q-col-gutter-${defaultGutter.value}`)
     }
 
     return classesList
+  })
+
+  const defaultGutter = computed(() => {
+    if (props.gutter) return props.gutter
+
+    return props.useInline ? Spacing.Md : Spacing.Lg
   })
 
   /**

--- a/ui/src/composables/private/use-toggle-visibility.js
+++ b/ui/src/composables/private/use-toggle-visibility.js
@@ -1,0 +1,48 @@
+import { ref, computed } from 'vue'
+
+const visibleState = ref({})
+
+/**
+ * @param {{
+ *  group?: string,
+ *  uuid: string
+ * }}
+ */
+export default function useToggleVisibility ({ group, uuid }) {
+  group = group || 'default'
+
+  visibleState.value[group] = {
+    ...visibleState.value[group],
+    [uuid]: false
+  }
+
+  const isVisible = computed(() => visibleState.value[group]?.[uuid] || false)
+
+  function toggleVisibility () {
+    const item = visibleState.value[group]
+    const lastVisibleItemKey = Object.keys(item).find(key => !!item[key])
+
+    /**
+     * cenário onde esta visível e clicou no mesmo item
+     */
+    if (visibleState.value[group][uuid]) {
+      visibleState.value[group][uuid] = false
+      return
+    }
+
+    /**
+     * cenário onde tem um item visível e clicou em outro item
+     */
+    if (lastVisibleItemKey) {
+      visibleState.value[group][lastVisibleItemKey] = false
+    }
+
+    visibleState.value[group][uuid] = true
+  }
+
+  return {
+    isVisible,
+
+    toggleVisibility
+  }
+}

--- a/ui/src/composables/private/use-view.js
+++ b/ui/src/composables/private/use-view.js
@@ -1,0 +1,180 @@
+import { NotifyError } from '../../plugins'
+import { camelizeFieldsName } from '../../helpers'
+
+import { useView as useViewComposable } from '@bildvitta/composables'
+import { ref, computed, watch, markRaw } from 'vue'
+import { useRouter } from 'vue-router'
+
+export const baseProps = {
+  beforeFetch: {
+    default: null,
+    type: Function
+  },
+
+  errors: {
+    default: () => ({}),
+    type: Object
+  },
+
+  entity: {
+    type: String,
+    required: ''
+  },
+
+  fetching: {
+    type: Boolean
+  },
+
+  fields: {
+    default: () => ({}),
+    type: Object
+  },
+
+  metadata: {
+    default: () => ({}),
+    type: Object
+  },
+
+  url: {
+    default: '',
+    type: String
+  },
+
+  useBoundary: {
+    default: true,
+    type: Boolean
+  },
+
+  useStore: {
+    default: true,
+    type: Boolean
+  }
+}
+
+export const baseEmits = [
+  'update:fields',
+  'update:errors',
+  'update:metadata',
+  'update:fetching'
+]
+
+/**
+ * @param {{
+ *  mode: import('@bildvitta/composables').ViewModeTypes,
+ *  props: baseProps,
+ *  emit: (baseEmits: string) => void,
+ *  slots: import('vue').Slots
+ * }} config
+ */
+export default function useView (config) {
+  const {
+    emit,
+    mode,
+    slots,
+    props
+  } = config
+
+  // composables
+  const router = useRouter()
+  const { viewState } = useViewComposable({ mode })
+
+  // refs
+  const cancelBeforeFetch = ref(false)
+
+  // constants
+  const fetchErrorMessage = 'Ops… Não conseguimos acessar as informações. Por favor, tente novamente em alguns minutos.'
+
+  // computed
+  const componentClass = computed(() => props.useBoundary && 'container spaced')
+  const hasFooterSlot = computed(() => !!slots.footer)
+  const hasHeaderSlot = computed(() => !!slots.header)
+
+  // watch
+  watch(() => viewState.value.fetching, value => emit('update:fetching', value))
+
+  // functions
+  function errorHandler (error) {
+    const { response } = error
+
+    const status = response?.status
+
+    const redirect = status >= 500
+      ? 'ServerError'
+      : ({ 403: 'Forbidden', 404: 'NotFound' })[status]
+
+    /**
+     * caso exista um desses status será redirecionado sem aparecer o "notify"
+     */
+    if (redirect) {
+      router.replace({ name: redirect })
+
+      return
+    }
+
+    NotifyError(fetchErrorMessage)
+  }
+
+  function setErrors (errors = {}) {
+    viewState.value.errors = markRaw(errors)
+  }
+
+  function setFields (fields = {}) {
+    const camelizedFields = camelizeFieldsName(fields)
+
+    viewState.value.fields = markRaw(camelizedFields)
+  }
+
+  function setMetadata (metadata = {}) {
+    viewState.value.metadata = markRaw(metadata)
+  }
+
+  function setResult (result = {}) {
+    viewState.value.result = result
+  }
+
+  function updateModels (models) {
+    for (const key in models) {
+      if (!models[key]) continue
+
+      emit(`update:${key}`, models[key])
+    }
+  }
+
+  function fetchHandler (payload, resolve) {
+    const hasBeforeFetch = typeof props.beforeFetch === 'function'
+
+    if (hasBeforeFetch && !cancelBeforeFetch.value) {
+      return props.beforeFetch({
+        payload,
+        resolve: payload => resolve(payload),
+        done: () => {
+          cancelBeforeFetch.value = true
+        }
+      })
+    }
+
+    resolve()
+  }
+
+  return {
+    // state
+    viewState,
+
+    // constants
+    fetchErrorMessage,
+
+    // computed
+    componentClass,
+    hasFooterSlot,
+    hasHeaderSlot,
+
+    // functions
+    errorHandler,
+    fetchHandler,
+    setErrors,
+    setFields,
+    setResult,
+    setMetadata,
+    updateModels
+  }
+}

--- a/ui/src/composables/private/use-view.js
+++ b/ui/src/composables/private/use-view.js
@@ -89,7 +89,7 @@ export default function useView (config) {
   const componentClass = computed(() => props.useBoundary && 'container spaced')
   const hasFooterSlot = computed(() => !!slots.footer)
   const hasHeaderSlot = computed(() => !!slots.header)
-  const hasFetchErrorSlot = computed(() => !!slots.fetchError)
+  const hasFetchErrorSlot = computed(() => !!slots['fetch-error'])
   const canShowFetchErrorSlot = computed(() => hasFetchErrorSlot.value && hasFetchError.value)
 
   // watch

--- a/ui/src/composables/private/use-view.js
+++ b/ui/src/composables/private/use-view.js
@@ -80,6 +80,7 @@ export default function useView (config) {
 
   // refs
   const cancelBeforeFetch = ref(false)
+  const hasFetchError = ref(false)
 
   // constants
   const fetchErrorMessage = 'Ops… Não conseguimos acessar as informações. Por favor, tente novamente em alguns minutos.'
@@ -88,6 +89,8 @@ export default function useView (config) {
   const componentClass = computed(() => props.useBoundary && 'container spaced')
   const hasFooterSlot = computed(() => !!slots.footer)
   const hasHeaderSlot = computed(() => !!slots.header)
+  const hasFetchErrorSlot = computed(() => !!slots.fetchError)
+  const canShowFetchErrorSlot = computed(() => hasFetchErrorSlot.value && hasFetchError.value)
 
   // watch
   watch(() => viewState.value.fetching, value => emit('update:fetching', value))
@@ -110,6 +113,8 @@ export default function useView (config) {
 
       return
     }
+
+    hasFetchError.value = true
 
     NotifyError(fetchErrorMessage)
   }
@@ -167,6 +172,7 @@ export default function useView (config) {
     componentClass,
     hasFooterSlot,
     hasHeaderSlot,
+    canShowFetchErrorSlot,
 
     // functions
     errorHandler,

--- a/ui/src/mixins/view.js
+++ b/ui/src/mixins/view.js
@@ -81,7 +81,7 @@ export default {
     },
 
     mx_hasFetchErrorSlot () {
-      return !!(this.$slots.fetchError)
+      return !!(this.$slots['fetch-error'])
     },
 
     mx_fetchErrorMessage () {

--- a/ui/src/mixins/view.js
+++ b/ui/src/mixins/view.js
@@ -56,7 +56,8 @@ export default {
       mx_fields: {},
       mx_metadata: {},
       mx_cancelBeforeFetch: false,
-      mx_isFetching: false
+      mx_isFetching: false,
+      mx_hasFetchError: false
     }
   },
 
@@ -79,8 +80,16 @@ export default {
       return !!(this.$slots.header)
     },
 
+    mx_hasFetchErrorSlot () {
+      return !!(this.$slots.fetchError)
+    },
+
     mx_fetchErrorMessage () {
       return 'Ops… Não conseguimos acessar as informações. Por favor, tente novamente em alguns minutos.'
+    },
+
+    mx_canShowFetchErrorSlot () {
+      return this.mx_hasFetchError && this.mx_hasFetchErrorSlot
     }
   },
 
@@ -100,6 +109,8 @@ export default {
 
         return
       }
+
+      this.mx_hasFetchError = true
 
       this.$qas.error(this.mx_fetchErrorMessage)
     },

--- a/ui/src/vue-plugin.js
+++ b/ui/src/vue-plugin.js
@@ -72,7 +72,7 @@ import QasWhatsappLink from './components/whatsapp-link/QasWhatsappLink.vue'
 
 import { Notify, Loading, Quasar, Dialog as QuasarDialog } from 'quasar'
 
-import { getAction } from '@bildvitta/store-adapter'
+import { getAction, getGetter } from '@bildvitta/store-adapter'
 
 // Plugins
 import {
@@ -176,7 +176,8 @@ async function install (app) {
   app.provide('qas', {
     delete: params => Delete.call(app.config.globalProperties, params),
 
-    getAction: params => getAction.call(app.config.globalProperties, params)
+    getAction: params => getAction.call(app.config.globalProperties, params),
+    getGetter: params => getGetter.call(app.config.globalProperties, params)
   })
 
   app.directive(Test.name, Test)

--- a/ui/src/vue-plugin.js
+++ b/ui/src/vue-plugin.js
@@ -64,6 +64,7 @@ import QasTableGenerator from './components/table-generator/QasTableGenerator.vu
 import QasTabsGenerator from './components/tabs-generator/QasTabsGenerator.vue'
 import QasTextTruncate from './components/text-truncate/QasTextTruncate.vue'
 import QasTimeline from './components/timeline/QasTimeline.vue'
+import QasToggleVisibility from './components/toggle-visibility/QasToggleVisibility.vue'
 import QasTransfer from './components/transfer/QasTransfer.vue'
 import QasTreeGenerator from './components/tree-generator/QasTreeGenerator.vue'
 import QasUploader from './components/uploader/QasUploader.vue'
@@ -157,6 +158,7 @@ async function install (app) {
   app.component('QasTabsGenerator', QasTabsGenerator)
   app.component('QasTextTruncate', QasTextTruncate)
   app.component('QasTimeline', QasTimeline)
+  app.component('QasToggleVisibility', QasToggleVisibility)
   app.component('QasTransfer', QasTransfer)
   app.component('QasTreeGenerator', QasTreeGenerator)
   app.component('QasUploader', QasUploader)
@@ -252,6 +254,7 @@ export {
   QasTabsGenerator,
   QasTextTruncate,
   QasTimeline,
+  QasToggleVisibility,
   QasTransfer,
   QasTreeGenerator,
   QasUploader,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- (Remova este texto de descrição.) -->
## Não publicado
## BREAKING CHANGES
- [`QasFormGenerator`, `QasGridGenerator`]: removido a propriedade `useCommonColumns` em favor de utilizar a propriedade `commonColumns`.
- `QasSingleView`: Possível breaking change ao utilizar o `before-fetch`.

### Adicionado
- [`QasFormGenerator`, `QasGridGenerator`]: adicionado nova propriedade `commonColumns`, esta propriedade vai substituir a necessidade do `useCommonColumns` e dar mais flexibilidade.
- `QasAppMenu`: adicionado propriedade `helpChatLink`, para a ação de "Solicitar ajuda".
- `QasActionsMenu`: possibilidade de passar a prop `to` para os botões.
- `QasHeaderActions`: adicionado prop `spacing`.
- `QasSingleView`: Adicionado propriedade `use-store` para dar a possibilidade de utilizar o componente sem a store do vuex/pinia.
- `QasToggleVisibility`: Adicionado novo componente.
- `QasExpansionItem`: adicionado novo slot `header-bottom`.
- [`QasFormView`, `QasListView`, `QasSingleView`]: adicionado novo slot chamado `fetch-error` que é disponibilizado quando ocorre o `fetchError`.
- `QasActions`: adicionado nova opção de ação terciária.

### Corrigido
- `QasSelect`: Corrigido forma de atribuir as options, já que estava dando problema de endereço de memória em selects dependentes que são lazy-loading dentro de um `QasNestedFields`.
- `QasAppMenu`: adicionado validações para garantir que não aconteça nenhum erro que trave a aplicação.
- `QasHeaderActions`: Corrigido quebra de de layout em casos de ter 2 itens com split usando `QasActionsMenu`.
- `QasExpansionItem`: corrigido função `setHasNextSibling`.
- `QasGridGenerator`: Corrigido gutter quando se é utilizado a prop `useInline`.
- `QasExpansionItem`: Adicionado nova propriedade `useHeaderSeparator` para forçar o controle do QSeparator.
- `QasExpansionItem`: Adicionado classe para z-index, onde corrige o problema de quando usado grid com gutter no conteúdo e sobrepunha o header fazendo com que perdesse o evento de click.
- `QasTableGenerator`: adicionado nova propriedade `useBox`.

### Modificado
- `QasSingleView`:
  - modificado para composition API.
  - removido obrigatoriedade da propriedade "entity".
- `QasExpansionItem`: modificado layout do componente quando ele é usado como nested (QasExpansionItem dentro de QasExpansionItem).
- `QasExpansionItem`:
  - Repassando todos eventos do QExpansionItem.
- `QasToggleVisibility`: adicionado evento `prevent.stop` no botão para não disparar evento de click na tabela.
- `boot/notifications`: removido notificações em localhost, uma vez que ficava gerando vários errors de conexão no console/network, o que atrapalhava o desenvolvimento local.
- `QasExpansionItem`:
  - adicionado espaçamento `sm` no conteúdo quando for nested.
  - agora é possível sobrescrever a propriedade "useInline" pela `gridGeneratorProps`.
- `QasLabel`: Modificado tag renderizada no componente para ser de acordo com a passada pela prop `typography`.

### Removido
- [`QasFormGenerator`, `QasGridGenerator`]: removido a propriedade `useCommonColumns` em favor de utilizar a propriedade `commonColumns`.


<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [ ] v3-beta.x -> a partir da branch `develop`.
- [x] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [x] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [x] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
