### PR TITLE
feat: added expansion border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,15 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
-## [Não publicado]
+## Não publicado
 ## BREAKING CHANGES
-- `QasExpansionItem`: a prop `useHeaderSeparator` foi removida, agora não existe mais separator no header.
+- `QasExpansionItem`: removido a prop `useHeaderSeparator`, agora não existe mais separator no header.
 
 ### Modificado
-- `QasExpansionItem`: 
-  - Modificado a borda do componente, agora ao ter um expansion dentro de outro expansion, ficará uma borda.
+- `QasExpansionItem`: Modificado a borda do componente, agora ao ter um expansion dentro de outro expansion, ficará uma borda.
 
 ### Removido
-- `QasExpansionItem`: a prop `useHeaderSeparator` foi removida, agora não existe mais separator no header.
+- `QasExpansionItem`: removido a prop `useHeaderSeparator`, agora não existe mais separator no header.
 
 ## [3.17.0-beta.24] - 23-01-2025
 ## BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ## [Não publicado]
 ## BREAKING CHANGES
-- `QasExpansionItem`: a prop `useHeaderSeparator` vem por default `true` agora.
+- `QasExpansionItem`: a prop `useHeaderSeparator` foi removida, agora não existe mais separator no header.
 
 ### Modificado
 - `QasExpansionItem`: 
   - Modificado a borda do componente, agora ao ter um expansion dentro de outro expansion, ficará uma borda.
-  - `QasExpansionItem`: a prop `useHeaderSeparator` vem por default `true` agora.
+
+### Removido
+- `QasExpansionItem`: a prop `useHeaderSeparator` foi removida, agora não existe mais separator no header.
 
 ## [3.17.0-beta.22] - 20-12-2024
 ### Modificado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ## BREAKING CHANGES
 - `QasExpansionItem`: a prop `useHeaderSeparator` vem por default `true` agora.
 
+### Modificado
+- `QasExpansionItem`: 
+  - Modificado a borda do componente, agora ao ter um expansion dentro de outro expansion, ficará uma borda.
+  - `QasExpansionItem`: a prop `useHeaderSeparator` vem por default `true` agora.
+
 ## [3.17.0-beta.22] - 20-12-2024
 ### Modificado
 - `QasUploader`: modificado header do componente para utilizar o `QasHeader` ao invés do `QasLabel`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## [Não publicado]
+## BREAKING CHANGES
+- `QasExpansionItem`: a prop `useHeaderSeparator` vem por default `true` agora.
+
 ## [3.17.0-beta.22] - 20-12-2024
 ### Modificado
 - `QasUploader`: modificado header do componente para utilizar o `QasHeader` ao invés do `QasLabel`.

