### PR TITLE
feat: fix header fieldset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ### Adicionado
 - `QasCopy`: adicionado prop `raw-text` pra usar em casos onde o texto exibido não é o mesmo do valor que vai ser copiado.
 
+### Corrigido
+- `QasFormGenerator`: corrigido validação para exibição do `fieldset`, ao não passar propriedades como label e description, fazia com que ficasse um espaço em branco.
+
 ## [3.17.0-beta.19] - 03-12-2024
 ### Corrigido
 - `QasAppMenu`: corrigido problema que ocorria quando um item do menu com "children" ficava vazio, ele quebrava por não encontrar a rota e mostrava um label mesmo que sem nenhum item abaixo.

--- a/docs/src/examples/QasFormGenerator/Fieldset.vue
+++ b/docs/src/examples/QasFormGenerator/Fieldset.vue
@@ -33,7 +33,10 @@ export default {
       return {
         isActive: { col: 12 },
         company: { col: 12 },
-        phone: { col: 12 }
+        phone: { col: 12 },
+        manager: { col: 12, sm: 4 },
+        supervisor: { col: 12, sm: 4 },
+        realEstateBroker: { col: 12, sm: 4 }
       }
     },
 
@@ -87,6 +90,10 @@ export default {
           description: 'Informe o documento do usuário.',
           fields: ['phone', 'company'],
           column: { col: 12, sm: 6 }
+        },
+
+        salesTeam: {
+          fields: ['manager', 'supervisor', 'realEstateBroker']
         }
       }
     },
@@ -121,6 +128,54 @@ export default {
             {
               label: 'Empresa 3',
               value: 'empresa-3'
+            }
+          ]
+        },
+
+        manager: {
+          name: 'manager',
+          label: 'Gerente',
+          type: 'select',
+          options: [
+            {
+              label: 'Cleyton da Silva',
+              value: 'cleyton-da-silva'
+            },
+            {
+              label: 'Julio Souza',
+              value: 'julio-souza'
+            }
+          ]
+        },
+
+        supervisor: {
+          name: 'supervisor',
+          label: 'Supervisor',
+          type: 'select',
+          options: [
+            {
+              label: 'Cleyton da Silva',
+              value: 'cleyton-da-silva'
+            },
+            {
+              label: 'Julio Souza',
+              value: 'julio-souza'
+            }
+          ]
+        },
+
+        realEstateBroker: {
+          name: 'realEstateBroker',
+          label: 'Corretor',
+          type: 'select',
+          options: [
+            {
+              label: 'Cleyton da Silva',
+              value: 'cleyton-da-silva'
+            },
+            {
+              label: 'Julio Souza',
+              value: 'julio-souza'
             }
           ]
         },

