### PR TITLE
Feature/grid filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasErrorMessage`: adicionado novo componente para mostrar mensagem de erros de forma padronizada.
 - `QasRadio`: adicionado propriedades `error` e `errorMessage` em conjunto do componente `QasErrorMessage`.
 - `css/mixins/set-error-message`: mixin para aplicar os estilos diretamente no css.
-- `QasFilters`: adicionado prop `useFullContent` para que o componente ocupe 100%, recomendado para o quando precisar utilizar grids.
+- `QasFilters`: 
+ - adicionado prop `useFullContent` para que o componente ocupe 100%, recomendado para quando precisar utilizar grids.
+ - adicionado prop `listenerQueryKeys` que serão chaves que o componente deve ouvir sempre que houver mudanças na query, para que bata a api novamente de `/filters`.
 
 ### Corrigido
 - `QasInput`: alterado ordem da prop `iconRight` que estava adicionando na esquerda e não na direita.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ## BREAKING CHANGE
 - `QasInput`: alterado ordem da prop `iconRight` que estava adicionando na esquerda e não na direita, verificar lugares.
 - Alterar `quasar.variables.scss`, nova cor do `$negative` sendo `$red-14`.
+- `QasFilters`: removido slot `right-side`, agora a forma recomendada para quando precisar utilizar itens ao lado do componente, utilize o grid em conjunto com a prop `useFullContent`. Contém um exemplo do uso na docs.
 
 ### Adicionado
 - `QasErrorMessage`: adicionado novo componente para mostrar mensagem de erros de forma padronizada.
 - `QasRadio`: adicionado propriedades `error` e `errorMessage` em conjunto do componente `QasErrorMessage`.
 - `css/mixins/set-error-message`: mixin para aplicar os estilos diretamente no css.
+- `QasFilters`: adicionado prop `useFullContent` para que o componente ocupe 100%, recomendado para o quando precisar utilizar grids.
 
 ### Corrigido
 - `QasInput`: alterado ordem da prop `iconRight` que estava adicionando na esquerda e não na direita.
@@ -35,6 +37,9 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
   - QasExpansionItem
   - QasUploader
   - QasCheckbox
+
+### Removido
+- `QasFilters`: removido slot `right-side`, agora a forma recomendada para quando precisar utilizar itens ao lado do componente, utilize o grid em conjunto com a prop `useFullContent`. Contém um exemplo do uso na docs.
 
 ## [3.17.0] - 12-03-2025
 ## BREAKING CHANGES

--- a/docs/src/examples/QasFilters/WithGrid.vue
+++ b/docs/src/examples/QasFilters/WithGrid.vue
@@ -1,0 +1,83 @@
+<template>
+  <div class="container spaced">
+    <div>
+      <div class="q-col-gutter-md q-mb-lg row">
+        <div class="col-12">
+          <qas-label label="Caso 1" />
+        </div>
+
+        <div class="col-4">
+          <qas-select label="Select" />
+        </div>
+
+        <div class="col-4">
+          <qas-select label="Select" />
+        </div>
+
+        <div class="col-4">
+          <qas-filters :entity="entity" search-placeholder="Pesquisar por nome do usuário" use-full-content />
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <div class="q-col-gutter-md q-mb-lg row">
+        <div class="col-12">
+          <qas-label label="Caso 2" />
+        </div>
+
+        <div class="col-6">
+          <qas-select label="Select" />
+        </div>
+
+        <div class="col-6">
+          <qas-filters :entity="entity" search-placeholder="Pesquisar por nome do usuário" use-full-content />
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <div class="q-col-gutter-md q-mb-lg row">
+        <div class="col-12">
+          <qas-label label="Caso 3" />
+        </div>
+
+        <div class="col-6">
+          <qas-select label="Select" />
+        </div>
+
+        <div class="col-6">
+          <qas-select label="Select" />
+        </div>
+
+        <div class="col-6">
+          <qas-filters :entity="entity" search-placeholder="Pesquisar por nome do usuário" use-full-content />
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <div class="q-mb-lg">
+        <qas-label label="Caso 4" />
+
+        <div class="row">
+          <qas-select class="col-6 q-mb-lg" label="Select" />
+        </div>
+
+        <qas-filters :entity="entity" search-placeholder="Pesquisar por nome do usuário" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'WithGrid',
+
+  computed: {
+    entity () {
+      return 'users'
+    }
+  }
+}
+</script>

--- a/docs/src/pages/components/filters.md
+++ b/docs/src/pages/components/filters.md
@@ -46,7 +46,10 @@ Ao utilizar a propriedade `:use-update-route="false"`, a leitura dos filtros ass
 
 <doc-example file="QasFilters/CustomFilterButton" title="Usando slot filter-button com a função 'filter'" />
 
-<doc-example file="QasFilters/RightSide" title="Usando o slot right-side" />
+:::info
+Utilize a prop `useFullContent` quando precisar adicionar o componente em um grid.
+:::
+<doc-example file="QasFilters/WithGrid" title="Usando o qas-filters em um grid" />
 
 #### Filtros com campos lazy loading
 Para utilizar campos de select lazy loading (que carregam os dados somente quando o campo é aberto), é necessário que o campo lazy loading siga os requisitos descritos na documentação do [QasSelect](/components/select) (procure pela seção "Lazy Loading") e também que o back-end retorne as opções selecionadas de acordo com a query passada no endpoint GET `:entity/filters`.

--- a/ui/src/components/filters/QasFilters.vue
+++ b/ui/src/components/filters/QasFilters.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="qas-filters" :class="filtersClasses">
-    <div v-if="showFilters" class="q-col-gutter-x-md row">
-      <div v-if="showSearch" class="col-12 col-md-6">
+    <div v-if="showFilters" class="row">
+      <div v-if="showSearch" class="col-12" :class="searchContainerClasses">
         <slot :filter="filter" name="search">
           <q-form v-if="useSearch" @submit.prevent="filter()">
             <qas-search-input v-model="internalSearch" :placeholder="searchPlaceholder" :use-search-on-type="useSearchOnType" @clear="clearSearch" @filter="filter()" @update:model-value="onSearch">
@@ -19,10 +19,6 @@
         <slot :context="mx_context" :filter="filter" :filters="activeFilters" name="filter-button" :remove-filter="removeFilter">
           <pv-filters-button v-if="useFilterButton" ref="filtersButton" v-model="internalFilters" v-bind="filterButtonProps" />
         </slot>
-      </div>
-
-      <div class="col-12 col-md-6">
-        <slot name="right-side" />
       </div>
     </div>
 
@@ -84,6 +80,10 @@ export default {
       type: Boolean
     },
 
+    useFullContent: {
+      type: Boolean
+    },
+
     useSearch: {
       default: true,
       type: Boolean
@@ -116,6 +116,11 @@ export default {
     useUpdateRoute: {
       default: true,
       type: Boolean
+    },
+
+    listenerQueryKeys: {
+      type: Array,
+      default: () => []
     }
   },
 
@@ -200,6 +205,10 @@ export default {
       return formattedFieldsProps
     },
 
+    searchContainerClasses () {
+      return { 'col-md-6': !this.useFullContent }
+    },
+
     fields () {
       return getState.call(this, { entity: this.entity, key: 'filters' })
     },
@@ -268,6 +277,11 @@ export default {
         this.fetchFilters()
         this.useUpdateRoute && this.updateValues()
       }
+    },
+
+    '$route.query' (to, from) {
+      console.log(to, '<--- to')
+      console.log(from, '<--- from')
     },
 
     internalFilters: {

--- a/ui/src/components/filters/QasFilters.vue
+++ b/ui/src/components/filters/QasFilters.vue
@@ -274,14 +274,17 @@ export default {
   watch: {
     $route (to, from) {
       if (to.name === from.name) {
-        this.fetchFilters()
+        /**
+       * Verifica se alguma chave da query que está no "listenerQueryKeys" mudou,
+       * se sim, faz bate o fetchFilters novamente.
+       */
+        const hasQueryChanged = this.listenerQueryKeys.find(
+          queryKey => to.query[queryKey] !== from.query[queryKey]
+        )
+
+        this.fetchFilters({ hasQueryChanged })
         this.useUpdateRoute && this.updateValues()
       }
-    },
-
-    '$route.query' (to, from) {
-      console.log(to, '<--- to')
-      console.log(from, '<--- from')
     },
 
     internalFilters: {
@@ -342,8 +345,8 @@ export default {
       this.filter()
     },
 
-    async fetchFilters () {
-      if (!this.useForceRefetch && (this.hasFields || !this.useFilterButton)) {
+    async fetchFilters ({ hasQueryChanged = false } = {}) {
+      if (!hasQueryChanged && !this.useForceRefetch && (this.hasFields || !this.useFilterButton)) {
         return null
       }
 
@@ -353,6 +356,7 @@ export default {
       const { filters } = this.mx_context
 
       try {
+        console.log('buscando fetchFilters')
         const response = await getAction.call(this, {
           entity: this.entity,
           key: 'fetchFilters',

--- a/ui/src/components/filters/QasFilters.yml
+++ b/ui/src/components/filters/QasFilters.yml
@@ -29,6 +29,11 @@ props:
     type: Object
     examples: [v-model:filters="filters"]
 
+  listener-query-keys:
+    desc: Chaves da query que serão ouvidas as mudanças de valores, para fazer a busca do "/filters" novamente.
+    default: []
+    type: Array
+
   search-placeholder:
     desc: Placeholder do campo de busca.
     default: Pesquisar...
@@ -50,6 +55,10 @@ props:
 
   use-force-refetch:
     desc: Força refazer o "fetch" mesmo caso já exista dados na store de filters.
+    type: Boolean
+
+  use-full-content:
+    desc: Para que o componente ocupe 100%, recomendado para quando precisar utilizar grids.
     type: Boolean
 
   use-update-route:


### PR DESCRIPTION
### Adicionado
- `QasFilters`: 
 - adicionado prop `useFullContent` para que o componente ocupe 100%, recomendado para quando precisar utilizar grids.
 - adicionado prop `listenerQueryKeys` que serão chaves que o componente deve ouvir sempre que houver mudanças na query, para que bata a api novamente de `/filters`.
 
### Removido
- `QasFilters`: removido slot `right-side`, agora a forma recomendada para quando precisar utilizar itens ao lado do componente, utilize o grid em conjunto com a prop `useFullContent`. Contém um exemplo do uso na docs

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [x] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
