### PR TITLE
QasAppMenu: fix children issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## [Unreleased]
+### Corrigido
+- `QasAppMenu`: corrigido problema que ocorria quando um item do menu com "children" ficava vazio, ele quebrava por não encontrar a rota e mostrava um label mesmo que sem nenhum item abaixo.
+
 ## [3.17.0-beta.18] - 19-11-2024
 ## BREAKING CHANGES
 - `QasCard`: a prop `actionsMenuProps` anteriormente era passado diretamente era repassado pra o `list` internamente, impedindo de repassar outras props. Agora deve passar o `list` dentro do `actionsMenuProps`.

--- a/docs/src/pages/components/app-menu.md
+++ b/docs/src/pages/components/app-menu.md
@@ -6,6 +6,9 @@ Model do componente, controla quando o menu lateral é aberto e fechado.
 
 <doc-api file="app-menu/QasAppMenu" name="QasAppMenu" />
 
+:::info
+Não adicione prop "to" nos itens do menu que tem "children", é por ela que validamos se mostramos ou não a label no menu caso o children fique vazio (por questões de permissionamento).
+:::
 
 ## Uso
 <doc-example file="QasAppMenu/Basic" title="Básico" />

--- a/ui/src/components/app-menu/QasAppMenu.vue
+++ b/ui/src/components/app-menu/QasAppMenu.vue
@@ -58,7 +58,9 @@
                 </div>
               </div>
 
-              <q-item v-else :key="index" :active="isActive(menuItem)" active-class="q-router-link--active" class="qas-app-menu__item" :to="getRouterRedirect(menuItem)">
+              <!-- quando tem children vazio, não deve mostrar label do item, e a label do item
+              não tem "to", então validar se tem "to" para mostrar o item -->
+              <q-item v-else-if="menuItem.to" :key="index" :active="isActive(menuItem)" active-class="q-router-link--active" class="qas-app-menu__item" :to="getRouterRedirect(menuItem)">
                 <q-item-section v-if="menuItem.icon" avatar>
                   <q-icon :name="menuItem.icon" />
                 </q-item-section>
@@ -276,6 +278,9 @@ function hasSeparator (index) {
 }
 
 function isActive ({ to }) {
+  // quando o children vem vazio, "to" é "undefined", então precisa ser feito esta trativa.
+  if (!to) return false
+
   const currentPath = getNormalizedPath(router.currentRoute.value.path)
   const itemPath = typeof to === 'string' ? getNormalizedPath(to) : getPathFromObject(to)
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## [Unreleased]
### Corrigido
- `QasAppMenu`: corrigido problema que ocorria quando um item do menu com "children" ficava vazio, ele quebrava por não encontrar a rota e mostrava um label mesmo que sem nenhum item abaixo.


<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [ ] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
