### PR TITLE
QasBoardGeneratorChanges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
   - adicionado nova propriedade `beforeUpdatePosition`.
   - adicionado novo evento `update-error`.
   - adicionado payload do retorno da api no evento `update-success`.
+  - adicionado método `cancelDrop` no `defineExpose`.
 
 ## [3.17.0-beta.22] - 20-12-2024
 ### Modificado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasBoardGenerator`:
+  - adicionado nova propriedade `beforeUpdatePosition`.
+  - adicionado novo evento `update-error`.
+  - adicionado payload do retorno da api no evento `update-success`.
+
 ## [3.17.0-beta.22] - 20-12-2024
 ### Modificado
 - `QasUploader`: modificado header do componente para utilizar o `QasHeader` ao invés do `QasLabel`.

--- a/docs/src/pages/components/board-generator.md
+++ b/docs/src/pages/components/board-generator.md
@@ -8,6 +8,10 @@ Componente usado para board de colunas.
 
 ## Uso
 
+:::warning
+Utilize a propriedade `beforeUpdatePosition` apenas em casos necessários, como validar um card antes de salvar a posição.
+:::
+
 :::info
 Normalmente componente utilizado junto com `QasListView` para pegar os headers, sendo realizado a requisição das colunas após o `fetchSuccess`.
 Porém ainda sim é possível utilizar sem, sendo que precisa passar os headers fixos para buscar as colunas.

--- a/docs/src/pages/components/board-generator.md
+++ b/docs/src/pages/components/board-generator.md
@@ -9,7 +9,21 @@ Componente usado para board de colunas.
 ## Uso
 
 :::warning
-Utilize a propriedade `beforeUpdatePosition` apenas em casos necessários, como validar um card antes de salvar a posição.
+##### beforeUpdatePosition
+- Utilize a propriedade `beforeUpdatePosition` apenas em casos necessários, como validar um card antes de salvar a posição.
+- propriedade que é um callback é utilizada para servir como um interceptador.
+
+```js
+function beforeUpdatePosition (context) {
+  // context.event
+  // context.cancel()
+  // context.getItem()
+  // context.getColumnTo()
+  // context.getColumnFrom()
+  // context.openConfirmDialog()
+  // context.update()
+}
+```
 :::
 
 :::info

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -7,7 +7,7 @@
         </qas-box>
 
         <div :id="header[props.columnIdKey]" ref="columnContainer" class="qas-board-generator__column secondary-scroll" :data-header-key="getKeyByHeader(header)" :style="containerStyle">
-          <div v-for="item in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item">
+          <div v-for="item in getItemsByHeader(header)" :id="`header-column__${item[props.itemIdKey]}`" :key="item[props.itemIdKey]" class="qas-board-generator__item">
             <slot :column-index="index" :fields="getFieldsByHeader(header)" :item="item" name="column-item" />
           </div>
 
@@ -402,6 +402,10 @@ function getItemById (id) {
   return Object.values(columnsResultsModel.value).flat().find(item => item[props.itemIdKey] === id)
 }
 
+function getHeaderColumnId (id) {
+  return id.replace('header-column__', '')
+}
+
 function getHeaderById (id) {
   return props.headers.find(header => getKeyByHeader(header) === id)
 }
