### PR TITLE
QasExpansionItems changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+## BREAKING CHANGES
+- `QasExpansionItems`: modificado slot header, agora ao abrir, ele sobrescreve toda a seção header, incluindo o botão de dropdown.
+
+### Adicionado
+- `QasExpansionItems`:
+  - adicionado propriedade `disable`.
+  - adicionado propriedade `disableButton`.
+  - adicionado propriedade `group`.
+  - adicionado v-model.
+  - adicionado novo slot `header-left`.
+
+### Modificado
+- `QasExpansionItems`: modificado slot header, agora ao abrir, ele sobrescreve toda a seção header, incluindo o botão de dropdown.
+
 ## [3.17.0-beta.9] - 07-10-2024
 ### Adicionado
 - `QasSelect`:

--- a/docs/src/examples/QasExpansionItem/Disable.vue
+++ b/docs/src/examples/QasExpansionItem/Disable.vue
@@ -1,17 +1,25 @@
 <template>
   <div class="container spaced">
-    <qas-expansion-item label="John Doe">
+    <qas-expansion-item disable-button label="John Doe">
       <template #content>
         Meu conteúdo customizado
       </template>
-      <!-- <template #header>
+    </qas-expansion-item>
+
+    <qas-expansion-item class="q-mt-lg" disable label="John Doe">
+      <template #content>
         Meu conteúdo customizado
-      </template> -->
+      </template>
+    </qas-expansion-item>
+
+    <qas-expansion-item class="q-mt-lg" label="John Doe">
+      <template #content>
+        Meu conteúdo customizado
+      </template>
     </qas-expansion-item>
   </div>
 </template>
 
 <script setup>
 defineOptions({ name: 'Disable' })
-
 </script>

--- a/docs/src/examples/QasExpansionItem/Disable.vue
+++ b/docs/src/examples/QasExpansionItem/Disable.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="container spaced">
+    <qas-expansion-item label="John Doe">
+      <template #content>
+        Meu conteúdo customizado
+      </template>
+      <!-- <template #header>
+        Meu conteúdo customizado
+      </template> -->
+    </qas-expansion-item>
+  </div>
+</template>
+
+<script setup>
+defineOptions({ name: 'Disable' })
+
+</script>

--- a/docs/src/examples/QasExpansionItem/Group.vue
+++ b/docs/src/examples/QasExpansionItem/Group.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="container spaced">
+    <qas-expansion-item group="user" label="John Doe user">
+      <template #content>
+        Meu conteúdo customizado
+      </template>
+    </qas-expansion-item>
+
+    <qas-expansion-item class="q-mt-lg" group="user" label="John Doe 2 user">
+      <template #content>
+        Meu conteúdo customizado
+      </template>
+    </qas-expansion-item>
+
+    <q-separator class="q-my-lg" />
+
+    <qas-expansion-item class="q-mt-lg" group="contact" label="Contact">
+      <template #content>
+        Meu conteúdo customizado
+      </template>
+    </qas-expansion-item>
+
+    <qas-expansion-item class="q-mt-lg" group="contact" label="Contact 2">
+      <template #content>
+        Meu conteúdo customizado
+      </template>
+    </qas-expansion-item>
+  </div>
+</template>
+
+<script setup>
+defineOptions({ name: 'Group' })
+</script>

