### PR TITLE
feat(QasExpansionItem): HeaderSlot full width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,21 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
-### Adicionado
-- `QasExpansionItem`: Adicionado `full-width` para o slot `header-left` conseguir pegar largura total do elemento.
+## BREAKING CHANGES
+- `QasExpansionItem`:
+  - Renomeado slot `label` para `header-label`.
+  - Removido slot `header-left`.
+
+### Corrigido
+- `QasExpansionItem`: Corrigido direção do ícone de dropdown.
+
+### Modificado
+- `QasExpansionItem`:
+  - Modificado slot `header` para ele ser o antigo `header-left`, pegando toda a largura do conteúdo menos o ícone.
+  - Renomeado slot `label` para `header-label`.
+
+### Removido
+- `QasExpansionItem`: Removido slot `header-left`.
 
 ## [3.17.0-beta.16] - 11-11-2024
 ## BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasExpansionItem`: Adicionado `full-width` para o slot `header-left` conseguir pegar largura total do elemento.
+
 ## [3.17.0-beta.16] - 11-11-2024
 ## BREAKING CHANGES
 - `QasRadio` e `QasCheckbox`: Adicionado label por padrão a partir do field, caso tenha lugares que são feitos a mão, irá duplicar a label.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ## BREAKING CHANGES
 - `QasExpansionItem`:
   - Renomeado slot `label` para `header-label`.
-  - Removido slot `header-left`.
+  - Removido slot `header-left` (agora o `header` tem o mesmo comportamento que o `header-left`).
 
 ### Corrigido
 - `QasExpansionItem`: Corrigido direção do ícone de dropdown.
@@ -25,7 +25,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
   - Renomeado slot `label` para `header-label`.
 
 ### Removido
-- `QasExpansionItem`: Removido slot `header-left`.
+- `QasExpansionItem`: Removido slot `header-left` (agora o `header` tem o mesmo comportamento que o `header-left`).
 
 ## [3.17.0-beta.16] - 11-11-2024
 ## BREAKING CHANGES

--- a/docs/src/examples/QasExpansionItem/HeaderLeftSlot.vue
+++ b/docs/src/examples/QasExpansionItem/HeaderLeftSlot.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="container spaced">
+    <qas-expansion-item label="John Doe">
+      <template #header-left>
+        <div class="items-center justify-between row">
+          <qas-label label="Meu titulo" margin="none" typography="h5" />
+
+          <div class="text-body1 text-grey-8">
+            {{ date }}
+          </div>
+        </div>
+      </template>
+
+      <template #content>
+        Meu conteúdo customizado
+      </template>
+    </qas-expansion-item>
+  </div>
+</template>
+
+<script setup>
+import { dateTime } from '../../../../ui/src/helpers'
+
+defineOptions({ name: 'HeaderLeftSlot' })
+
+const date = dateTime('2023-01-11T14:58:40.000000Z')
+</script>

--- a/docs/src/examples/QasExpansionItem/HeaderSlot.vue
+++ b/docs/src/examples/QasExpansionItem/HeaderSlot.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container spaced">
     <qas-expansion-item label="John Doe">
-      <template #header-left>
+      <template #header>
         <div class="items-center justify-between row">
           <qas-label label="Meu titulo" margin="none" typography="h5" />
 
@@ -19,7 +19,7 @@
 </template>
 
 <script setup>
-import { dateTime } from '../../../../ui/src/helpers'
+import { dateTime } from '@bildvitta/quasar-ui-asteroid/src/helpers'
 
 defineOptions({ name: 'HeaderLeftSlot' })
 

