### PR TITLE
feat(QasExpansionItem): insert border negative when has error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasExpansionItem`: Corrigido cor da borda em casos de erro e dentro de um `QasBox`.
+
 ## [3.17.0-beta.17] - 13-11-2024
 ## BREAKING CHANGES
 - `QasExpansionItem`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
+### Modificado
+- `QasExpansionItem`: Modificado comportamente renderizar na dom o content apenas ao abrir o expansion pela primeira vez.
+
 ### Corrigido
 - `QasExpansionItem`: Corrigido cor da borda em casos de erro e dentro de um `QasBox`.
 

--- a/docs/src/examples/QasExpansionItem/WithBox.vue
+++ b/docs/src/examples/QasExpansionItem/WithBox.vue
@@ -4,6 +4,8 @@
     <qas-box>
       <div class="q-mb-md">Conteúdo dentro de uma box, o Expansion deverá ter uma borda.</div>
       <qas-expansion-item :badges="badges" :grid-generator-props="gridGeneratorProps" label="John Doe" />
+
+      <qas-expansion-item class="q-mt-md" error error-message="Card com mensagem de erro" :grid-generator-props="gridGeneratorProps" label="John Doe" />
     </qas-box>
   </qas-single-view>
 </template>

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -244,7 +244,7 @@ function setHasNextSibling (value) {
 
   &--error {
     #{$root}__box {
-      border: 2px solid $negative;
+      border: 2px solid $negative !important;
     }
 
     #{$root}__error-message {

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -1,7 +1,7 @@
 <template>
   <div ref="expansionItem" class="full-width qas-expansion-item" :class="classes" v-bind="expansionProps.parent">
     <component :is="component.is" class="qas-expansion-item__box" v-bind="boxProps">
-      <q-expansion-item v-model="modelValue" v-bind="expansionProps.item" header-class="text-bold q-mt-sm q-pa-none qas-expansion-item__header">
+      <q-expansion-item v-model="modelValue" v-bind="expansionProps.item" header-class="text-bold q-mt-sm q-pa-none qas-expansion-item__header" @show="setShowContent">
         <template #header>
           <div class="full-width justify-between no-wrap row">
             <div class="full-width">
@@ -31,7 +31,7 @@
         <q-separator v-if="hasHeaderSeparator" class="q-my-md" />
 
         <div :class="contentClasses">
-          <slot name="content">
+          <slot v-if="showContent" name="content">
             <qas-grid-generator v-if="hasGridGenerator" use-inline v-bind="gridGeneratorProps" />
           </slot>
         </div>
@@ -117,6 +117,7 @@ const slots = defineSlots()
 // refs
 const expansionItem = ref(null)
 const hasNextSibling = ref(false)
+const showContent = ref(false)
 
 onMounted(setHasNextSibling)
 
@@ -216,13 +217,17 @@ const isDisabled = computed(() => props.disable || props.disableButton)
  * Caso o componente esteja dentro de um QasExpansionItem, verifica se existe um próximo irmão
  * para adicionar um separador.
  */
-function setHasNextSibling (value) {
+function setHasNextSibling () {
   if (!isNestedExpansionItem) return
 
   const hasTextContentSibling = !!expansionItem.value.nextSibling?.textContent?.trim?.()
   const hasElementSibling = !!expansionItem.value.nextElementSibling
 
   hasNextSibling.value = hasElementSibling || hasTextContentSibling
+}
+
+function setShowContent () {
+  showContent.value = true
 }
 </script>
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
![image](https://github.com/user-attachments/assets/ce93d3b2-5122-40b9-b85f-242df22305a0)


<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
