### PR TITLE
QasTextTruncate: fix button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasTextTruncate`: corrigido botão do "ver mais" que não aparecia mesmo quando existia ellipsis.
+
 ## [3.17.0-beta.31] - 19-02-2025
 ### Adicionado
 - `QasWelcome`: Adicionado slot `after-greeting` para acessar conteúdo após saudações.

--- a/docs/src/examples/QasTextTruncate/Basic.vue
+++ b/docs/src/examples/QasTextTruncate/Basic.vue
@@ -2,13 +2,31 @@
   <div class="container q-py-lg">
     <qas-text-truncate dialog-title="Aqui está meu título!" :text="text" />
   </div>
+
+  <qas-list-view v-model:fields="fields" v-model:results="results" :entity="entity" :use-filter="false">
+    <template #default>
+      <qas-table-generator :fields="fields" :results="results" row-key="uuid">
+        <template #body-cell-name="{ row }">
+          <qas-text-truncate dialog-title="Aqui está meu título!" :max-width="180" :text="row.name" />
+        </template>
+      </qas-table-generator>
+    </template>
+  </qas-list-view>
 </template>
 
 <script>
 export default {
   data () {
     return {
-      text: ''
+      text: '',
+      fields: {},
+      results: []
+    }
+  },
+
+  computed: {
+    entity () {
+      return 'users'
     }
   },
 

--- a/docs/src/examples/QasTextTruncate/Basic.vue
+++ b/docs/src/examples/QasTextTruncate/Basic.vue
@@ -2,31 +2,13 @@
   <div class="container q-py-lg">
     <qas-text-truncate dialog-title="Aqui está meu título!" :text="text" />
   </div>
-
-  <qas-list-view v-model:fields="fields" v-model:results="results" :entity="entity" :use-filter="false">
-    <template #default>
-      <qas-table-generator :fields="fields" :results="results" row-key="uuid">
-        <template #body-cell-name="{ row }">
-          <qas-text-truncate dialog-title="Aqui está meu título!" :max-width="180" :text="row.name" />
-        </template>
-      </qas-table-generator>
-    </template>
-  </qas-list-view>
 </template>
 
 <script>
 export default {
   data () {
     return {
-      text: '',
-      fields: {},
-      results: []
-    }
-  },
-
-  computed: {
-    entity () {
-      return 'users'
+      text: ''
     }
   },
 

--- a/docs/src/examples/QasTextTruncate/InsideTable.vue
+++ b/docs/src/examples/QasTextTruncate/InsideTable.vue
@@ -1,0 +1,19 @@
+<template>
+  <qas-list-view v-model:fields="viewState.fields" v-model:results="viewState.results" :entity="entity" :use-filter="false">
+    <template #default>
+      <qas-table-generator :fields="viewState.fields" :results="viewState.results" row-key="uuid">
+        <template #body-cell-name="{ row }">
+          <qas-text-truncate dialog-title="Aqui está meu título!" :max-width="180" :text="row.name" />
+        </template>
+      </qas-table-generator>
+    </template>
+  </qas-list-view>
+</template>
+
+<script setup>
+import { useView } from '@bildvitta/composables'
+
+const { viewState } = useView({ mode: 'list' })
+
+const entity = 'users'
+</script>

--- a/docs/src/pages/components/text-truncate.md
+++ b/docs/src/pages/components/text-truncate.md
@@ -10,6 +10,8 @@ Trunca um texto baseado no tamanho do elemento pai e adiciona um rotulo "ver mai
 
 <doc-example file="QasTextTruncate/Basic" title="Básico" />
 
+<doc-example file="QasTextTruncate/InsideTable" title="Dentro da tabela" />
+
 <doc-example file="QasTextTruncate/WithCounter" title="Com contador" />
 
 :::warning

--- a/ui/src/components/text-truncate/QasTextTruncate.vue
+++ b/ui/src/components/text-truncate/QasTextTruncate.vue
@@ -41,6 +41,7 @@ import { baseProps } from '../../shared/badge-config'
 
 import {
   computed,
+  nextTick,
   onMounted,
   onUnmounted,
   ref,
@@ -223,16 +224,21 @@ function useTruncate ({ parent, props, hasBadges }) {
 
   // watch
   watch(() => props.maxWidth, truncateText)
+  watch(() => props.text, truncateText)
 
   // functions
-  function truncateText () {
+  async function truncateText () {
+    await nextTick()
     // Se tiver badges, então não pode ser feito calculo de width.
     if (hasBadges.value) return
 
     parent.value.style.maxWidth = '100%'
     textWidth.value = truncate.value.clientWidth
+    console.log('TCL: truncateText -> textWidth.value', truncate.value)
+    // console.log('TCL: truncateText -> textWidth.value', truncate.value.clientWidth)
     textContent.value = truncate.value?.innerHTML
 
+    // console.log('TCL: truncateText -> truncate.value.parentElement', truncate.value)
     maxPossibleWidth.value = props.maxWidth || truncate.value.parentElement.clientWidth * 0.90
 
     parent.value.style.maxWidth = `${maxPossibleWidth.value}px`

--- a/ui/src/components/text-truncate/QasTextTruncate.vue
+++ b/ui/src/components/text-truncate/QasTextTruncate.vue
@@ -224,7 +224,6 @@ function useTruncate ({ parent, props, hasBadges }) {
 
   // watch
   watch(() => props.maxWidth, truncateText)
-  watch(() => props.text, truncateText)
 
   // functions
   async function truncateText () {

--- a/ui/src/components/text-truncate/QasTextTruncate.vue
+++ b/ui/src/components/text-truncate/QasTextTruncate.vue
@@ -229,16 +229,14 @@ function useTruncate ({ parent, props, hasBadges }) {
   // functions
   async function truncateText () {
     await nextTick()
+
     // Se tiver badges, então não pode ser feito calculo de width.
     if (hasBadges.value) return
 
     parent.value.style.maxWidth = '100%'
     textWidth.value = truncate.value.clientWidth
-    console.log('TCL: truncateText -> textWidth.value', truncate.value)
-    // console.log('TCL: truncateText -> textWidth.value', truncate.value.clientWidth)
     textContent.value = truncate.value?.innerHTML
 
-    // console.log('TCL: truncateText -> truncate.value.parentElement', truncate.value)
     maxPossibleWidth.value = props.maxWidth || truncate.value.parentElement.clientWidth * 0.90
 
     parent.value.style.maxWidth = `${maxPossibleWidth.value}px`


### PR DESCRIPTION
… component

<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Corrigido
- `QasTextTruncate`: corrigido botão do "ver mais" que não aparecia mesmo quando existia ellipsis.

closes #1243 

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