--- a/docs/src/pages/components/expansion-item.md
+++ b/docs/src/pages/components/expansion-item.md
@@ -22,6 +22,7 @@ Componente de card expansivo, wrapper do QExpansionItem(https://quasar.dev/vue-c
 <doc-example file="QasExpansionItem/WithMaxContentHeight" title="Com limite de altura no conteúdo" />
 <doc-example file="QasExpansionItem/Slot" title="Slot" />
 <doc-example file="QasExpansionItem/Nested" title="Nested" />
+<doc-example file="QasExpansionItem/HeaderLeftSlot" title="HeaderLeftSlot" />
 <doc-example file="QasExpansionItem/HeaderBottomSlot" title="HeaderBottomSlot" />
 <doc-example file="QasExpansionItem/Error" title="Com erro" />
 <doc-example file="QasExpansionItem/WithBox" title="Dentro de um QasBox" />

--- a/docs/src/pages/components/expansion-item.md
+++ b/docs/src/pages/components/expansion-item.md
@@ -22,7 +22,7 @@ Componente de card expansivo, wrapper do QExpansionItem(https://quasar.dev/vue-c
 <doc-example file="QasExpansionItem/WithMaxContentHeight" title="Com limite de altura no conteúdo" />
 <doc-example file="QasExpansionItem/Slot" title="Slot" />
 <doc-example file="QasExpansionItem/Nested" title="Nested" />
-<doc-example file="QasExpansionItem/HeaderLeftSlot" title="HeaderLeftSlot" />
+<doc-example file="QasExpansionItem/HeaderSlot" title="Header Slot" />
 <doc-example file="QasExpansionItem/HeaderBottomSlot" title="HeaderBottomSlot" />
 <doc-example file="QasExpansionItem/Error" title="Com erro" />
 <doc-example file="QasExpansionItem/WithBox" title="Dentro de um QasBox" />

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -3,33 +3,31 @@
     <component :is="component.is" class="qas-expansion-item__box" v-bind="boxProps">
       <q-expansion-item v-model="modelValue" v-bind="expansionProps.item" header-class="text-bold q-mt-sm q-pa-none qas-expansion-item__header">
         <template #header>
-          <slot name="header">
-            <div class="full-width justify-between no-wrap row">
-              <div class="full-width">
-                <slot name="header-left">
-                  <div class="items-center q-col-gutter-sm row">
-                    <slot name="label">
-                      <h5 class="col-auto qas-expansion-item__label text-h5">
-                        {{ props.label }}
-                      </h5>
-                    </slot>
+          <div class="full-width justify-between no-wrap row">
+            <div class="full-width">
+              <slot name="header">
+                <div class="items-center q-col-gutter-sm row">
+                  <slot name="header-label">
+                    <h5 class="col-auto qas-expansion-item__label text-h5">
+                      {{ props.label }}
+                    </h5>
+                  </slot>
 
-                    <div v-if="hasBadges" class="col-auto items-center q-col-gutter-sm row">
-                      <div v-for="(badge, badgeIndex) in props.badges" :key="badgeIndex" class="col-auto">
-                        <qas-badge v-bind="badge" />
-                      </div>
+                  <div v-if="hasBadges" class="col-auto items-center q-col-gutter-sm row">
+                    <div v-for="(badge, badgeIndex) in props.badges" :key="badgeIndex" class="col-auto">
+                      <qas-badge v-bind="badge" />
                     </div>
                   </div>
+                </div>
 
-                  <div v-if="hasHeaderBottom" class="q-mt-sm">
-                    <slot name="header-bottom" />
-                  </div>
-                </slot>
-              </div>
-
-              <qas-btn class="qas-expansion-item__dropdown" color="grey-10" :disable="isDisabled" icon="sym_r_keyboard_arrow_up" />
+                <div v-if="hasHeaderBottom" class="q-mt-sm">
+                  <slot name="header-bottom" />
+                </div>
+              </slot>
             </div>
-          </slot>
+
+            <qas-btn class="qas-expansion-item__dropdown" color="grey-10" :disable="isDisabled" icon="sym_r_keyboard_arrow_down" />
+          </div>
         </template>
 
         <q-separator v-if="hasHeaderSeparator" class="q-my-md" />

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -8,9 +8,7 @@
               <slot name="header">
                 <div class="items-center q-col-gutter-sm row">
                   <slot name="header-label">
-                    <h5 class="col-auto qas-expansion-item__label text-h5">
-                      {{ props.label }}
-                    </h5>
+                    <qas-label class="col-auto qas-expansion-item__label" :label="props.label" margin="none" typography="h5" />
                   </slot>
 
                   <div v-if="hasBadges" class="col-auto items-center q-col-gutter-sm row">

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -5,7 +5,7 @@
         <template #header>
           <slot name="header">
             <div class="full-width justify-between no-wrap row">
-              <div>
+              <div class="full-width">
                 <slot name="header-left">
                   <div class="items-center q-col-gutter-sm row">
                     <slot name="label">

--- a/ui/src/components/expansion-item/QasExpansionItem.yml
+++ b/ui/src/components/expansion-item/QasExpansionItem.yml
@@ -56,15 +56,12 @@ props:
 
 slots:
   header:
-    desc: Slot para substituir o conteúdo do header (incluindo o botão dropdown).
+    desc: Slot para substituir o conteúdo do header (não inclui o botão dropdown).
 
   header-bottom:
     desc: Slot para acessar o conteúdo que fica abaixo do header.
 
-  header-left:
-    desc: Slot para substituir o conteúdo do header á esquerda (não inclui o botão dropdown).
-
-  label:
+  header-label:
     desc: Slot para substituir o conteúdo da label do header.
 
   content:


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- (Remova este texto de descrição.) -->
![image](https://github.com/user-attachments/assets/721b4c30-a3e4-4921-a4f2-7cf2c59b0210)

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
