### PR TITLE
Changes QasTableGenerator, QasActionsMenu, QasExpansionItem, QasDateTimeInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ### Modificado
 - `QasExpansionItem`: modificado componente para ter uma borda caso esteja dentro de um `QasBox`.
-
-### Modificado
-- `QasDateTimeInput`: alterado o ícone do calendário.
+- `QasDateTimeInput`: modificado o ícone do calendário.
 
 ## [3.17.0-beta.6] - 10-09-2024
 ### Corrigido

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## [Nao publicado]
+### Adicionado
+- `QasTableGenerator`: adicionado componente `QasEmptyResultText` onde será exibido no caso dos valores da tabela serem vazios.
+
+### Modificado
+- `QasExpansionItem`: modificado componente para ter uma borda caso esteja dentro de um `QasBox`.
+
+### Modificado
+- `QasDateTimeInput`: alterado o ícone do calendário.
+
 ## [3.17.0-beta.6] - 10-09-2024
 ### Corrigido
 - `QasFormGenerator`: corrigido fieldset que não estava sendo exibido.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ## [Nao publicado]
 ### Adicionado
 - `QasTableGenerator`: adicionado componente `QasEmptyResultText` onde será exibido no caso dos valores da tabela serem vazios.
+- `QasActionsMenu`: adicionado label `Opções` no botão splitted quando não for mobile.
 
 ### Modificado
 - `QasExpansionItem`: modificado componente para ter uma borda caso esteja dentro de um `QasBox`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,17 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## [Nao publicado]
+## Não publicado
 ### Adicionado
 - `QasTableGenerator`: adicionado componente `QasEmptyResultText` onde será exibido no caso dos valores da tabela serem vazios.
-- `QasActionsMenu`: adicionado label `Opções` no botão splitted quando não for mobile.
 
 ### Modificado
 - `QasExpansionItem`: modificado componente para ter uma borda caso esteja dentro de um `QasBox`.
 - `QasDateTimeInput`: modificado o ícone do calendário.
+- `QasActionsMenu`: modificado o botão splitted, agora possui a label `Opções` quando não for mobile.
+
+## Corrigido
+- `QasGridGenerator`: ajuste de lógica do ellipsis que estava causando um warning.
 
 ## [3.17.0-beta.6] - 10-09-2024
 ### Corrigido

--- a/docs/src/examples/QasExpansionItem/WithBox.vue
+++ b/docs/src/examples/QasExpansionItem/WithBox.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- Usando qas-single-view apenas para recuperar os dados -->
-  <qas-single-view v-model:fields="fields" v-model:result="result" :custom-id="customId" :entity="entity">
+  <qas-single-view v-model:fields="viewState.fields" v-model:result="viewState.result" :custom-id="customId" :entity="entity">
     <qas-box>
       <div class="q-mb-md">Conteúdo dentro de uma box, o Expansion deverá ter uma borda.</div>
       <qas-expansion-item :badges="badges" :grid-generator-props="gridGeneratorProps" label="John Doe" />
@@ -9,12 +9,12 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { computed } from 'vue'
+import { useView } from '@bildvitta/composables'
 
-defineOptions({ name: 'UsersList' })
+defineOptions({ name: 'WithBox' })
 
-const fields = ref({})
-const result = ref({})
+const { viewState } = useView({ mode: 'single' })
 
 const entity = 'users'
 
