### PR TITLE
Changes in QasGridGenerator and QasTextTruncate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 `QasTextTruncate`: Adicionado novas propriedade `useBadge` e `useWrapBadge`.
 
 ### Modificado
-- `QasGridGenerator`: modificado espaçamento entre itens no dialog para `sm`.
+- `QasTextTruncate`: modificado espaçamento entre itens no dialog para `sm`.
 - `QasGridItem`: modificado classe de cor, agora o label tem as mesmas cores tanto inline quando modo normal "text-grey-10".
 - `QasGridGenerator`:
   - modificado tamanho default da propriedade "gutter", agora quando for "useInline" terá o default de "8px".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
+## BREAKING CHANGES
+- [`QasGridItem`, `QasGridGenerator`]: modificado classe de cor, agora o label tem as mesmas cores tanto inline quando modo normal "text-grey-10",
+verificar lugares onde usa modo inline para ver se não estava sendo estilizado manualmente.
+
 ### Adicionado
 `QasTextTruncate`: Adicionado novas propriedade `useBadge` e `useWrapBadge`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,21 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+`QasTextTruncate`: Adicionado novas propriedade `useBadge` e `useWrapBadge`.
+
+### Modificado
+- `QasGridGenerator`: modificado espaçamento entre itens no dialog para `sm`.
+- `QasGridItem`: modificado classe de cor, agora o label tem as mesmas cores tanto inline quando modo normal "text-grey-10".
+- `QasGridGenerator`:
+  - modificado tamanho default da propriedade "gutter", agora quando for "useInline" terá o default de "8px".
+  - `composables/private/useGenerator`: modificações referente ao gutter para o QasGridGenerator.
+  - corrigido typo "getContainerClassses" por "getContainerClasses".
+
 ## [3.17.0-beta.27] - 07-02-2025
 ### Adicionado
-- `QasCheckbox`: 
+- `QasCheckbox`:
  - adicionado prop `error-message` pra exibir o erro no campo.
  - adicionado prop `required` pra exibir `*` como sufixo da label.
 

--- a/docs/src/examples/QasTextTruncate/WithBadge.vue
+++ b/docs/src/examples/QasTextTruncate/WithBadge.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container q-py-lg">
-    <qas-text-truncate class="text-negative" dialog-title="Aqui está meu título!" :list="list" :max-visible-item="2" :max-width="100" use-badge use-object-list />
+    <qas-text-truncate class="text-negative" dialog-title="Aqui está meu título!" :list :max-visible-item="2" :max-width="100" use-badge use-object-list />
   </div>
 </template>
 

--- a/docs/src/examples/QasTextTruncate/WithBadge.vue
+++ b/docs/src/examples/QasTextTruncate/WithBadge.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="container q-py-lg">
+    <qas-text-truncate class="text-negative" dialog-title="Aqui está meu título!" :list="list" :max-visible-item="2" :max-width="100" use-badge use-object-list />
+  </div>
+</template>
+
+<script setup>
+defineOptions({ name: 'WithBadge' })
+
+const list = [
+  {
+    label: 'Primeiro item',
+    color: 'green-8'
+  },
+  {
+    label: 'Segundo item',
+    color: 'blue-8',
+    textColor: 'white'
+  },
+  {
+    label: 'Terceiro item',
+    color: 'red-8'
+  },
+  {
+    label: 'Quarto item',
+    color: 'yellow-8'
+  },
+  {
+    label: 'Quinto item',
+    color: 'purple-8'
+  },
+  {
+    label: 'Sexto item',
+    color: 'orange-8'
+  }
+]
+</script>

--- a/docs/src/pages/components/text-truncate.md
+++ b/docs/src/pages/components/text-truncate.md
@@ -20,7 +20,7 @@ Quando for utilizar por slot, não pode haver nenhum elemento englobando o texto
 
 :::info
 - Quando utilizar com badge, é necessário utilizar junto com a propriedade "useObjectList".
