### PR TITLE
feat: added raw-text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasCopy`: adicionado prop `raw-text` pra usar em casos onde o texto exibido não é o mesmo do valor que vai ser copiado.
+
 ## [3.17.0-beta.19] - 03-12-2024
 ### Corrigido
 - `QasAppMenu`: corrigido problema que ocorria quando um item do menu com "children" ficava vazio, ele quebrava por não encontrar a rota e mostrava um label mesmo que sem nenhum item abaixo.

--- a/docs/src/examples/QasCopy/WithRawText.vue
+++ b/docs/src/examples/QasCopy/WithRawText.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="container q-py-lg">
+    <qas-copy raw-text="Texto a ser copiado" text="Texto a ser exibido" />
+  </div>
+</template>
+
+<script setup>
+defineOptions({ name: 'WithRawText' })
+</script>

--- a/docs/src/pages/components/copy.md
+++ b/docs/src/pages/components/copy.md
@@ -9,3 +9,5 @@ Copia algum texto para o clipboard após clicar no botão.
 ## Uso
 
 <doc-example file="QasCopy/Basic" title="Básico" />
+
+<doc-example file="QasCopy/WithRawText" title="Valor copiado diferente do exibido" />

--- a/ui/src/components/copy/QasCopy.vue
+++ b/ui/src/components/copy/QasCopy.vue
@@ -28,13 +28,18 @@ const props = defineProps({
   useText: {
     type: Boolean,
     default: true
+  },
+
+  rawText: {
+    default: '',
+    type: String
   }
 })
 
 const isLoading = ref(false)
 
 function copy () {
-  copyToClipboard(props.text, value => {
+  copyToClipboard(props.rawText || props.text, value => {
     isLoading.value = value
   })
 }

--- a/ui/src/components/copy/QasCopy.yml
+++ b/ui/src/components/copy/QasCopy.yml
@@ -19,5 +19,5 @@ props:
     default: true
 
   raw-text:
-    desc: Valor a ser copiado caso seja diferente do texto exibido.
+    desc: Caso o texto a ser copiado precise ser diferente do texto a ser exibido, utilize esta propriedade.
     type: String

--- a/ui/src/components/copy/QasCopy.yml
+++ b/ui/src/components/copy/QasCopy.yml
@@ -18,3 +18,6 @@ props:
     type: Boolean
     default: true
 
+  raw-text:
+    desc: Valor a ser copiado caso seja diferente do texto exibido.
+    type: String


### PR DESCRIPTION
### Adicionado
- `QasCopy`: adicionado prop `raw-text` pra usar em casos onde o texto exibido não é o mesmo do valor que vai ser copiado.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