@@ -548,12 +552,15 @@ function onDropCard (event) {
   onConfirmDrop.value = () => confirmDrop(event)
 
   if (typeof props.beforeUpdatePosition === 'function') {
+    const toId = getHeaderColumnId(event.to.id)
+    const fromId = getHeaderColumnId(event.from.id)
+
     props.beforeUpdatePosition({
       event,
       cancel: () => onCancelDrop.value(),
       getItem: () => getItemById(event.item.id),
-      getColumnTo: () => getHeaderById(event.to.id),
-      getColumnFrom: () => getHeaderById(event.from.id),
+      getColumnTo: () => getHeaderById(toId),
+      getColumnFrom: () => getHeaderById(fromId),
       openConfirmDialog,
       update: () => confirmDrop(event)
     })

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -403,7 +403,7 @@ function getItemById (id) {
 }
 
 function getHeaderById (id) {
-  return props.headers.find(header => getKeyByHeader(header) === id)
+  return props.headers.find(header => String(getKeyByHeader(header)) === String(id))
 }
 
 // function getColumnBy

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -6,8 +6,8 @@
           <slot :fields="getFieldsByHeader(header)" :header="header" :index="index" name="header-column" />
         </qas-box>
 
-        <div :id="header[props.columnIdKey]" ref="columnContainer" class="qas-board-generator__column secondary-scroll" :data-header-key="getKeyByHeader(header)" :style="containerStyle">
-          <div v-for="item in getItemsByHeader(header)" :id="`header-column__${item[props.itemIdKey]}`" :key="item[props.itemIdKey]" class="qas-board-generator__item">
+        <div ref="columnContainer" class="qas-board-generator__column secondary-scroll" :data-header-key="getKeyByHeader(header)" :style="containerStyle">
+          <div v-for="item in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item">
             <slot :column-index="index" :fields="getFieldsByHeader(header)" :item="item" name="column-item" />
           </div>
 
@@ -402,10 +402,6 @@ function getItemById (id) {
   return Object.values(columnsResultsModel.value).flat().find(item => item[props.itemIdKey] === id)
 }
 
-function getHeaderColumnId (id) {
-  return id.replace('header-column__', '')
-}
-
 function getHeaderById (id) {
   return props.headers.find(header => getKeyByHeader(header) === id)
 }
@@ -552,15 +548,12 @@ function onDropCard (event) {
   onConfirmDrop.value = () => confirmDrop(event)
 
   if (typeof props.beforeUpdatePosition === 'function') {
-    const toId = getHeaderColumnId(event.to.id)
-    const fromId = getHeaderColumnId(event.from.id)
-
     props.beforeUpdatePosition({
       event,
       cancel: () => onCancelDrop.value(),
       getItem: () => getItemById(event.item.id),
-      getColumnTo: () => getHeaderById(toId),
-      getColumnFrom: () => getHeaderById(fromId),
+      getColumnTo: () => getHeaderById(event.to.dataset.headerKey),
+      getColumnFrom: () => getHeaderById(event.from.dataset.headerKey),
       openConfirmDialog,
       update: () => confirmDrop(event)
     })

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -6,7 +6,7 @@
           <slot :fields="getFieldsByHeader(header)" :header="header" :index="index" name="header-column" />
         </qas-box>
 
-        <div ref="columnContainer" class="qas-board-generator__column secondary-scroll" :data-header-key="getKeyByHeader(header)" :style="containerStyle">
+        <div :id="header[props.columnIdKey]" ref="columnContainer" class="qas-board-generator__column secondary-scroll" :data-header-key="getKeyByHeader(header)" :style="containerStyle">
           <div v-for="item in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item">
             <slot :column-index="index" :fields="getFieldsByHeader(header)" :item="item" name="column-item" />
           </div>
@@ -402,6 +402,12 @@ function getItemById (id) {
   return Object.values(columnsResultsModel.value).flat().find(item => item[props.itemIdKey] === id)
 }
 
+function getHeaderById (id) {
+  return props.headers.find(header => getKeyByHeader(header) === id)
+}
+
+// function getColumnBy
+
 /**
 * Pegar key com base na chave identificador, exemplo:
 * header -> { date: '2024-02-12', ... }
@@ -546,6 +552,8 @@ function onDropCard (event) {
       event,
       cancel: () => onCancelDrop.value(),
       getItem: () => getItemById(event.item.id),
+      getColumnTo: () => getHeaderById(event.to.id),
+      getColumnFrom: () => getHeaderById(event.from.id),
       openConfirmDialog,
       update: () => confirmDrop(event)
     })
@@ -639,8 +647,7 @@ function removeItemFromList ({ headerKey, itemId }) {
 }
 
 /**
- * Descricao:
- * Metodo que realiza a request de update
+ * Método que realiza a request de update
  *
  * @param {{
  *  newHeaderKey: string - ID da coluna de destino,

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -402,6 +402,12 @@ function getColumnItemById (id) {
   return Object.values(columnsResultsModel.value).flat().find(item => item[props.itemIdKey] === id)
 }
 
+/**
+ * Recupera o payload do header por id:
+ *
+ * @example getHeaderById('2024-02-15')
+ * @returns {Object} // { date: '2024-02-15'... }
+ */
 function getHeaderById (id) {
   return props.headers.find(header => String(getKeyByHeader(header)) === String(id))
 }
@@ -548,7 +554,7 @@ function onDropCard (event) {
   if (typeof props.beforeUpdatePosition === 'function') {
     props.beforeUpdatePosition({
       event,
-      cancel: () => onCancelDrop.value(),
+      cancel: onCancelDrop.value,
       getItem: () => getColumnItemById(event.item.id),
       getColumnTo: () => getHeaderById(event.to.dataset.headerKey),
       getColumnFrom: () => getHeaderById(event.from.dataset.headerKey),

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -398,7 +398,7 @@ function getItemsByHeader (header) {
   return hasColumnsLength.value ? columnsResultsModel.value[getKeyByHeader(header)] : []
 }
 
-function getItemById (id) {
+function getColumnItemById (id) {
   return Object.values(columnsResultsModel.value).flat().find(item => item[props.itemIdKey] === id)
 }
 
@@ -549,7 +549,7 @@ function onDropCard (event) {
     props.beforeUpdatePosition({
       event,
       cancel: () => onCancelDrop.value(),
-      getItem: () => getItemById(event.item.id),
+      getItem: () => getColumnItemById(event.item.id),
       getColumnTo: () => getHeaderById(event.to.dataset.headerKey),
       getColumnFrom: () => getHeaderById(event.from.dataset.headerKey),
       openConfirmDialog,

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -406,8 +406,6 @@ function getHeaderById (id) {
   return props.headers.find(header => String(getKeyByHeader(header)) === String(id))
 }
 
-// function getColumnBy
-
 /**
 * Pegar key com base na chave identificador, exemplo:
 * header -> { date: '2024-02-12', ... }

--- a/ui/src/components/board-generator/QasBoardGenerator.yml
+++ b/ui/src/components/board-generator/QasBoardGenerator.yml
@@ -34,6 +34,15 @@ props:
         type: Function
         default: undefined
 
+      getColumnTo:
+        desc: Recupera o payload da coluna que o item será adicionado.
+        type: Function
+        default: {}
+
+      getColumnFrom:
+        desc: Recupera o payload da coluna que o item saiu.
+        type: Function
+        default: {}
 
   column-id-key:
     desc: chave que será o id usado para ser o identificador da coluna.
@@ -202,6 +211,9 @@ events:
         type: Object
 
 methods:
+  'cancelDrop: () => void':
+    desc: Cancela o drop e volta o item para coluna original.
+
   'fetchColumns: () => void':
     desc: Busca todas colunas com base nos headers fornecidos.
 

--- a/ui/src/components/board-generator/QasBoardGenerator.yml
+++ b/ui/src/components/board-generator/QasBoardGenerator.yml
@@ -4,6 +4,37 @@ meta:
   desc: Componente usado para board de colunas.
 
 props:
+  before-update-position:
+    desc: função onde será executada antes do dialog de confirmação ou atualização da posição.
+    type: function
+    default: undefined
+    params:
+      event:
+        desc: Evento do "onAdd" do sortablejs.
+        type: Object
+        default: {}
+
+      cancel:
+        desc: Cancela o drag and drop.
+        type: Function
+        default: undefined
+
+      getItem:
+        desc: Recupera o item atual a ser dropado.
+        type: Function
+        default: {}
+
+      openConfirmDialog:
+        desc: Chama o dialog de confirmação para salvar nova posição.
+        type: Function
+        default: undefined
+
+      update:
+        desc: Salva nova posição.
+        type: Function
+        default: undefined
+
+
   column-id-key:
     desc: chave que será o id usado para ser o identificador da coluna.
     type: String
@@ -158,6 +189,17 @@ events:
 
   '@update-success -> function()':
     desc: Dispara quando o PATCH do drag and drop é com sucesso.
+    params:
+      data:
+        desc: Retorno da API.
+        type: Object
+
+  '@update-error -> function()':
+    desc: Dispara quando o PATCH do drag and drop cai em uma exceção.
+    params:
+      error:
+        desc: Retorno da API.
+        type: Object
 
 methods:
   'fetchColumns: () => void':


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Adicionado
- `QasBoardGenerator`:
  - adicionado nova propriedade `beforeUpdatePosition`.
  - adicionado novo evento `update-error`.
  - adicionado payload do retorno da api no evento `update-success`.
  - adicionado método `cancelDrop` no `defineExpose`.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
