### PR TITLE
feat: fix form-generator button / list-view loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
+## BREAKING CHANGES
+- `QasListView`: possível breaking changes caso o loading era controlado externamente em conjunto com o `useResultsAreaOnly`.Agora o loading é exibido mesmo a prop sendo passada.
+
 ### Adicionado
 - `QasFormGenerator`: criado slot `legend-bottom-[nome-do-fieldset]`.
 - `QasTableGenerator`: adicionado componente `QasEmptyResultText` onde será exibido no caso dos valores da tabela serem vazios.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ## Não publicado
 ## BREAKING CHANGES
-- `QasListView`: possível breaking changes caso o loading era controlado externamente em conjunto com o `useResultsAreaOnly`.Agora o loading é exibido mesmo a prop sendo passada.
+- `QasListView`: possível breaking changes caso o loading era controlado externamente em conjunto com o `useResultsAreaOnly`. Agora o loading é exibido mesmo a prop sendo passada.
 
 ### Adicionado
 - `QasFormGenerator`: criado slot `legend-bottom-[nome-do-fieldset]`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,11 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasExpansionItem`: modificado componente para ter uma borda caso esteja dentro de um `QasBox`.
 - `QasDateTimeInput`: modificado o ícone do calendário.
 - `QasActionsMenu`: modificado o botão splitted, agora possui a label `Opções` quando não for mobile.
+- `QasListView`: modificado a forma que os loadings são exibidos.
 
 ## Corrigido
 - `QasGridGenerator`: ajuste de lógica do ellipsis que estava causando um warning.
+- `QasFormGenerator`: ajuste ao usar o `buttonProps` com um select com opções com label grande, fazia com que o select não respeitasse o ellipsis.
 
 ## [3.17.0-beta.6] - 10-09-2024
 ### Corrigido

--- a/docs/src/examples/QasFormGenerator/WithButton.vue
+++ b/docs/src/examples/QasFormGenerator/WithButton.vue
@@ -19,7 +19,8 @@ const columns = {
   isActive: { col: 12 },
   phone: { col: 12, sm: 4 },
   name: { col: 12, sm: 4 },
-  email: { col: 12, sm: 4 }
+  email: { col: 12, sm: 4 },
+  company: { col: 12, sm: 4 }
 }
 
 const fieldsProps = {
@@ -32,8 +33,7 @@ const fieldset = {
   personalInformation: {
     label: 'Informações pessoais',
     description: 'Informe o nome e email do usuário.',
-    fields: ['isActive', 'phone', 'name', 'email'],
-    column: '12',
+    fields: ['isActive', 'phone', 'name', 'company'],
     buttonProps: {
       label: 'Botão',
       icon: 'sym_r_draft',
@@ -53,6 +53,19 @@ const fields = {
     label: 'Usuário ativo?',
     type: 'boolean',
     default: false
+  },
+
+  company: {
+    name: 'company',
+    label: 'Empresa',
+    multiple: true,
+    type: 'select',
+    options: [
+      { label: 'Empresa com nome grande 1', value: 'company-1' },
+      { label: 'Empresa com nome grande 2', value: 'company-2' },
+      { label: 'Empresa com nome grande 3', value: 'company-3' },
+      { label: 'Empresa com nome grande 4', value: 'company-4' }
+    ]
   },
 
   name: {

--- a/ui/src/components/form-generator/QasFormGenerator.vue
+++ b/ui/src/components/form-generator/QasFormGenerator.vue
@@ -8,16 +8,18 @@
 
         <div>
           <slot :fields="fieldsetItem.fields?.visible" :name="`legend-section-${fieldsetItemKey}`">
-            <div class="items-end justify-end" :class="getRowContainerClasses(fieldsetItem)">
-              <div :class="fieldContainerClasses">
-                <div v-for="(field, key) in fieldsetItem.fields.visible" :key="key" :class="getFieldClass({ index: key, fields: normalizedFields })">
-                  <slot :field="field" :name="`field-${field.name}`">
-                    <qas-field :disable="isFieldDisabled(field)" v-bind="props.fieldsProps[field.name]" :error="props.errors[key]" :field="field" :model-value="props.modelValue[field.name]" @update:model-value="updateModelValue({ key: field.name, value: $event })" />
-                  </slot>
+            <div class="q-col-gutter-md row">
+              <div class="col">
+                <div :class="fieldContainerClasses">
+                  <div v-for="(field, key) in fieldsetItem.fields.visible" :key="key" :class="getFieldClass({ index: key, fields: normalizedFields })">
+                    <slot :field="field" :name="`field-${field.name}`">
+                      <qas-field :disable="isFieldDisabled(field)" v-bind="props.fieldsProps[field.name]" :error="props.errors[key]" :field="field" :model-value="props.modelValue[field.name]" @update:model-value="updateModelValue({ key: field.name, value: $event })" />
+                    </slot>
+                  </div>
                 </div>
               </div>
 
-              <div v-if="hasButtonProps(fieldsetItem)" :class="buttonContainerClasses">
+              <div v-if="hasButtonProps(fieldsetItem)" class="col-12 col-sm-auto items-end justify-end row">
                 <qas-btn v-bind="fieldsetItem.buttonProps" />
               </div>
             </div>
@@ -204,12 +206,6 @@ const fieldContainerClasses = computed(() => {
   ]
 })
 
-const buttonContainerClasses = computed(() => {
-  return screen.isSmall
-    ? 'row items-center justify-end q-mt-lg'
-    : 'q-ml-lg'
-})
-
 // methods
 function getFieldType ({ type }) {
   return type === 'hidden' ? 'hidden' : 'visible'
@@ -241,10 +237,6 @@ function updateModelValue ({ key, value }) {
 
 function hasButtonProps ({ buttonProps = {} }) {
   return !!Object.keys(buttonProps).length
-}
-
-function getRowContainerClasses (item) {
-  return { row: hasButtonProps(item) && !screen.isSmall }
 }
 
 // composables

--- a/ui/src/components/form-generator/QasFormGenerator.vue
+++ b/ui/src/components/form-generator/QasFormGenerator.vue
@@ -206,7 +206,7 @@ const fieldContainerClasses = computed(() => {
   ]
 })
 
-// methods
+// functions
 function getFieldType ({ type }) {
   return type === 'hidden' ? 'hidden' : 'visible'
 }

--- a/ui/src/components/form-generator/QasFormGenerator.vue
+++ b/ui/src/components/form-generator/QasFormGenerator.vue
@@ -17,7 +17,9 @@
                 </div>
               </div>
 
-              <qas-btn v-if="hasButtonProps(fieldsetItem)" class="md:q-mt-none q-ml-md q-mt-md" v-bind="fieldsetItem.buttonProps" />
+              <div v-if="hasButtonProps(fieldsetItem)" :class="buttonContainerClasses">
+                <qas-btn v-bind="fieldsetItem.buttonProps" />
+              </div>
             </div>
 
             <div v-for="(field, key) in fieldsetItem.fields.hidden" :key="key">
@@ -202,6 +204,12 @@ const fieldContainerClasses = computed(() => {
   ]
 })
 
+const buttonContainerClasses = computed(() => {
+  return screen.isSmall
+    ? 'row items-center justify-end q-mt-lg'
+    : 'q-ml-lg'
+})
+
 // methods
 function getFieldType ({ type }) {
   return type === 'hidden' ? 'hidden' : 'visible'
@@ -236,7 +244,7 @@ function hasButtonProps ({ buttonProps = {} }) {
 }
 
 function getRowContainerClasses (item) {
-  return { row: hasButtonProps(item) }
+  return { row: hasButtonProps(item) && !screen.isSmall }
 }
 
 // composables

--- a/ui/src/components/grid-generator/QasGridGenerator.vue
+++ b/ui/src/components/grid-generator/QasGridGenerator.vue
@@ -153,7 +153,7 @@ const formattedFields = computed(() => {
 // watch
 watch(() => formattedFields.value, setFieldsByResult, { immediate: true })
 
-// methods
+// functions
 function getFieldsByResult () {
   if (!hasResult.value || !hasFields.value) return {}
 

--- a/ui/src/components/list-view/QasListView.vue
+++ b/ui/src/components/list-view/QasListView.vue
@@ -163,7 +163,6 @@ export default {
   },
 
   created () {
-    console.log('teste')
     this.mx_fetchHandler({ ...this.mx_context, url: this.url }, this.fetchList)
 
     this.setCurrentPage()

--- a/ui/src/components/list-view/QasListView.vue
+++ b/ui/src/components/list-view/QasListView.vue
@@ -12,6 +12,10 @@
       <main class="relative-position">
         <div v-if="showResults">
           <slot />
+
+          <q-inner-loading :showing="mx_isFetching">
+            <q-spinner color="grey" size="3em" />
+          </q-inner-loading>
         </div>
 
         <div v-else-if="!mx_isFetching">
@@ -29,10 +33,6 @@
         <div v-if="hasPages" class="flex items-center q-mt-md" :class="paginationClasses">
           <qas-pagination v-model="page" :max="totalPages" @click="changePage" />
         </div>
-
-        <q-inner-loading :showing="hasResults && mx_isFetching">
-          <q-spinner color="grey" size="3em" />
-        </q-inner-loading>
       </main>
     </q-pull-to-refresh>
 
@@ -163,6 +163,7 @@ export default {
   },
 
   created () {
+    console.log('teste')
     this.mx_fetchHandler({ ...this.mx_context, url: this.url }, this.fetchList)
 
     this.setCurrentPage()

--- a/ui/src/components/text-truncate/QasTextTruncate.vue
+++ b/ui/src/components/text-truncate/QasTextTruncate.vue
@@ -148,7 +148,7 @@ function useDialog ({ props, textContent }) {
     }
   })
 
-  // methods
+  // functions
   function toggle () {
     show.value = !show.value
   }
@@ -170,7 +170,7 @@ function useMutationObserver ({ truncate, callbackFn = () => {} }) {
   onMounted(() => observeContentChange())
   onUnmounted(() => observer.value.disconnect())
 
-  // methods
+  // functions
   function observeContentChange () {
     const config = { childList: true, subtree: true, characterData: true }
 
@@ -197,7 +197,7 @@ function useTruncate ({ parent, props }) {
   // computed
   const isTruncated = computed(() => textWidth.value > maxPossibleWidth.value)
 
-  // methods
+  // functions
   function truncateText () {
     parent.value.style.maxWidth = '100%'
     textWidth.value = truncate.value.clientWidth


### PR DESCRIPTION
- `QasListView`: modificado a forma que os loadings são exibidos.
- `QasFormGenerator`: ajuste ao usar o `buttonProps` com um select com opções com label grande, fazia com que o select não respeitasse o ellipsis.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [ ] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