@@ -33,8 +33,8 @@ const badges = [
 
 const gridGeneratorProps = computed(() => {
   return {
-    fields: fields.value,
-    result: result.value
+    fields: viewState.value.fields,
+    result: viewState.value.result
   }
 })
 

--- a/docs/src/examples/QasExpansionItem/WithBox.vue
+++ b/docs/src/examples/QasExpansionItem/WithBox.vue
@@ -1,0 +1,43 @@
+<template>
+  <!-- Usando qas-single-view apenas para recuperar os dados -->
+  <qas-single-view v-model:fields="fields" v-model:result="result" :custom-id="customId" :entity="entity">
+    <qas-box>
+      <div class="q-mb-md">Conteúdo dentro de uma box, o Expansion deverá ter uma borda.</div>
+      <qas-expansion-item :badges="badges" :grid-generator-props="gridGeneratorProps" label="John Doe" />
+    </qas-box>
+  </qas-single-view>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+
+defineOptions({ name: 'UsersList' })
+
+const fields = ref({})
+const result = ref({})
+
+const entity = 'users'
+
+const badges = [
+  {
+    color: 'green-14',
+    label: 'Aprovado',
+    textColor: 'white'
+  },
+  {
+    color: 'red-14',
+    label: 'Reprovado',
+    textColor: 'white'
+  }
+]
+
+const gridGeneratorProps = computed(() => {
+  return {
+    fields: fields.value,
+    result: result.value
+  }
+})
+
+// USAR SOMENTE SE NECESSÁRIO, AQUI PEGAMOS O ID DO USUÁRIO NO NOSSO MOCK DE DADOS
+const customId = '3102fad5-f14c-45d4-98e9-46ef0aa9580e'
+</script>

--- a/docs/src/pages/components/expansion-item.md
+++ b/docs/src/pages/components/expansion-item.md
@@ -23,3 +23,4 @@ Componente de card expansivo, wrapper do QExpansionItem(https://quasar.dev/vue-c
 <doc-example file="QasExpansionItem/Nested" title="Nested" />
 <doc-example file="QasExpansionItem/HeaderBottomSlot" title="HeaderBottomSlot" />
 <doc-example file="QasExpansionItem/Error" title="Com erro" />
+<doc-example file="QasExpansionItem/WithBox" title="Dentro de um QasBox" />

--- a/ui/src/components/btn-dropdown/QasBtnDropdown.vue
+++ b/ui/src/components/btn-dropdown/QasBtnDropdown.vue
@@ -104,12 +104,16 @@ const hasDefaultSlot = computed(() => !!slots.default)
 const hasMenuOnLeftSide = computed(() => hasDefaultSlot.value && !props.useSplit && isSingleButton.value)
 
 const splittedButtonProps = computed(() => {
+  const iconKey = screen.isSmall ? 'icon' : 'iconRight'
+
   return {
     color: 'grey-10',
     disable: props.disable,
     ...(screen.isSmall ? { icon: props.dropdownIcon } : { iconRight: props.dropdownIcon }),
+    [iconKey]: props.dropdownIcon,
     variant: 'tertiary',
-    label: screen.isSmall ? '' : 'Opções'
+    label: 'Opções',
+    useLabelOnSmallScreen: false
   }
 })
 

--- a/ui/src/components/btn-dropdown/QasBtnDropdown.vue
+++ b/ui/src/components/btn-dropdown/QasBtnDropdown.vue
@@ -109,7 +109,6 @@ const splittedButtonProps = computed(() => {
   return {
     color: 'grey-10',
     disable: props.disable,
-    ...(screen.isSmall ? { icon: props.dropdownIcon } : { iconRight: props.dropdownIcon }),
     [iconKey]: props.dropdownIcon,
     variant: 'tertiary',
     label: 'Opções',

--- a/ui/src/components/btn-dropdown/QasBtnDropdown.vue
+++ b/ui/src/components/btn-dropdown/QasBtnDropdown.vue
@@ -19,7 +19,7 @@
     </div>
 
     <div v-if="props.useSplit">
-      <qas-btn color="grey-10" :disable="disable" :icon="props.dropdownIcon" variant="tertiary">
+      <qas-btn v-bind="splittedButtonProps">
         <q-menu v-if="hasDefaultSlot" anchor="bottom right" auto-close self="top right">
           <div :class="classes.menuContent">
             <slot />
@@ -102,6 +102,16 @@ const isSingleButton = computed(() => buttonsPropsListSize.value === 1)
 const hasButtons = computed(() => !screen.isSmall || !props.useSplit)
 const hasDefaultSlot = computed(() => !!slots.default)
 const hasMenuOnLeftSide = computed(() => hasDefaultSlot.value && !props.useSplit && isSingleButton.value)
+
+const splittedButtonProps = computed(() => {
+  return {
+    color: 'grey-10',
+    disable: props.disable,
+    ...(screen.isSmall ? { icon: props.dropdownIcon } : { iconRight: props.dropdownIcon }),
+    variant: 'tertiary',
+    label: screen.isSmall ? '' : 'Opções'
+  }
+})
 
 watch(() => props.menu, value => {
   isMenuOpened.value = value

--- a/ui/src/components/date-time-input/QasDateTimeInput.vue
+++ b/ui/src/components/date-time-input/QasDateTimeInput.vue
@@ -1,7 +1,7 @@
 <template>
   <qas-input ref="input" v-bind="attributes" v-model="currentValue" inputmode="numeric" :unmasked-value="false" @blur="validateDateTimeOnBlur" @focus="resetError" @update:model-value="updateModelValue">
     <template #append>
-      <qas-btn v-if="!props.useTimeOnly" color="grey-10" :disable="attrs.readonly" icon="sym_r_event" variant="tertiary">
+      <qas-btn v-if="!props.useTimeOnly" color="grey-10" :disable="attrs.readonly" icon="sym_r_calendar_today" variant="tertiary">
         <q-popup-proxy ref="dateProxy" transition-hide="scale" transition-show="scale" v-bind="props.datePopupProxyProps">
           <qas-date v-model="currentValue" v-bind="defaultDateProps" :mask="maskDate" width="290px" @update:model-value="updateModelValue" />
         </q-popup-proxy>

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -164,14 +164,14 @@ const boxProps = computed(() => {
    * Caso o QasExpansionItem estiver dentro de um QasBox e não for um QasExpansionItem
    * dentro de outro QasExpansionItem, o componente terá uma borda.
   */
-  if (isNestedBox && !isNestedExpansionItem) {
-    return {
-      unelevated: true,
-      outlined: true
-    }
-  }
+  const isBoxed = isNestedBox && !isNestedExpansionItem
 
-  return {}
+  if (!isBoxed) return {}
+
+  return {
+    unelevated: isBoxed,
+    outlined: isBoxed
+  }
 })
 
 // functions

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="expansionItem" class="full-width qas-expansion-item" :class="errorClasses" v-bind="expansionProps.parent">
-    <component :is="component.is" class="qas-expansion-item__box">
+    <component :is="component.is" class="qas-expansion-item__box" v-bind="boxProps">
       <q-expansion-item header-class="text-bold q-mt-sm q-pa-none qas-expansion-item__header" :label="props.label" v-bind="expansionProps.item">
         <template #header>
           <slot name="header">
@@ -100,6 +100,8 @@ onMounted(setHasNextSibling)
 
 // constants
 const isNestedExpansionItem = inject('isExpansionItem', false)
+const isNestedBox = inject('isBox', false)
+
 const component = {
   is: isNestedExpansionItem ? 'div' : QasBox
 }
@@ -155,6 +157,21 @@ const expansionProps = computed(() => {
       onAfterHide
     }
   }
+})
+
+const boxProps = computed(() => {
+  /**
+   * Caso o QasExpansionItem estiver dentro de um QasBox e não for um QasExpansionItem
+   * dentro de outro QasExpansionItem, o componente terá uma borda.
+  */
+  if (isNestedBox && !isNestedExpansionItem) {
+    return {
+      unelevated: true,
+      outlined: true
+    }
+  }
+
+  return {}
 })
 
 // functions

--- a/ui/src/components/grid-generator/QasGridGenerator.vue
+++ b/ui/src/components/grid-generator/QasGridGenerator.vue
@@ -203,7 +203,7 @@ function getContentClasses (field) {
     props.contentClass,
 
     {
-      ellipsis: !screen.isSmall && this.hasEllipsis(field)
+      ellipsis: !screen.isSmall && hasEllipsis(field)
     }
   ]
 }

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -139,7 +139,7 @@ export default {
     attributes () {
       const attributes = {
         class: this.tableClass,
-        columns: this.hasResults ? this.columnsByFields : [],
+        columns: this.columnsByFields,
         flat: true,
         hideBottom: true,
         pagination: { rowsPerPage: 0 },

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -4,7 +4,7 @@
       <qas-header v-if="hasHeaderProps" v-bind="headerProps" />
     </slot>
 
-    <q-table ref="table" class="bg-white qas-table-generator text-grey-8" v-bind="attributes">
+    <q-table v-show="hasResults" ref="table" class="bg-white qas-table-generator text-grey-8" v-bind="attributes">
       <template v-for="(_, name) in slots" #[name]="context">
         <slot :name="name" v-bind="context" />
       </template>
@@ -19,6 +19,8 @@
         </q-td>
       </template>
     </q-table>
+
+    <qas-empty-result-text v-if="!hasResults" />
   </component>
 </template>
 
@@ -130,10 +132,14 @@ export default {
       return !!this.$slots['body-cell']
     },
 
+    hasResults () {
+      return !!this.resultsByFields.length
+    },
+
     attributes () {
       const attributes = {
         class: this.tableClass,
-        columns: this.columnsByFields,
+        columns: this.hasResults ? this.columnsByFields : [],
         flat: true,
         hideBottom: true,
         pagination: { rowsPerPage: 0 },


### PR DESCRIPTION
### Adicionado
- `QasTableGenerator`: adicionado componente `QasEmptyResultText` onde será exibido no caso dos valores da tabela serem vazios.
- `QasActionsMenu`: adicionado label `Opções` no botão splitted quando não for mobile.

### Modificado
- `QasExpansionItem`: modificado componente para ter uma borda caso esteja dentro de um `QasBox`.

### Modificado
- `QasDateTimeInput`: alterado o ícone do calendário.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [ ] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
