### PR TITLE
Ajustes - QasExpansionItem / QasCheckbox / QasRadio / QasTableGenerator / QasGrabbable / QasCopy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ## BREAKING CHANGES
 - `QasRadio` e `QasCheckbox`: Adicionado label por padrão a partir do field, caso tenha lugares que são feitos a mão, irá duplicar a label.
 
+### Corrigido
+- `QasTableGenerator`: Corrigido scroll vertical desnecessário no Safari.
+
 ### Adicionado
 - `QasRadio` e `QasCheckbox`: Adicionado label por padrão em casos de ter mais de uma opção.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,11 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ### Corrigido
 - `QasTableGenerator`: Corrigido scroll vertical desnecessário no Safari.
+- `QasGrabbable`: Corrigido o grab em casos de não passar elementos para ignorar.
 
 ### Adicionado
 - `QasRadio` e `QasCheckbox`: Adicionado label por padrão em casos de ter mais de uma opção.
+- `QasCopy`: Adicionado prop `use-text` para controlar se irá exibir label ao lado do botão de copiar.
 
 ## [3.17.0-beta.14] - 22-10-2024
 ### Corrigido

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+## BREAKING CHANGES
+- `QasRadio` e `QasCheckbox`: Adicionado label por padrão a partir do field, caso tenha lugares que são feitos a mão, irá duplicar a label.
+
+### Adicionado
+- `QasRadio` e `QasCheckbox`: Adicionado label por padrão em casos de ter mais de uma opção.
+
 ## [3.17.0-beta.14] - 22-10-2024
 ### Corrigido
 - `QasBoardGenerator`:

--- a/docs/src/examples/QasCheckbox/Children.vue
+++ b/docs/src/examples/QasCheckbox/Children.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container spaced">
-    <qas-checkbox v-model="model" label="Aceitar" :options="optionsChildren" />
+    <qas-checkbox v-model="model" label="Checkbox com chidren" :options="optionsChildren" />
 
     <div class="q-mt-lg">
       model: {{ model }}

--- a/docs/src/examples/QasCheckbox/Options.vue
+++ b/docs/src/examples/QasCheckbox/Options.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container spaced">
-    <qas-checkbox v-model="model" :options />
+    <qas-checkbox v-model="model" label="Checkbox com opções" :options />
 
     <div class="q-mt-lg">
       model: {{ model }}

--- a/docs/src/examples/QasExpansionItem/WithMaxContentHeight.vue
+++ b/docs/src/examples/QasExpansionItem/WithMaxContentHeight.vue
@@ -1,0 +1,40 @@
+<template>
+  <!-- Usando qas-single-view apenas para recuperar os dados -->
+  <qas-single-view v-model:fields="fields" v-model:result="result" :custom-id="customId" :entity="entity">
+    <qas-expansion-item :badges="badges" :grid-generator-props="gridGeneratorProps" label="John Doe" max-content-height="150px" />
+  </qas-single-view>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+
+defineOptions({ name: 'WithMaxContentHeight' })
+
+const fields = ref({})
+const result = ref({})
+
+const entity = 'users'
+
+const badges = [
+  {
+    color: 'green-14',
+    label: 'Aprovado',
+    textColor: 'white'
+  },
+  {
+    color: 'red-14',
+    label: 'Reprovado',
+    textColor: 'white'
+  }
+]
+
+const gridGeneratorProps = computed(() => {
+  return {
+    fields: fields.value,
+    result: result.value
+  }
+})
+
+// USAR SOMENTE SE NECESSÁRIO, AQUI PEGAMOS O ID DO USUÁRIO NO NOSSO MOCK DE DADOS
+const customId = '3102fad5-f14c-45d4-98e9-46ef0aa9580e'
+</script>

--- a/docs/src/examples/QasExpansionItem/WithMaxContentHeight.vue
+++ b/docs/src/examples/QasExpansionItem/WithMaxContentHeight.vue
@@ -1,17 +1,17 @@
 <template>
   <!-- Usando qas-single-view apenas para recuperar os dados -->