--- a/docs/src/pages/components/expansion-item.md
+++ b/docs/src/pages/components/expansion-item.md
@@ -18,9 +18,10 @@ Componente de card expansivo, wrapper do QExpansionItem(https://quasar.dev/vue-c
 
 ## Uso
 
-<doc-example file="QasExpansionItem/Basic" title="Básico" />
+<!-- <doc-example file="QasExpansionItem/Basic" title="Básico" />
 <doc-example file="QasExpansionItem/Slot" title="Slot" />
 <doc-example file="QasExpansionItem/Nested" title="Nested" />
 <doc-example file="QasExpansionItem/HeaderBottomSlot" title="HeaderBottomSlot" />
 <doc-example file="QasExpansionItem/Error" title="Com erro" />
-<doc-example file="QasExpansionItem/WithBox" title="Dentro de um QasBox" />
+<doc-example file="QasExpansionItem/WithBox" title="Dentro de um QasBox" /> -->
+<doc-example file="QasExpansionItem/Disable" title="Desabilitado" />

--- a/docs/src/pages/components/expansion-item.md
+++ b/docs/src/pages/components/expansion-item.md
@@ -9,6 +9,7 @@ Componente de card expansivo, wrapper do QExpansionItem(https://quasar.dev/vue-c
 :::info
 - Quando usado QasExpansionItem dentro de QasExpansionItem, o componente já lida com isto internamente alterando o estilo dos QasExpansionItem interno.
 - O componente repassa todos os eventos do [QExpansionItem](https://quasar.dev/vue-components/expansion-item#usage).
+- Usar o "disable-button" em casos onde não existe previamente o conteúdo para o slot `content`, e o "disable" para quando de fato o componente precisa estar "desabilitado".
 :::
 
 :::warning
@@ -17,11 +18,11 @@ Componente de card expansivo, wrapper do QExpansionItem(https://quasar.dev/vue-c
 :::
 
 ## Uso
-
-<!-- <doc-example file="QasExpansionItem/Basic" title="Básico" />
+<doc-example file="QasExpansionItem/Basic" title="Básico" />
 <doc-example file="QasExpansionItem/Slot" title="Slot" />
 <doc-example file="QasExpansionItem/Nested" title="Nested" />
 <doc-example file="QasExpansionItem/HeaderBottomSlot" title="HeaderBottomSlot" />
 <doc-example file="QasExpansionItem/Error" title="Com erro" />
-<doc-example file="QasExpansionItem/WithBox" title="Dentro de um QasBox" /> -->
+<doc-example file="QasExpansionItem/WithBox" title="Dentro de um QasBox" />
 <doc-example file="QasExpansionItem/Disable" title="Desabilitado" />
+<doc-example file="QasExpansionItem/Group" title="Agrupamento" />

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -1,7 +1,7 @@
 <template>
   <div ref="expansionItem" class="full-width qas-expansion-item" :class="classes" v-bind="expansionProps.parent">
     <component :is="component.is" class="qas-expansion-item__box" v-bind="boxProps">
-      <q-expansion-item v-model="modelValue" v-bind="expansionProps.item" :disable="isDisabled" :group="props.group" header-class="text-bold q-mt-sm q-pa-none qas-expansion-item__header" hide-expand-icon :label="props.label">
+      <q-expansion-item v-model="modelValue" v-bind="expansionProps.item" header-class="text-bold q-mt-sm q-pa-none qas-expansion-item__header">
         <template #header>
           <slot name="header">
             <div class="full-width justify-between no-wrap row">
@@ -172,11 +172,15 @@ const expansionProps = computed(() => {
   } = attrs
 
   return {
-    parent: {
-      ...propsPayload
-    },
+    parent: propsPayload,
 
     item: {
+      disable: isDisabled.value,
+      hideExpandIcon: true,
+      label: props.label,
+      group: props.group,
+
+      // events
       onUpdateModelValue,
       onShow,
       onBeforeShow,

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -149,8 +149,7 @@ const classes = computed(() => {
   return {
     'qas-expansion-item--error': hasError.value,
     'qas-expansion-item--disabled': props.disable || props.disableButton,
-    'qas-expansion-item--disabled-full': props.disable,
-    'qas-expansion-item--disabled-button': !props.disable && props.disableButton
+    'qas-expansion-item--disabled-full': props.disable
   }
 })
 

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -1,27 +1,31 @@
 <template>
   <div ref="expansionItem" class="full-width qas-expansion-item" :class="errorClasses" v-bind="expansionProps.parent">
     <component :is="component.is" class="qas-expansion-item__box" v-bind="boxProps">
-      <q-expansion-item header-class="text-bold q-mt-sm q-pa-none qas-expansion-item__header" :label="props.label" v-bind="expansionProps.item">
+      <q-expansion-item v-bind="expansionProps.item" :disable="true" header-class="text-bold q-mt-sm q-pa-none qas-expansion-item__header" hide-expand-icon :label="props.label">
         <template #header>
           <slot name="header">
-            <div class="full-width">
-              <div class="items-center q-col-gutter-sm row">
-                <slot name="label">
-                  <h5 class="col-auto text-h5">
-                    {{ props.label }}
-                  </h5>
-                </slot>
+            <div class="full-width justify-between row">
+              <div class="col-auto">
+                <div class="items-center q-col-gutter-sm row">
+                  <slot name="label">
+                    <h5 class="col-auto text-h5">
+                      {{ props.label }}
+                    </h5>
+                  </slot>
 
-                <div class="col-auto items-center q-col-gutter-sm row">
-                  <div v-for="(badge, badgeIndex) in props.badges" :key="badgeIndex" class="col-auto">
-                    <qas-badge v-bind="badge" />
+                  <div v-if="hasBadges" class="col-auto items-center q-col-gutter-sm row">
+                    <div v-for="(badge, badgeIndex) in props.badges" :key="badgeIndex" class="col-auto">
+                      <qas-badge v-bind="badge" />
+                    </div>
                   </div>
+                </div>
+
+                <div v-if="hasHeaderBottom" class="q-mt-sm">
+                  <slot name="header-bottom" />
                 </div>
               </div>
 
-              <div v-if="hasHeaderBottom" class="q-mt-sm">
-                <slot name="header-bottom" />
-              </div>
+              <qas-btn icon="sym_r_keyboard_arrow_up" />
             </div>
           </slot>
         </template>
@@ -58,6 +62,11 @@ const props = defineProps({
   badges: {
     type: Array,
     default: () => []
+  },
+
+  disabled: {
+    type: Boolean,
+    default: false
   },
 
   error: {
@@ -107,6 +116,7 @@ const component = {
 }
 
 // computed
+const hasBadges = computed(() => !!props.badges.length)
 const hasError = computed(() => props.error || !!props.errorMessage)
 const hasGridGenerator = computed(() => !!Object.keys(props.gridGeneratorProps).length)
 const hasBottomSeparator = computed(() => isNestedExpansionItem && hasNextSibling.value)

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -1,31 +1,33 @@
 <template>
-  <div ref="expansionItem" class="full-width qas-expansion-item" :class="errorClasses" v-bind="expansionProps.parent">
+  <div ref="expansionItem" class="full-width qas-expansion-item" :class="classes" v-bind="expansionProps.parent">
     <component :is="component.is" class="qas-expansion-item__box" v-bind="boxProps">
-      <q-expansion-item v-bind="expansionProps.item" :disable="true" header-class="text-bold q-mt-sm q-pa-none qas-expansion-item__header" hide-expand-icon :label="props.label">
+      <q-expansion-item v-model="modelValue" v-bind="expansionProps.item" :disable="isDisabled" :group="props.group" header-class="text-bold q-mt-sm q-pa-none qas-expansion-item__header" hide-expand-icon :label="props.label">
         <template #header>
           <slot name="header">
-            <div class="full-width justify-between row">
-              <div class="col-auto">
-                <div class="items-center q-col-gutter-sm row">
-                  <slot name="label">
-                    <h5 class="col-auto text-h5">
-                      {{ props.label }}
-                    </h5>
-                  </slot>
+            <div class="full-width justify-between no-wrap row">
+              <div>
+                <slot name="header-left">
+                  <div class="items-center q-col-gutter-sm row">
+                    <slot name="label">
+                      <h5 class="col-auto qas-expansion-item__label text-h5">
+                        {{ props.label }}
+                      </h5>
+                    </slot>
 
-                  <div v-if="hasBadges" class="col-auto items-center q-col-gutter-sm row">
-                    <div v-for="(badge, badgeIndex) in props.badges" :key="badgeIndex" class="col-auto">
-                      <qas-badge v-bind="badge" />
+                    <div v-if="hasBadges" class="col-auto items-center q-col-gutter-sm row">
+                      <div v-for="(badge, badgeIndex) in props.badges" :key="badgeIndex" class="col-auto">
+                        <qas-badge v-bind="badge" />
+                      </div>
                     </div>
                   </div>
-                </div>
 
-                <div v-if="hasHeaderBottom" class="q-mt-sm">
-                  <slot name="header-bottom" />
-                </div>
+                  <div v-if="hasHeaderBottom" class="q-mt-sm">
+                    <slot name="header-bottom" />
+                  </div>
+                </slot>
               </div>
 
-              <qas-btn icon="sym_r_keyboard_arrow_up" />
+              <qas-btn class="qas-expansion-item__dropdown" color="grey-10" :disable="isDisabled" icon="sym_r_keyboard_arrow_up" />
             </div>
           </slot>
         </template>
@@ -64,9 +66,12 @@ const props = defineProps({
     default: () => []
   },
 
-  disabled: {
-    type: Boolean,
-    default: false
+  disable: {
+    type: Boolean
+  },
+
+  disableButton: {
+    type: Boolean
   },
 
   error: {
@@ -74,6 +79,11 @@ const props = defineProps({
   },
 
   errorMessage: {
+    type: String,
+    default: ''
+  },
+
+  group: {
     type: String,
     default: ''
   },
@@ -93,6 +103,8 @@ const props = defineProps({
     default: undefined
   }
 })
+
+const modelValue = defineModel({ type: Boolean })
 
 const attrs = useAttrs()
 
@@ -133,7 +145,14 @@ const hasHeaderSeparator = computed(() => {
   return typeof props.useHeaderSeparator === 'undefined' ? !isNestedExpansionItem : props.useHeaderSeparator
 })
 
-const errorClasses = computed(() => ({ 'qas-expansion-item--error': hasError.value }))
+const classes = computed(() => {
+  return {
+    'qas-expansion-item--error': hasError.value,
+    'qas-expansion-item--disabled': props.disable || props.disableButton,
+    'qas-expansion-item--disabled-full': props.disable,
+    'qas-expansion-item--disabled-button': !props.disable && props.disableButton
+  }
+})
 
 const contentClasses = computed(() => {
   return {
@@ -184,6 +203,8 @@ const boxProps = computed(() => {
   }
 })
 
+const isDisabled = computed(() => props.disable || props.disableButton)
+
 // functions
 
 /**
@@ -204,10 +225,16 @@ function setHasNextSibling (value) {
 .qas-expansion-item {
   $root: &;
 
-  // em alguns casos quando usado com grid, o espaçamento afetava o header, com z-index o problema é resolvido
-  &__header {
-    position: relative;
-    z-index: 1;
+  &--disabled {
+    .q-item.disabled {
+      opacity: 1 !important;
+    }
+  }
+
+  &--disabled-full {
+    #{$root}__label {
+      color: $grey-6 !important;
+    }
   }
 
   &--error {
@@ -217,6 +244,24 @@ function setHasNextSibling (value) {
 
     #{$root}__error-message {
       padding-left: 12px; // espaçamento igual ao de erro do quasar.
+    }
+  }
+
+  // em alguns casos quando usado com grid, o espaçamento afetava o header, com z-index o problema é resolvido
+  &__header {
+    position: relative;
+    z-index: 1;
+  }
+
+  .q-expansion-item {
+    #{$root}__dropdown {
+      transition: transform var(--qas-generic-transition);;
+    }
+
+    &--expanded {
+      #{$root}__dropdown {
+        transform: rotate(180deg);
+      }
     }
   }
 

--- a/ui/src/components/expansion-item/QasExpansionItem.yml
+++ b/ui/src/components/expansion-item/QasExpansionItem.yml
@@ -8,6 +8,16 @@ props:
     desc: Lista de badges que serão exibidas na parte superior do card.
     type: Array
 
+  disable:
+    desc: Desabilita o componente e aplica estilo de desabilitado no label e no button.
+    default: false
+    type: Boolean
+
+  disable-button:
+    desc: Desabilita o componente sem aplicar o estilo de desabilitado no label (usar em casos onde não tem conteúdo no slot content).
+    default: false
+    type: Boolean
+
   error:
     desc: Booleano que caso seja true o card passa a ter uma borda vermelha.
     type: Boolean
@@ -16,9 +26,19 @@ props:
     desc: Mensagem de erro onde será exibida na parte inferior do card.
     type: String
 
+  group:
+    desc: Agrupamento para estado aberto|fechado.
+    default: ''
+    type: String
+
   label:
     desc: Titulo exibido na parte superior do card.
     type: String
+
+  model-value:
+    desc: Model que controla o estado aberto|fechado.
+    default: false
+    type: Boolean
 
   grid-generator-props:
     desc: Propriedades que serão repassadas para o QasGridGenerator.
@@ -31,13 +51,24 @@ props:
 
 slots:
   header:
-    desc: 'Slot para substituir o conteúdo do header'
+    desc: Slot para substituir o conteúdo do header (incluindo o botão dropdown).
 
   header-bottom:
-    desc: 'Slot para acessar o conteúdo que fica abaixo do header.'
+    desc: Slot para acessar o conteúdo que fica abaixo do header.
+
+  header-left:
+    desc: Slot para substituir o conteúdo do header á esquerda (não inclui o botão dropdown).
 
   label:
-    desc: 'Slot para substituir o conteúdo da label do header.'
+    desc: Slot para substituir o conteúdo da label do header.
 
   content:
-    desc: 'Slot para substituir o conteúdo principal do card.'
+    desc: Slot para substituir o conteúdo principal do card.
+
+events:
+  '@update:model-value -> function(value)':
+    desc: Dispara quando o model-value altera, também usado para v-model.
+    params:
+      value:
+        desc: Novo valor do model.
+        type: Boolean


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
## BREAKING CHANGES
- `QasExpansionItems`: modificado slot header, agora ao abrir, ele sobrescreve toda a seção header, incluindo o botão de dropdown.

### Adicionado
- `QasExpansionItems`:
  - adicionado propriedade `disable`.
  - adicionado propriedade `disableButton`.
  - adicionado propriedade `group`.
  - adicionado v-model.
  - adicionado novo slot `header-left`.

### Modificado
- `QasExpansionItems`: modificado slot header, agora ao abrir, ele sobrescreve toda a seção header, incluindo o botão de dropdown.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
