### PR TITLE
feat: input focus / badge value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasFilters`: 
+  - Não exibir badge ao limpar um campo do filtro pelo backspace, exibia uma badge com valor vazio.
+  - Campo de input não ficar com foco após efetuar a busca ou limpar pelo filtro lateral.
+
 ## [3.17.0-beta.4] - 02-09-2024
 ### Adicionado
 - `QasSelect`:

--- a/ui/src/components/filters/QasFilters.vue
+++ b/ui/src/components/filters/QasFilters.vue
@@ -4,10 +4,20 @@
       <div v-if="showSearch" class="col-12 col-md-6">
         <slot :filter="filter" name="search">
           <q-form v-if="useSearch" @submit.prevent="filter()">
-            <qas-search-input v-model="internalSearch" :placeholder="searchPlaceholder" :use-search-on-type="useSearchOnType" @clear="clearSearch" @filter="filter()" @update:model-value="onSearch">
+            <qas-search-input
+              ref="searchInput" v-model="internalSearch" :placeholder="searchPlaceholder"
+              :use-search-on-type="useSearchOnType" @clear="clearSearch" @click="() => console.log('caiu')"
+              @filter="filter()" @update:model-value="onSearch"
+            >
               <template v-if="showFilterButton" #after-clear>
-                <slot :context="mx_context" :filter="filter" :filters="activeFilters" name="filter-button" :remove-filter="removeFilter">
-                  <pv-filters-button v-if="useFilterButton" ref="filtersButton" v-model="internalFilters" v-bind="filterButtonProps" />
+                <slot
+                  :context="mx_context" :filter="filter" :filters="activeFilters" name="filter-button"
+                  :remove-filter="removeFilter"
+                >
+                  <pv-filters-button
+                    v-if="useFilterButton" ref="filtersButton" v-model="internalFilters"
+                    v-bind="filterButtonProps"
+                  />
                 </slot>
               </template>
             </qas-search-input>
@@ -16,8 +26,14 @@
       </div>
 
       <div v-else-if="showFilterButton" class="col-12">
-        <slot :context="mx_context" :filter="filter" :filters="activeFilters" name="filter-button" :remove-filter="removeFilter">
-          <pv-filters-button v-if="useFilterButton" ref="filtersButton" v-model="internalFilters" v-bind="filterButtonProps" />
+        <slot
+          :context="mx_context" :filter="filter" :filters="activeFilters" name="filter-button"
+          :remove-filter="removeFilter"
+        >
+          <pv-filters-button
+            v-if="useFilterButton" ref="filtersButton" v-model="internalFilters"
+            v-bind="filterButtonProps"
+          />
         </slot>
       </div>
 
@@ -27,7 +43,10 @@
     </div>
 
     <div v-if="hasChip" class="q-mt-md">
-      <qas-badge v-for="(filterItem, key) in activeFilters" :key="key" :data-cy="`filters-${filterItem.value}-chip`" removable @remove="removeFilter(filterItem)">
+      <qas-badge
+        v-for="(filterItem, key) in activeFilters" :key="key" :data-cy="`filters-${filterItem.value}-chip`"
+        removable @remove="removeFilter(filterItem)"
+      >
         <div class="ellipsis qas-filters__badge-content" :title="getChipValue(filterItem.value)">
           {{ filterItem.label }}: "{{ getChipValue(filterItem.value) }}"
         </div>
@@ -160,7 +179,7 @@ export default {
           const field = { ...this.fields[key], ...this.formattedFieldsProps?.[decamelize(key)] }
           const value = humanize(field, this.normalizeValues(filters[key], field?.multiple))
 
-          if (!value) continue
+          if (!value || (Array.isArray(value) && !value.length)) continue
 
           const { label, name } = field
 
@@ -386,6 +405,7 @@ export default {
 
     hideFiltersMenu () {
       this.$refs.filtersButton?.hideMenu()
+      this.$refs.searchInput?.input?.blur()
     },
 
     setInternalFilters () {

--- a/ui/src/components/input/QasInput.vue
+++ b/ui/src/components/input/QasInput.vue
@@ -203,6 +203,10 @@ export default {
       return this.inputReference.focus()
     },
 
+    blur () {
+      return this.inputReference.blur()
+    },
+
     resetValidation () {
       return this.inputReference.resetValidation()
     },


### PR DESCRIPTION
### Corrigido
- `QasFilters`: 
  - Não exibir badge ao limpar um campo do filtro pelo backspace, exibia uma badge com valor vazio.
  - Campo de input não ficar com foco após efetuar a busca ou limpar pelo filtro lateral.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