-- Só é repassados para o QasBadge props que o mesmo aceite.
+- Só são repassados para o QasBadge props que o mesmo aceite.
 - Utilize a propriedade "useWrapBadge" quando utilizar fora de tabela em casos que precise quebrar as badges em mais linhas.
 :::
 <doc-example file="QasTextTruncate/WithBadge" title="Uso com badges" />

--- a/docs/src/pages/components/text-truncate.md
+++ b/docs/src/pages/components/text-truncate.md
@@ -17,3 +17,10 @@ Quando for utilizar por slot, não pode haver nenhum elemento englobando o texto
 :::
 
 <doc-example file="QasTextTruncate/DefaultSlot" title="Slot default" />
+
+:::info
+- Quando utilizar com badge, é necessário utilizar junto com a propriedade "useObjectList".
+- Só é repassados para o QasBadge props que o mesmo aceite.
+- Utilize a propriedade "useWrapBadge" quando utilizar fora de tabela em casos que precise quebrar as badges em mais linhas.
+:::
+<doc-example file="QasTextTruncate/WithBadge" title="Uso com badges" />

--- a/ui/src/components/badge/QasBadge.vue
+++ b/ui/src/components/badge/QasBadge.vue
@@ -5,6 +5,8 @@
 </template>
 
 <script setup>