--- a/ui/src/components/form-generator/QasFormGenerator.vue
+++ b/ui/src/components/form-generator/QasFormGenerator.vue
@@ -169,16 +169,23 @@ const normalizedFields = computed(() => {
   for (const fieldsetKey in props.fieldset) {
     const fieldsetItem = props.fieldset[fieldsetKey]
 
-    const { label, description, headerProps } = fieldsetItem
-    const hasHeader = !!label || !!description || Object.keys(headerProps || {}).length
+    const {
+      label,
+      description,
+      column,
+      buttonProps,
+      headerProps
+    } = fieldsetItem
+
+    const hasHeader = !!(label || description || Object.keys(headerProps || {}).length)
 
     fields[fieldsetKey] = {
-      label: fieldsetItem.label,
-      description: fieldsetItem.description,
-      column: fieldsetItem.column,
-      buttonProps: fieldsetItem.buttonProps,
+      label,
+      description,
+      column,
+      buttonProps,
       fields: { hidden: {}, visible: {} },
-      headerProps: fieldsetItem.headerProps,
+      headerProps,
 
       // Indica que existe um fieldset para que o legend-bottom possa ser renderizado.
       __hasFieldset: true,

--- a/ui/src/components/form-generator/QasFormGenerator.vue
+++ b/ui/src/components/form-generator/QasFormGenerator.vue
@@ -169,6 +169,9 @@ const normalizedFields = computed(() => {
   for (const fieldsetKey in props.fieldset) {
     const fieldsetItem = props.fieldset[fieldsetKey]
 
+    const { label, description, headerProps } = fieldsetItem
+    const hasHeader = !!label || !!description || Object.keys(headerProps || {}).length
+
     fields[fieldsetKey] = {
       label: fieldsetItem.label,
       description: fieldsetItem.description,
@@ -181,9 +184,7 @@ const normalizedFields = computed(() => {
       __hasFieldset: true,
 
       // Indica que existe props para que o header seja renderizado.
-      __hasHeader: (
-        !!fieldsetItem.label || !!fieldsetItem.description || Object.keys(fieldsetItem.headerProps || {}).length
-      )
+      __hasHeader: hasHeader
     }
 
     fieldsetItem.fields.forEach(fieldName => {

--- a/ui/src/components/form-generator/QasFormGenerator.vue
+++ b/ui/src/components/form-generator/QasFormGenerator.vue
@@ -2,8 +2,8 @@
   <div :class="fieldsetClasses">
     <div v-for="(fieldsetItem, fieldsetItemKey) in normalizedFields" :key="fieldsetItemKey" :class="getFieldSetColumnClass(fieldsetItem.column)">
       <component :is="containerComponent.is" v-bind="containerComponent.props">
-        <slot v-if="fieldsetItem.__hasHeader" :name="`legend-${fieldsetItemKey}`">
-          <qas-header v-bind="getHeaderProps(fieldsetItem)" />
+        <slot v-if="fieldsetItem.__hasFieldset" :name="`legend-${fieldsetItemKey}`">
+          <qas-header v-if="fieldsetItem.__hasHeader" v-bind="getHeaderProps(fieldsetItem)" />
         </slot>
 
         <div>

--- a/ui/src/components/form-generator/QasFormGenerator.vue
+++ b/ui/src/components/form-generator/QasFormGenerator.vue
@@ -2,7 +2,7 @@
   <div :class="fieldsetClasses">
     <div v-for="(fieldsetItem, fieldsetItemKey) in normalizedFields" :key="fieldsetItemKey" :class="getFieldSetColumnClass(fieldsetItem.column)">
       <component :is="containerComponent.is" v-bind="containerComponent.props">
-        <slot v-if="fieldsetItem.__isFieldset" :name="`legend-${fieldsetItemKey}`">
+        <slot v-if="fieldsetItem.__hasHeader" :name="`legend-${fieldsetItemKey}`">
           <qas-header v-bind="getHeaderProps(fieldsetItem)" />
         </slot>
 
@@ -32,7 +32,7 @@
           </slot>
         </div>
 
-        <slot v-if="fieldsetItem.__isFieldset" :name="`legend-bottom-${fieldsetItemKey}`" />
+        <slot v-if="fieldsetItem.__hasFieldset" :name="`legend-bottom-${fieldsetItemKey}`" />
       </component>
     </div>
   </div>
@@ -177,8 +177,13 @@ const normalizedFields = computed(() => {
       fields: { hidden: {}, visible: {} },
       headerProps: fieldsetItem.headerProps,
 
-      // Indica que existe um fieldset para que o QasHeader possa ser renderizado
-      __isFieldset: true
+      // Indica que existe um fieldset para que o legend-bottom possa ser renderizado.
+      __hasFieldset: true,
+
+      // Indica que existe props para que o header seja renderizado.
+      __hasHeader: (
+        !!fieldsetItem.label || !!fieldsetItem.description || Object.keys(fieldsetItem.headerProps || {}).length
+      )
     }
 
     fieldsetItem.fields.forEach(fieldName => {


### PR DESCRIPTION
### Corrigido
- `QasFormGenerator`: corrigido validação para exibição do `fieldset`, ao não passar propriedades como label e description, fazia com que ficasse um espaço em branco.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