--- a/docs/src/pages/components/expansion-item.md
+++ b/docs/src/pages/components/expansion-item.md
@@ -12,11 +12,6 @@ Componente de card expansivo, wrapper do QExpansionItem(https://quasar.dev/vue-c
 - Usar o "disable-button" em casos onde não existe previamente o conteúdo para o slot `content`, e o "disable" para quando de fato o componente precisa estar "desabilitado".
 :::
 
-:::warning
-- Não recomendamos o uso de nested de 3 níveis (QasExpansionItem dentro de QasExpansionItem dentro de QasExpansionItem).
-- O separador no header funciona de forma automática, porém em alguns casos é necessário forçar aparecer/remover, use a propriedade "useHeaderSeparator" nestes casos específicos.
-:::
-
 ## Uso
 <doc-example file="QasExpansionItem/Basic" title="Básico" />
 <doc-example file="QasExpansionItem/WithMaxContentHeight" title="Com limite de altura no conteúdo" />

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -28,8 +28,6 @@
           </div>
         </template>
 
-        <q-separator v-if="props.useHeaderSeparator" class="q-my-md" />
-
         <div :class="contentClasses">
           <slot v-if="showContent" name="content">
             <qas-grid-generator v-if="hasGridGenerator" use-inline v-bind="gridGeneratorProps" />
@@ -95,11 +93,6 @@ const props = defineProps({
   maxContentHeight: {
     type: String,
     default: ''
-  },
-
-  useHeaderSeparator: {
-    type: Boolean,
-    default: true
   }
 })
 
@@ -136,8 +129,7 @@ const classes = computed(() => {
 
 const contentClasses = computed(() => {
   return {
-    'q-mt-sm': isNestedExpansionItem,
-    'q-mt-md': !isNestedExpansionItem && !props.useHeaderSeparator,
+    'q-mt-md': true,
     'qas-expansion-item__content overflow-auto': !!props.maxContentHeight
   }
 })

--- a/ui/src/components/expansion-item/QasExpansionItem.vue
+++ b/ui/src/components/expansion-item/QasExpansionItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="expansionItem" class="full-width qas-expansion-item" :class="classes" v-bind="expansionProps.parent">
-    <component :is="component.is" class="qas-expansion-item__box" v-bind="boxProps">
+    <qas-box class="qas-expansion-item__box" v-bind="boxProps">
       <q-expansion-item v-model="modelValue" v-bind="expansionProps.item" header-class="text-bold q-mt-sm q-pa-none qas-expansion-item__header" @show="setShowContent">
         <template #header>
           <div class="full-width justify-between no-wrap row">
@@ -28,17 +28,15 @@
           </div>
         </template>
 
-        <q-separator v-if="hasHeaderSeparator" class="q-my-md" />
+        <q-separator v-if="props.useHeaderSeparator" class="q-my-md" />
 
         <div :class="contentClasses">
           <slot v-if="showContent" name="content">
             <qas-grid-generator v-if="hasGridGenerator" use-inline v-bind="gridGeneratorProps" />
           </slot>
         </div>
-
-        <q-separator v-if="hasBottomSeparator" class="q-mt-md" />
       </q-expansion-item>
-    </component>
+    </qas-box>
 
     <div v-if="hasError" class="q-pt-sm qas-expansion-item__error-message text-caption text-negative">
       {{ props.errorMessage }}
@@ -49,7 +47,7 @@
 <script setup>
 import QasBox from '../box/QasBox.vue'
 
-import { computed, provide, inject, onMounted, ref, useAttrs } from 'vue'
+import { computed, provide, inject, ref, useAttrs } from 'vue'
 
 defineOptions({
   name: 'QasExpansionItem',
@@ -101,7 +99,7 @@ const props = defineProps({
 
   useHeaderSeparator: {
     type: Boolean,
-    default: undefined
+    default: true
   }
 })
 
@@ -116,36 +114,17 @@ const slots = defineSlots()
 
 // refs
 const expansionItem = ref(null)
-const hasNextSibling = ref(false)
 const showContent = ref(false)
-
-onMounted(setHasNextSibling)
 
 // constants
 const isNestedExpansionItem = inject('isExpansionItem', false)
 const isNestedBox = inject('isBox', false)
 
-const component = {
-  is: isNestedExpansionItem ? 'div' : QasBox
-}
-
 // computed
 const hasBadges = computed(() => !!props.badges.length)
 const hasError = computed(() => props.error || !!props.errorMessage)
 const hasGridGenerator = computed(() => !!Object.keys(props.gridGeneratorProps).length)
-const hasBottomSeparator = computed(() => isNestedExpansionItem && hasNextSibling.value)
 const hasHeaderBottom = computed(() => !!slots['header-bottom'])
-
-/**
- * Verifica se o componente deve adicionar um separador no header.
- *
- * - Se a propriedade useHeaderSeparator for true, retorna separador.
- * - Se a propriedade useHeaderSeparator for undefined, retorna separador apenas se não for um componente aninhado.
- * - Se a propriedade useHeaderSeparator for false, não retorna separador.
- */
-const hasHeaderSeparator = computed(() => {
-  return typeof props.useHeaderSeparator === 'undefined' ? !isNestedExpansionItem : props.useHeaderSeparator
-})
 
 const classes = computed(() => {
   return {
@@ -196,10 +175,10 @@ const expansionProps = computed(() => {
 
 const boxProps = computed(() => {
   /**
-   * Caso o QasExpansionItem estiver dentro de um QasBox e não for um QasExpansionItem
+   * Caso o QasExpansionItem estiver dentro de um QasBox ou for um QasExpansionItem
    * dentro de outro QasExpansionItem, o componente terá uma borda.
   */
-  const isBoxed = isNestedBox && !isNestedExpansionItem
+  const isBoxed = isNestedBox || isNestedExpansionItem
 
   if (!isBoxed) return {}
 
@@ -212,20 +191,6 @@ const boxProps = computed(() => {
 const isDisabled = computed(() => props.disable || props.disableButton)
 
 // functions
-
-/**
- * Caso o componente esteja dentro de um QasExpansionItem, verifica se existe um próximo irmão
- * para adicionar um separador.
- */
-function setHasNextSibling () {
-  if (!isNestedExpansionItem) return
-
-  const hasTextContentSibling = !!expansionItem.value.nextSibling?.textContent?.trim?.()
-  const hasElementSibling = !!expansionItem.value.nextElementSibling
-
-  hasNextSibling.value = hasElementSibling || hasTextContentSibling
-}
-
 function setShowContent () {
   showContent.value = true
 }

--- a/ui/src/components/expansion-item/QasExpansionItem.yml
+++ b/ui/src/components/expansion-item/QasExpansionItem.yml
@@ -49,11 +49,6 @@ props:
     desc: Propriedades que serão repassadas para o QasGridGenerator.
     type: Object
 
-  use-header-separator:
-    desc: Propriedade para forçar o QSeparator no header.
-    type: Boolean
-    default: undefined
-
 slots:
   header:
     desc: Slot para substituir o conteúdo do header (não inclui o botão dropdown).


### PR DESCRIPTION
## BREAKING CHANGES
- `QasExpansionItem`: a prop `useHeaderSeparator` foi removida, agora não existe mais separator no header.

### Modificado
- `QasExpansionItem`: 
  - Modificado a borda do componente, agora ao ter um expansion dentro de outro expansion, ficará uma borda.

### Removido
- `QasExpansionItem`: a prop `useHeaderSeparator` foi removida, agora não existe mais separator no header.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