-  <qas-single-view v-model:fields="fields" v-model:result="result" :custom-id="customId" :entity="entity">
-    <qas-expansion-item :badges="badges" :grid-generator-props="gridGeneratorProps" label="John Doe" max-content-height="150px" />
+  <qas-single-view v-model:fields="viewState.fields" v-model:result="viewState.result" :custom-id="customId" :entity="entity">
+    <qas-expansion-item :badges="badges" :fields="viewState.fields" :grid-generator-props="gridGeneratorProps" label="John Doe" max-content-height="150px" :result="viewState.result" />
   </qas-single-view>
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { computed } from 'vue'
+import { useView } from '@bildvitta/composables'
 
 defineOptions({ name: 'WithMaxContentHeight' })
 
-const fields = ref({})
-const result = ref({})
+const { viewState } = useView({ mode: 'single' })
 
 const entity = 'users'
 
@@ -30,8 +30,8 @@ const badges = [
 
 const gridGeneratorProps = computed(() => {
   return {
-    fields: fields.value,
-    result: result.value
+    fields: viewState.value.fields,
+    result: viewState.value.result
   }
 })
 

--- a/docs/src/examples/QasField/Checkbox.vue
+++ b/docs/src/examples/QasField/Checkbox.vue
@@ -1,14 +1,12 @@
 <template>
   <div class="container spaced">
-    <div>Com children: </div>
-    <qas-field v-model="model" :field="{ ...field, options: childrenOptions }" />
+    <qas-field v-model="model" :field="fieldWithChildren" />
 
     <div class="q-my-lg">
       model: <qas-debugger :inspect="[model]" />
     </div>
 
-    <div>Sem children: </div>
-    <qas-field v-model="model2" :field="{ ...field, options }" />
+    <qas-field v-model="model2" :field="fieldWithoutChildren" />
 
     <div class="q-my-lg">
       model2: <qas-debugger :inspect="[model2]" />
@@ -26,48 +24,46 @@ export default {
   },
 
   computed: {
-    field () {
+    fieldWithChildren () {
       return {
         name: 'checkbox',
         type: 'checkbox',
-        label: 'Campo checkbox'
+        label: 'Campo checkbox com children',
+        options: [
+          {
+            label: 'Opção 1',
+            value: 1,
+            children: [
+              {
+                label: 'Opção 2',
+                value: 2
+              },
+              {
+                label: 'Opção 3',
+                value: 3
+              }
+            ]
+          }
+        ]
       }
     },
 
-    childrenOptions () {
-      return [
-        {
-          label: 'Opção 1',
-          value: 1,
-          children: [
-            {
-              label: 'Opção 2',
-              value: 2
-            },
-            {
-              label: 'Opção 3',
-              value: 3
-            }
-          ]
-        }
-      ]
-    },
-
-    options () {
-      return [
-        {
-          label: 'Opção 1',
-          value: 1
-        },
-        {
-          label: 'Opção 2',
-          value: 2
-        },
-        {
-          label: 'Opção 3',
-          value: 3
-        }
-      ]
+    fieldWithoutChildren () {
+      return {
+        name: 'checkbox',
+        type: 'checkbox',
+        label: 'Campo checkbox sem children',
+        options: [
+          {
+            label: 'Opção 2',
+            value: 2
+          },
+          {
+            label: 'Opção 3',
+            value: 3
+          }
+        ]
+      }
     }
   }
 }

--- a/docs/src/examples/QasRadio/OptionGroup.vue
+++ b/docs/src/examples/QasRadio/OptionGroup.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container spaced">
-    <qas-radio v-model="model" :options />
+    <qas-radio v-model="model" label="Com opções" :options />
   </div>
 </template>
 

--- a/docs/src/pages/components/checkbox.md
+++ b/docs/src/pages/components/checkbox.md
@@ -9,5 +9,9 @@ Componente para gerar dinamicamente checkbox agrupados.
 ## Uso
 
 <doc-example file="QasCheckbox/Single" title="Single" />
+
+:::info
+Caso não queira exibir a label acima do checkbox, no field não deverá ser enviado a prop "label".
+:::
 <doc-example file="QasCheckbox/Options" title="Options" />
 <doc-example file="QasCheckbox/Children" title="Children options" />

--- a/docs/src/pages/components/checkbox.md
+++ b/docs/src/pages/components/checkbox.md
@@ -7,11 +7,9 @@ Componente para gerar dinamicamente checkbox agrupados.
 <doc-api file="checkbox/QasCheckbox" name="QasCheckbox" />
 
 ## Uso
-
-<doc-example file="QasCheckbox/Single" title="Single" />
-
 :::info
-Caso não queira exibir a label acima do checkbox, no field não deverá ser enviado a prop "label".
+Por padrão é exibido a label em casos de ser options group, quando se recebe a prop "label". Caso não queria exibir, basta não enviar.
 :::
+<doc-example file="QasCheckbox/Single" title="Single" />
 <doc-example file="QasCheckbox/Options" title="Options" />
 <doc-example file="QasCheckbox/Children" title="Children options" />

--- a/docs/src/pages/components/expansion-item.md
+++ b/docs/src/pages/components/expansion-item.md
@@ -19,6 +19,7 @@ Componente de card expansivo, wrapper do QExpansionItem(https://quasar.dev/vue-c
 
 ## Uso
 <doc-example file="QasExpansionItem/Basic" title="Básico" />
+<doc-example file="QasExpansionItem/WithMaxContentHeight" title="Com limite de altura no conteúdo" />
 <doc-example file="QasExpansionItem/Slot" title="Slot" />
 <doc-example file="QasExpansionItem/Nested" title="Nested" />
 <doc-example file="QasExpansionItem/HeaderBottomSlot" title="HeaderBottomSlot" />

--- a/ui/src/components/checkbox/QasCheckbox.vue
+++ b/ui/src/components/checkbox/QasCheckbox.vue
@@ -6,16 +6,20 @@
     </q-checkbox>
 
     <!-- Group -->
-    <div v-else :class="classes">
-      <div v-for="(option, index) in props.options" :key="index">
-        <!-- Com children -->
-        <q-checkbox v-if="hasChildren(option)" :class="getCheckboxClass(option)" dense :label="option.label" :model-value="getModelValue(index)" @update:model-value="updateCheckbox($event, option, index)" />
+    <div v-else>
+      <div v-if="hasCheckboxLabel" class="q-mb-sm text-body1">{{ checkboxLabel }}</div>
 
-        <!-- Com children -->
-        <q-option-group v-if="hasChildren(option)" class="q-ml-xs q-mt-xs" dense :inline="props.inline" :model-value="props.modelValue" :options="option.children" type="checkbox" @update:model-value="updateChildren($event, option, index)" />
+      <div :class="classes">
+        <div v-for="(option, index) in props.options" :key="index">
+          <!-- Com children -->
+          <q-checkbox v-if="hasChildren(option)" :class="getCheckboxClass(option)" dense :label="option.label" :model-value="getModelValue(index)" @update:model-value="updateCheckbox($event, option, index)" />
 
-        <!-- Sem children -->
-        <q-option-group v-else v-model="model" v-bind="attrs" dense :options="[option]" type="checkbox" />
+          <!-- Com children -->
+          <q-option-group v-if="hasChildren(option)" class="q-ml-xs q-mt-xs" dense :inline="props.inline" :model-value="props.modelValue" :options="option.children" type="checkbox" @update:model-value="updateChildren($event, option, index)" />
+
+          <!-- Sem children -->
+          <q-option-group v-else v-model="model" v-bind="attrs" dense :options="[option]" type="checkbox" />
+        </div>
       </div>
     </div>
   </div>
@@ -58,6 +62,10 @@ onMounted(handleParent)
 
 // computed
 const classes = computed(() => props.inline && 'flex q-gutter-x-sm')
+
+const checkboxLabel = computed(() => attrs.label)
+
+const hasCheckboxLabel = computed(() => !!checkboxLabel.value)
 
 const model = computed({
   get () {

--- a/ui/src/components/checkbox/QasCheckbox.vue
+++ b/ui/src/components/checkbox/QasCheckbox.vue
@@ -1,13 +1,15 @@
 <template>
   <div>
     <!-- Single -->
-    <q-checkbox v-if="isSingle" v-model="model" v-bind="singleAttrs" dense>
+    <q-checkbox v-if="isSingle" v-model="model" v-bind="singleAttributes" dense>
       <slot />
     </q-checkbox>
 
     <!-- Group -->
     <div v-else>
-      <div v-if="hasCheckboxLabel" class="q-mb-sm text-body1">{{ checkboxLabel }}</div>
+      <div v-if="hasCheckboxLabel" class="q-mb-sm text-body1">
+        {{ props.label }}
+      </div>
 
       <div :class="classes">
         <div v-for="(option, index) in props.options" :key="index">
@@ -68,9 +70,7 @@ onMounted(handleParent)
 // computed
 const classes = computed(() => props.inline && 'flex q-gutter-x-sm')
 
-const checkboxLabel = computed(() => props.label)
-
-const hasCheckboxLabel = computed(() => !!checkboxLabel.value)
+const hasCheckboxLabel = computed(() => !!props.label)
 
 const model = computed({
   get () {
@@ -84,7 +84,7 @@ const model = computed({
 
 const isSingle = computed(() => !props.options.length)
 
-const singleAttrs = computed(() => {
+const singleAttributes = computed(() => {
   return {
     ...attrs,
 

--- a/ui/src/components/checkbox/QasCheckbox.vue
+++ b/ui/src/components/checkbox/QasCheckbox.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <!-- Single -->
-    <q-checkbox v-if="isSingle" v-model="model" v-bind="attrs" dense>
+    <q-checkbox v-if="isSingle" v-model="model" v-bind="singleAttrs" dense>
       <slot />
     </q-checkbox>
 
@@ -34,6 +34,11 @@ defineOptions({
 })
 
 const props = defineProps({
+  label: {
+    default: '',
+    type: String
+  },
+
   options: {
     default: () => [],
     type: Array
@@ -63,7 +68,7 @@ onMounted(handleParent)
 // computed
 const classes = computed(() => props.inline && 'flex q-gutter-x-sm')
 
-const checkboxLabel = computed(() => attrs.label)
+const checkboxLabel = computed(() => props.label)
 
 const hasCheckboxLabel = computed(() => !!checkboxLabel.value)
 
@@ -78,6 +83,14 @@ const model = computed({
 })
 
 const isSingle = computed(() => !props.options.length)
+
+const singleAttrs = computed(() => {
+  return {
+    ...attrs,
+
+    label: props.label
+  }
+})
 
 // watch
 watch(() => props.options, handleParent)

--- a/ui/src/components/checkbox/QasCheckbox.yml
+++ b/ui/src/components/checkbox/QasCheckbox.yml
@@ -9,6 +9,12 @@ props:
     default: true
     type: Boolean
 
+  label:
+    desc: Label utilizada em casos de ser checkbox-group.
+    default: ''
+    type: String
+
+
   model-value:
     desc: Model do componente, usado para v-model.
     default: []

--- a/ui/src/components/checkbox/QasCheckbox.yml
+++ b/ui/src/components/checkbox/QasCheckbox.yml
@@ -14,7 +14,6 @@ props:
     default: ''
     type: String
 
-
   model-value:
     desc: Model do componente, usado para v-model.
     default: []

--- a/ui/src/components/copy/QasCopy.vue
+++ b/ui/src/components/copy/QasCopy.vue
@@ -1,6 +1,6 @@
 <template>
   <span>
-    <slot>{{ props.text }}</slot>
+    <slot v-if="props.useText">{{ props.text }}</slot>
 
     <qas-btn class="q-ml-xs" color="primary" :icon="props.icon" :loading="isLoading" variant="tertiary" @click.stop.prevent="copy">
       <q-tooltip>Copiar</q-tooltip>
@@ -23,6 +23,11 @@ const props = defineProps({
   text: {
     required: true,
     type: String
+  },
+
+  useText: {
+    type: Boolean,
+    default: true
   }
 })
 

--- a/ui/src/components/copy/QasCopy.yml
+++ b/ui/src/components/copy/QasCopy.yml
@@ -13,3 +13,8 @@ props:
     desc: Texto a ser copiado.
     type: String
 
+  use-text:
+    desc: Controla se o texto vai ser exibido ou não no botão.
+    type: Boolean
+    default: true
+

--- a/ui/src/components/copy/QasCopy.yml
+++ b/ui/src/components/copy/QasCopy.yml
@@ -14,7 +14,7 @@ props:
     type: String
 
   use-text:
-    desc: Controla se o texto vai ser exibido ou não no botão.
+    desc: Controla se o texto será exibo ao lado do botão ou não.
     type: Boolean
     default: true
 

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -83,6 +83,11 @@ const props = defineProps({
     default: ''
   },
 
+  gridGeneratorProps: {
+    type: Object,
+    default: () => ({})
+  },
+
   group: {
     type: String,
     default: undefined
@@ -93,9 +98,9 @@ const props = defineProps({
     default: ''
   },
 
-  gridGeneratorProps: {
-    type: Object,
-    default: () => ({})
+  maxContentHeight: {
+    type: String,
+    default: ''
   },
 
   useHeaderSeparator: {
@@ -156,7 +161,8 @@ const classes = computed(() => {
 const contentClasses = computed(() => {
   return {
     'q-mt-sm': isNestedExpansionItem,
-    'q-mt-md': !isNestedExpansionItem && !props.useHeaderSeparator
+    'q-mt-md': !isNestedExpansionItem && !props.useHeaderSeparator,
+    'qas-expansion-item__content overflow-auto': !!props.maxContentHeight
   }
 })
 
@@ -248,6 +254,10 @@ function setHasNextSibling (value) {
     #{$root}__error-message {
       padding-left: 12px; // espaçamento igual ao de erro do quasar.
     }
+  }
+
+  &__content {
+    max-height: v-bind("props.maxContentHeight");
   }
 
   // em alguns casos quando usado com grid, o espaçamento afetava o header, com z-index o problema é resolvido

--- a/ui/src/components/expansion-item/QasExpansionItem.yml
+++ b/ui/src/components/expansion-item/QasExpansionItem.yml
@@ -40,6 +40,11 @@ props:
     default: false
     type: Boolean
 
+  max-content-height:
+    desc: Define um tamanho máximo de altura do conteúdo.
+    default: ''
+    type: String
+
   grid-generator-props:
     desc: Propriedades que serão repassadas para o QasGridGenerator.
     type: Object

--- a/ui/src/components/radio/QasRadio.vue
+++ b/ui/src/components/radio/QasRadio.vue
@@ -1,5 +1,9 @@
 <template>
-  <component :is="component.is" v-bind="component.props" />
+  <div>
+    <div v-if="canShowOptionGroupLabel" class="q-mb-sm text-body1">{{ optionGroupLabel }}</div>
+
+    <component :is="component.is" v-bind="component.props" />
+  </div>
 </template>
 
 <script setup>
@@ -12,6 +16,13 @@ defineOptions({
 
 const attrs = useAttrs()
 
+const isOptionGroup = computed(() => !!attrs.options?.length)
+
+const optionGroupLabel = computed(() => attrs.label)
+
+// Só mostra a label caso for q-option-group e tenha label vindo nas props
+const canShowOptionGroupLabel = computed(() => isOptionGroup.value && !!optionGroupLabel.value)
+
 /**
  * - quando é um grupo de opções, o componente é 'QOptionGroup', caso contrário,
  * é 'QRadio'.
@@ -19,16 +30,15 @@ const attrs = useAttrs()
  * - todos os casos é usado o dense.
  */
 const component = computed(() => {
-  const isOptionGroup = !!attrs.options?.length
-
   const { inline = true, ...payloadProps } = attrs
 
   return {
-    is: isOptionGroup ? 'q-option-group' : 'q-radio',
+    is: isOptionGroup.value ? 'q-option-group' : 'q-radio',
+
     props: {
       ...payloadProps,
 
-      ...(isOptionGroup && {
+      ...(isOptionGroup.value && {
         inline,
         class: {
           'q-gutter-x-md': inline,

--- a/ui/src/components/radio/QasRadio.vue
+++ b/ui/src/components/radio/QasRadio.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
-    <div v-if="canShowOptionGroupLabel" class="q-mb-sm text-body1">{{ optionGroupLabel }}</div>
+    <div v-if="canShowOptionGroupLabel" class="q-mb-sm text-body1">
+      {{ props.label }}
+    </div>
 
     <component :is="component.is" v-bind="component.props" />
   </div>
@@ -25,10 +27,8 @@ const attrs = useAttrs()
 
 const isOptionGroup = computed(() => !!attrs.options?.length)
 
-const optionGroupLabel = computed(() => props.label)
-
 // Só mostra a label caso for q-option-group e tenha label vindo nas props
-const canShowOptionGroupLabel = computed(() => isOptionGroup.value && !!optionGroupLabel.value)
+const canShowOptionGroupLabel = computed(() => isOptionGroup.value && !!props.label)
 
 /**
  * - quando é um grupo de opções, o componente é 'QOptionGroup', caso contrário,

--- a/ui/src/components/radio/QasRadio.vue
+++ b/ui/src/components/radio/QasRadio.vue
@@ -14,11 +14,18 @@ defineOptions({
   inheritAttrs: false
 })
 
+const props = defineProps({
+  label: {
+    default: '',
+    type: String
+  }
+})
+
 const attrs = useAttrs()
 
 const isOptionGroup = computed(() => !!attrs.options?.length)
 
-const optionGroupLabel = computed(() => attrs.label)
+const optionGroupLabel = computed(() => props.label)
 
 // Só mostra a label caso for q-option-group e tenha label vindo nas props
 const canShowOptionGroupLabel = computed(() => isOptionGroup.value && !!optionGroupLabel.value)
@@ -37,6 +44,8 @@ const component = computed(() => {
 
     props: {
       ...payloadProps,
+
+      label: props.label,
 
       ...(isOptionGroup.value && {
         inline,

--- a/ui/src/components/radio/QasRadio.yml
+++ b/ui/src/components/radio/QasRadio.yml
@@ -1,5 +1,11 @@
 type: component
 
+props:
+  label:
+    desc: Label utilizada em casos de ser q-option-group.
+    default: ''
+    type: String
+
 meta:
   desc: Componente wrapper do QRadio.
 

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -138,7 +138,9 @@ export default {
 
     attributes () {
       const attributes = {
-        tableClass: 'overflow-hidden-y',
+        tableClass: {
+          'overflow-hidden-y': !this.useStickyHeader
+        },
         class: this.tableClass,
         columns: this.columnsByFields,
         flat: true,

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -138,6 +138,7 @@ export default {
 
     attributes () {
       const attributes = {
+        tableClass: 'overflow-hidden-y',
         class: this.tableClass,
         columns: this.columnsByFields,
         flat: true,

--- a/ui/src/helpers/set-scroll-on-grab.js
+++ b/ui/src/helpers/set-scroll-on-grab.js
@@ -50,7 +50,7 @@ export default function (element, options = {}, cancelMouseDownTarget) {
     /**
      * closest busca ancestral mais próximo de um elemento, ou seja, verifica se no event que recebo, tenho a classe no qual nao se deve aplicar o grab.
      */
-    const targetElement = event.target.closest(`.${cancelMouseDownTarget}`)
+    const targetElement = cancelMouseDownTarget ? event.target.closest(`.${cancelMouseDownTarget}`) : null
 
     if (!!cancelMouseDownTarget && !!targetElement) return null
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
ExpansionItem
![image](https://github.com/user-attachments/assets/9c7b8079-fbc9-4c97-86ee-5b3d98dddf17)

Correção TableGenerator
DEPOIS:
![image](https://github.com/user-attachments/assets/31f4a615-8759-4942-bbb8-57d765cc916e)

ANTES:
![image](https://github.com/user-attachments/assets/d01a0348-ce1c-47ae-98a4-da9a359380f5)


## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
