### PR TITLE
QasHeader: fix actions slot.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasHeader`: corrigido bug quando abria o slot de actions e não renderizava elemento, por exemplo com v-if.
+
 ## [3.17.0-beta.10] - 08-10-2024
 ## BREAKING CHANGES
 - `QasExpansionItems`: modificado slot header, agora ao abrir, ele sobrescreve toda a seção header, incluindo o botão de dropdown.

--- a/ui/src/components/header/QasHeader.vue
+++ b/ui/src/components/header/QasHeader.vue
@@ -14,8 +14,8 @@
       </div>
 
       <slot name="actions">
-        <div class="q-mt-xs text-right">
-          <component :is="actionsComponent.is" v-if="hasActionsSection" v-bind="actionsComponent.props" />
+        <div v-if="hasActionsSection" class="q-mt-xs text-right">
+          <component :is="actionsComponent.is" v-if="hasActionsComponent" v-bind="actionsComponent.props" />
         </div>
       </slot>
     </div>
@@ -29,7 +29,7 @@
 
       <div v-if="!hasLabelSection" class="justify-end row">
         <slot name="actions">
-          <component :is="actionsComponent.is" v-if="hasActionsSection" v-bind="actionsComponent.props" />
+          <component :is="actionsComponent.is" v-if="hasActionsComponent" v-bind="actionsComponent.props" />
         </slot>
       </div>
     </div>
@@ -133,12 +133,16 @@ const actionsComponent = computed(() => {
     }
   }
 
+  console.log(component, 'component')
+
   return component.true
 })
 
-const hasActionsSection = computed(() => {
-  return !!slots.actions || hasDefaultButton.value || hasDefaultActionsMenu.value || hasDefaultFilters.value
+const hasActionsComponent = computed(() => {
+  return hasDefaultButton.value || hasDefaultActionsMenu.value || hasDefaultFilters.value
 })
+
+const hasActionsSection = computed(() => !!slots.actions || hasActionsComponent.value)
 
 const hasBadges = computed(() => !!props.badges.length)
 const hasLabel = computed(() => !!Object.keys(props.labelProps).length)

--- a/ui/src/components/header/QasHeader.vue
+++ b/ui/src/components/header/QasHeader.vue
@@ -133,8 +133,6 @@ const actionsComponent = computed(() => {
     }
   }
 
-  console.log(component, 'component')
-
   return component.true
 })
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Corrigido
- `QasHeader`: corrigido bug quando abria o slot de actions e não renderizava elemento, por exemplo com v-if.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