+import { baseProps } from '../../shared/badge-config'
+
 import { computed } from 'vue'
 
 defineOptions({
@@ -12,35 +14,7 @@ defineOptions({
   inheritAttrs: false
 })
 
-const props = defineProps({
-  color: {
-    type: String,
-    default: 'light-blue-2'
-  },
-
-  label: {
-    type: String,
-    default: ''
-  },
-
-  multiLine: {
-    type: Boolean
-  },
-
-  textColor: {
-    type: String,
-    default: 'black'
-  },
-
-  removable: {
-    type: Boolean
-  },
-
-  tabindex: {
-    type: [String, Number],
-    default: undefined
-  }
-})
+const props = defineProps(baseProps)
 
 const emit = defineEmits(['remove'])
 const model = defineModel({ type: Boolean, default: true })

--- a/ui/src/components/form-generator/QasFormGenerator.yml
+++ b/ui/src/components/form-generator/QasFormGenerator.yml
@@ -55,7 +55,7 @@ props:
 
   gutter:
     desc: Espaçamento entre colunas.
-    default: lg
+    default: md
     type: [String, Boolean]
     examples: [xs, sm, md, lg, xl, '2xl', '3xl', '4xl', '5xl', false]
 

--- a/ui/src/components/grid-generator/QasGridGenerator.vue
+++ b/ui/src/components/grid-generator/QasGridGenerator.vue
@@ -3,7 +3,7 @@
     <qas-header v-if="hasHeader" v-bind="props.headerProps" />
 
     <div :class="classes">
-      <div v-for="(field, key) in fieldsByResult" :key="key" :class="getContainerClassses({ key })">
+      <div v-for="(field, key) in fieldsByResult" :key="key" :class="getContainerClasses({ key })">
         <slot :field="field" :name="`field-${field.name}`">
           <qas-grid-item :use-ellipsis="hasEllipsis(field)" :use-inline="props.useInline">
             <template #header>
@@ -98,7 +98,7 @@ const props = defineProps({
 })
 
 // composables
-const { classes, getFieldClass } = useGenerator({ props })
+const { classes, getFieldClass } = useGenerator({ props, isGrid: true })
 
 // computed
 const hasResult = computed(() => Object.keys(props.result).length)
@@ -181,7 +181,7 @@ function setFieldsByResult () {
   fieldsByResult.value = getFieldsByResult()
 }
 
-function getContainerClassses ({ key }) {
+function getContainerClasses ({ key }) {
   if (props.useInline) return 'row justify-between col-12'
 
   return getFieldClass({ index: key, isGridGenerator: true })

--- a/ui/src/components/grid-generator/QasGridGenerator.yml
+++ b/ui/src/components/grid-generator/QasGridGenerator.yml
@@ -36,8 +36,8 @@ props:
     examples: ["{ email: { name: 'email', type: 'email', label: 'E-mail' } }"]
 
   gutter:
-    desc: Espaçamento entre colunas.
-    default: lg
+    desc: Em caso de uso inline o default é "sm" senão é "md".
+    default: ''
     type: String
     examples: [xs, sm, md, lg, xl, 2xl, 3xl, 4xl, 5xl]
 

--- a/ui/src/components/grid-item/QasGridItem.vue
+++ b/ui/src/components/grid-item/QasGridItem.vue
@@ -65,8 +65,8 @@ const classes = computed(() => {
     },
 
     content: {
+      'text-grey-10': true,
       'text-body1': !isInline,
-      'text-grey-10': !isInline,
       'text-subtitle1': isInline,
       ellipsis: hasEllipsis.value
     }

--- a/ui/src/components/text-truncate/QasTextTruncate.vue
+++ b/ui/src/components/text-truncate/QasTextTruncate.vue
@@ -3,13 +3,13 @@
     <div class="no-wrap row text-no-wrap">
       <div ref="truncate" class="ellipsis">
         <slot>
-          <div v-if="hasBadges" class="q-col-gutter-sm row" :class="badgeParentClasses">
+          <div v-if="hasBadges" class="items-center q-col-gutter-sm row" :class="badgeParentClasses">
             <div v-for="(item, index) in normalizedBadgesList" :key="index">
               <qas-badge v-bind="getBadgeProps(item)" />
             </div>
           </div>
 
-          <div v-else>
+          <div v-else class="ellipsis">
             {{ formattedText }}
           </div>
         </slot>

--- a/ui/src/components/text-truncate/QasTextTruncate.vue
+++ b/ui/src/components/text-truncate/QasTextTruncate.vue
@@ -235,9 +235,6 @@ function useTruncate ({ parent, props, hasBadges }) {
 
     maxPossibleWidth.value = props.maxWidth || truncate.value.parentElement.clientWidth * 0.90
 
-    /**
-     * Se tiver badges, então
-     */
     parent.value.style.maxWidth = `${maxPossibleWidth.value}px`
   }
 

--- a/ui/src/components/text-truncate/QasTextTruncate.vue
+++ b/ui/src/components/text-truncate/QasTextTruncate.vue
@@ -311,7 +311,10 @@ function useBadgeHandler () {
   function getBadgeProps (item) {
     const itemProps = {}
 
-    // recupera somente keys que estão em baseProps do QasBadge
+    /**
+     * recupera somente keys que estão em baseProps do QasBadge
+     * pra evitar que passe propriedades desnecessárias
+     */
     for (const key in item) {
       if (baseProps[key]) {
         itemProps[key] = item[key]

--- a/ui/src/components/text-truncate/QasTextTruncate.yml
+++ b/ui/src/components/text-truncate/QasTextTruncate.yml
@@ -18,6 +18,10 @@ props:
     desc: Seta o título do dialog.
     type: String
 
+  empty-text:
+    desc: Texto a ser exibido no caso de não houver itens no "list" ou o "text" for vazio.
+    type: String
+
   max-width:
     desc: Seta o tamanho máximo do texto.
     type: Number
@@ -47,13 +51,20 @@ props:
     default: []
     type: Array
 
-  use-object-list:
-    desc: Utiliza a propriedade "list" como array de objeto contendo label (uso junto a prop list).
+  use-badge:
+    desc: Habilita badges para cada item da lista.
+    default: false
     type: Boolean
 
-  empty-text:
-    desc: Texto a ser exibido no caso de não houver itens no "list" ou o "text" for vazio.
-    type: String
+  use-object-list:
+    desc: Utiliza a propriedade "list" como array de objeto contendo label (uso junto a prop list).
+    default: false
+    type: Boolean
+
+  use-wrap-badge:
+    desc: Habilita o componente a "quebrar" o badge quando o texto for muito grande.
+    default: false
+    type: Boolean
 
 slots:
   default:

--- a/ui/src/components/text-truncate/QasTextTruncate.yml
+++ b/ui/src/components/text-truncate/QasTextTruncate.yml
@@ -62,7 +62,7 @@ props:
     type: Boolean
 
   use-wrap-badge:
-    desc: Habilita o componente a "quebrar" o badge quando o texto for muito grande.
+    desc: habilita a quebra de linha das badges quando o texto for muito grande.
     default: false
     type: Boolean
 

--- a/ui/src/composables/private/use-generator.js
+++ b/ui/src/composables/private/use-generator.js
@@ -1,6 +1,8 @@
-import { computed } from 'vue'
 import { Spacing } from '../../enums/Spacing'
 import { gutterValidator } from '../../helpers/private/gutter-validator'
+import useScreen from '../use-screen'
+
+import { computed } from 'vue'
 
 const IRREGULAR_CLASSES = ['col', 'col-auto', 'fit']
 
@@ -21,7 +23,7 @@ export const baseProps = {
   },
 
   gutter: {
-    default: Spacing.Md,
+    default: undefined,
     type: [String, Boolean],
     validator: gutterValidator
   }
@@ -34,20 +36,29 @@ export const baseProps = {
  * @name useGenerator
  * @param {Object} options - Opções do componente.
  * @param {baseProps} options.props - Propriedades do componente.
+ * @param {boolean} options.isGrid - Propriedades do componente.
  * @returns {{
  *  classes: classes,
  *  getFieldClass: getFieldClass
  * }}
  */
-export default function ({ props = {} }) {
+export default function ({ props = {}, isGrid = false }) {
+  const screen = useScreen()
+
+  const defaultGutter = computed(() => {
+    if (props.gutter !== undefined) return props.gutter
+
+    return (props.useInline && !screen.isSmall) && isGrid ? Spacing.Sm : Spacing.Md
+  })
+
   /**
    * @type {{ value: string[] | string }}
    */
   const classes = computed(() => {
     const classesList = ['row']
 
-    if (props.gutter) {
-      classesList.push(`q-col-gutter-${props.gutter}`)
+    if (defaultGutter.value) {
+      classesList.push(`q-col-gutter-${defaultGutter.value}`)
     }
 
     return classesList

--- a/ui/src/composables/private/use-generator.js
+++ b/ui/src/composables/private/use-generator.js
@@ -45,10 +45,14 @@ export const baseProps = {
 export default function ({ props = {}, isGrid = false }) {
   const screen = useScreen()
 
+  /**
+   * Se a propriedade gutter não for passada, será calculada automaticamente.
+   * se for usado no grid e for inline, o gutter será menor.
+   */
   const defaultGutter = computed(() => {
     if (props.gutter !== undefined) return props.gutter
 
-    return (props.useInline && !screen.isSmall) && isGrid ? Spacing.Sm : Spacing.Md
+    return isGrid && (props.useInline && !screen.isSmall) ? Spacing.Sm : Spacing.Md
   })
 
   /**

--- a/ui/src/shared/badge-config.js
+++ b/ui/src/shared/badge-config.js
@@ -1,0 +1,29 @@
+export const baseProps = {
+  color: {
+    type: String,
+    default: 'light-blue-2'
+  },
+
+  label: {
+    type: String,
+    default: ''
+  },
+
+  multiLine: {
+    type: Boolean
+  },
+
+  textColor: {
+    type: String,
+    default: 'black'
+  },
+
+  removable: {
+    type: Boolean
+  },
+
+  tabindex: {
+    type: [String, Number],
+    default: undefined
+  }
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Adicionado
`QasTextTruncate`: Adicionado novas propriedade `useBadge` e `useWrapBadge`.

### Modificado
- `QasGridGenerator`: modificado espaçamento entre itens no dialog para `sm`.
- `QasGridItem`: modificado classe de cor, agora o label tem as mesmas cores tanto inline quando modo normal "text-grey-10".
- `QasGridGenerator`:
  - modificado tamanho default da propriedade "gutter", agora quando for "useInline" terá o default de "8px".
  - `composables/private/useGenerator`: modificações referente ao gutter para o QasGridGenerator.
  - corrigido typo "getContainerClassses" por "getContainerClasses".

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
