### PR TITLE
Feature/text truncate dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
   - adicionado nova propriedade `useHomeItem` com default `true` para forçar padronização no item de inicio, é necessário remover esse item da prop "items" caso esteja sendo adicionado.
   - não esquecer de configurar corretamente a prop `homeRoute`.
 - `QasAlert/QasInfo`: removido `QasInfo` que agora foi mesclado com o `QasAlert`, olhar documentação.
-- `QasSearchBox`: modificado prop `height` para `maxHeight`, pois o nome da prop era `maxHeight`, mas internamente adicionava o style como `maxHeight`.
+- `QasSearchBox`: modificado prop `height` para `maxHeight`, pois o nome da prop era `height`, mas internamente adicionava o style como `maxHeight`.
 - `QasFilters`: removido slot `right-side`, agora a forma recomendada para quando precisar utilizar itens ao lado do componente, utilize o grid em conjunto com a prop `useFullContent`. Contém um exemplo do uso na docs.
 
 ### Adicionado
@@ -72,7 +72,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasToggle` modificado estilos.
 - `QasTreeGenerator`: adicionado separador nas ações.
 - `QasAlert/QasInfo`: modificado cor de error para `negative`.
-- `QasSearchBox`: modificado prop `height` para `maxHeight`, pois o nome da prop era `maxHeight`, mas internamente adicionava o style como `maxHeight`.
+- `QasSearchBox`: modificado prop `height` para `maxHeight`, pois o nome da prop era `height`, mas internamente adicionava o style como `maxHeight`.
 
 ### Removido
 - `QasAlert/QasInfo`: removido `QasInfo` que agora foi mesclado com o `QasAlert`, olhar documentação.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `css/components/menu`: adicionado estilo para adc separador em q-list > q-item dentro do `q-menu`.
 - `QasAppMenu`: adicionado nova propriedade `useHomeItem` com default `true` para forçar padronização no item de inicio, é necessário remover esse item da prop "items" caso esteja sendo adicionado.
 - `QasAppUser`: adicionado propriedade "useDataOnSmallScreen".
+- `QasTextTruncate`: Adicionado campo de busca no dialog do componente ao conter mais de 12 itens na lista.
 
 ### Corrigido
 - `QasPasswordInput`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
   - adicionado nova propriedade `useHomeItem` com default `true` para forçar padronização no item de inicio, é necessário remover esse item da prop "items" caso esteja sendo adicionado.
   - não esquecer de configurar corretamente a prop `homeRoute`.
 - `QasAlert/QasInfo`: removido `QasInfo` que agora foi mesclado com o `QasAlert`, olhar documentação.
+- `QasSearchBox`: modificado prop `height` para `maxHeight`, pois o nome da prop era `maxHeight`, mas internamente adicionava o style como `maxHeight`.
 
 ### Adicionado
 - `helpers/color`: adicionado helper para cores.
@@ -37,6 +38,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasAppMenu`: adicionado nova propriedade `useHomeItem` com default `true` para forçar padronização no item de inicio, é necessário remover esse item da prop "items" caso esteja sendo adicionado.
 - `QasAppUser`: adicionado propriedade "useDataOnSmallScreen".
 - `QasTextTruncate`: Adicionado campo de busca no dialog do componente ao conter mais de 12 itens na lista.
+- `QasSearchBox`: Adicionado prop `maxHeight` para definir uma altura máxima para o componente.
 
 ### Corrigido
 - `QasPasswordInput`:
@@ -66,6 +68,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasToggle` modificado estilos.
 - `QasTreeGenerator`: adicionado separador nas ações.
 - `QasAlert/QasInfo`: modificado cor de error para `negative`.
+- `QasSearchBox`: modificado prop `height` para `maxHeight`, pois o nome da prop era `maxHeight`, mas internamente adicionava o style como `maxHeight`.
 
 ### Removido
 - `QasAlert/QasInfo`: removido `QasInfo` que agora foi mesclado com o `QasAlert`, olhar documentação.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasTextTruncate`: Adicionado campo de busca no dialog do componente ao conter mais de 12 itens na lista.
 - `QasSearchBox`: Adicionado prop `maxHeight` para definir uma altura máxima para o componente.
 
+### Modificado
+- `QasSearchBox`: modificado prop `height` para `maxHeight`, pois o nome da prop era `height`, mas internamente adicionava o style como `maxHeight`.
+
 ## [3.18.0-beta.1] - 16-04-2025
 ## BREAKING CHANGE
 - `QasAppMenu`:
@@ -82,7 +85,6 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasToggle` modificado estilos.
 - `QasTreeGenerator`: adicionado separador nas ações.
 - `QasAlert/QasInfo`: modificado cor de error para `negative`.
-- `QasSearchBox`: modificado prop `height` para `maxHeight`, pois o nome da prop era `height`, mas internamente adicionava o style como `maxHeight`.
 
 ### Removido
 - `QasAlert/QasInfo`: removido `QasInfo` que agora foi mesclado com o `QasAlert`, olhar documentação.

--- a/docs/src/examples/QasTextTruncate/WithManyItems.vue
+++ b/docs/src/examples/QasTextTruncate/WithManyItems.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script setup>
-defineOptions({ name: 'WithBadge' })
+defineOptions({ name: 'WithManyItems' })
 
 // Com array de objetos
 const list = [

--- a/docs/src/examples/QasTextTruncate/WithManyItems.vue
+++ b/docs/src/examples/QasTextTruncate/WithManyItems.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="container q-gutter-md q-py-lg">
+    <qas-text-truncate
+      class="text-negative" dialog-title="Aqui está meu título!" :list :max-visible-item="3" :max-width="310" use-object-list
+    />
+
+    <qas-text-truncate class="text-negative" dialog-title="Aqui está meu título!" :list="normalizedItems" :max-visible-item="3" :max-width="310" />
+  </div>
+</template>
+
+<script setup>
+defineOptions({ name: 'WithBadge' })
+
+// Com array de objetos
+const list = [
+  { label: 'Primeiro', color: 'green-8' },
+  { label: 'Segundo item', color: 'blue-8', textColor: 'white' },
+  { label: 'Terceiro item', color: 'red-8' },
+  { label: 'Quarto item', color: 'yellow-8' },
+  { label: 'Quinto item', color: 'purple-8' },
+  { label: 'Sexto item', color: 'orange-8' },
+  { label: 'Sétimo item', color: 'green-8' },
+  { label: 'Oitavo item', color: 'blue-8' },
+  { label: 'Nono item', color: 'red-8' },
+  { label: 'Décimo item', color: 'yellow-8' },
+  { label: 'Décimo primeiro item', color: 'purple-8' },
+  { label: 'Décimo segundo item', color: 'orange-8' },
+  { label: 'Décimo terceiro item', color: 'green-8' },
+  { label: 'Décimo quarto item', color: 'blue-8' },
+  { label: 'Décimo quinto item', color: 'red-8' },
+  { label: 'Décimo sexto item', color: 'yellow-8' },
+  { label: 'Décimo sétimo item', color: 'purple-8' },
+  { label: 'Décimo oitavo item', color: 'orange-8' },
+  { label: 'Décimo nono item', color: 'green-8' },
+  { label: 'Vigésimo item', color: 'blue-8' },
+  { label: 'Vigésimo primeiro item', color: 'red-8' },
+  { label: 'Vigésimo segundo item', color: 'yellow-8' },
+  { label: 'Vigésimo terceiro item', color: 'purple-8' },
+  { label: 'Vigésimo quarto item', color: 'orange-8' },
+  { label: 'Vigésimo quinto item', color: 'green-8' },
+  { label: 'Vigésimo sexto item', color: 'blue-8' },
+  { label: 'Vigésimo sétimo item', color: 'red-8' },
+  { label: 'Vigésimo oitavo item', color: 'yellow-8' },
+  { label: 'Vigésimo nono item', color: 'purple-8' },
+  { label: 'Trigésimo item', color: 'orange-8' }
+]
+
+// Somente um array de strings
+const normalizedItems = list.map(item => item.label)
+</script>

--- a/docs/src/examples/QasTextTruncate/WithManyItems.vue
+++ b/docs/src/examples/QasTextTruncate/WithManyItems.vue
@@ -1,8 +1,6 @@
 <template>
   <div class="container q-gutter-md q-py-lg">
-    <qas-text-truncate
-      class="text-negative" dialog-title="Aqui está meu título!" :list :max-visible-item="3" :max-width="310" use-object-list
-    />
+    <qas-text-truncate class="text-negative" dialog-title="Aqui está meu título!" :list :max-visible-item="3" :max-width="310" use-object-list />
 
     <qas-text-truncate class="text-negative" dialog-title="Aqui está meu título!" :list="normalizedItems" :max-visible-item="3" :max-width="310" />
   </div>

--- a/docs/src/pages/components/text-truncate.md
+++ b/docs/src/pages/components/text-truncate.md
@@ -14,6 +14,8 @@ Trunca um texto baseado no tamanho do elemento pai e adiciona um rotulo "ver mai
 
 <doc-example file="QasTextTruncate/WithCounter" title="Com contador" />
 
+<doc-example file="QasTextTruncate/WithManyItems" title="Com muitos itens" />
+
 :::warning
 Quando for utilizar por slot, não pode haver nenhum elemento englobando o texto.
 :::

--- a/docs/src/pages/components/text-truncate.md
+++ b/docs/src/pages/components/text-truncate.md
@@ -14,7 +14,7 @@ Trunca um texto baseado no tamanho do elemento pai e adiciona um rotulo "ver mai
 
 <doc-example file="QasTextTruncate/WithCounter" title="Com contador" />
 
-<doc-example file="QasTextTruncate/WithManyItems" title="Com muitos itens" />
+<doc-example file="QasTextTruncate/WithManyItems" title="Com mais de 12 itens" />
 
 :::warning
 Quando for utilizar por slot, não pode haver nenhum elemento englobando o texto.

--- a/ui/src/components/search-box/QasSearchBox.vue
+++ b/ui/src/components/search-box/QasSearchBox.vue
@@ -58,8 +58,13 @@ export default {
       type: Object
     },
 
-    height: {
+    maxHeight: {
       default: '300px',
+      type: String
+    },
+
+    height: {
+      default: 'auto',
       type: String
     },
 
@@ -120,7 +125,11 @@ export default {
     },
 
     containerStyle () {
-      return { maxHeight: this.containerHeight }
+      return {
+        // Caso tenha height, deverá ter um tamanho fixo com base no height, portanto não terá max-height.
+        maxHeight: this.height !== 'auto' ? 'auto' : this.containerHeight,
+        height: this.height
+      }
     },
 
     hasNoOptionsOnFirstFetch () {
@@ -130,7 +139,7 @@ export default {
     containerHeight () {
       const hasEmptyList = (!this.list.length && !this.useLazyLoading) || this.hasNoOptionsOnFirstFetch
 
-      return hasEmptyList ? this.emptyListHeight : this.height
+      return hasEmptyList ? this.emptyListHeight : this.maxHeight
     },
 
     component () {

--- a/ui/src/components/search-box/QasSearchBox.vue
+++ b/ui/src/components/search-box/QasSearchBox.vue
@@ -64,7 +64,7 @@ export default {
     },
 
     height: {
-      default: 'auto',
+      default: '',
       type: String
     },
 
@@ -127,8 +127,8 @@ export default {
     containerStyle () {
       return {
         // Caso tenha height, deverá ter um tamanho fixo com base no height, portanto não terá max-height.
-        maxHeight: this.height !== 'auto' ? 'auto' : this.containerHeight,
-        height: this.height
+        maxHeight: this.height ? 'auto' : this.containerHeight,
+        ...(this.height && { height: this.height })
       }
     },
 

--- a/ui/src/components/search-box/QasSearchBox.yml
+++ b/ui/src/components/search-box/QasSearchBox.yml
@@ -33,7 +33,12 @@ props:
 
   height:
     desc: Define altura do box quando a lista não está vazia.
-    default: 300px
+    default: auto
+    type: String
+
+  maxHeight:
+    desc: Define altura máxima do box quando a lista não está vazia.
+    default: auto
     type: String
 
   lazy-loading-props:

--- a/ui/src/components/text-truncate/QasTextTruncate.vue
+++ b/ui/src/components/text-truncate/QasTextTruncate.vue
@@ -367,14 +367,3 @@ function useBadgeHandler () {
   }
 }
 </script>
-<style lang="scss">
-.qas-text-truncate {
-  &__dialog .qas-search-box {
-    /**
-      * Altura calculada com base no height passado para o qas-search-box.
-      * Se não passar um height, ao efetuar uma busca, o dialog vai ficar quebrando de tamanho.
-      */
-    height: 566px;
-  }
-}
-</style>

--- a/ui/src/components/text-truncate/QasTextTruncate.vue
+++ b/ui/src/components/text-truncate/QasTextTruncate.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="parent" class="qas-text-truncate" :class="classes">
+  <div ref="parent" :class="classes">
     <div class="no-wrap row text-no-wrap">
       <div ref="truncate" class="ellipsis">
         <slot>
@@ -18,7 +18,7 @@
       <qas-btn v-if="hasButton" class="q-ml-sm" :label="buttonLabel" @click.stop.prevent="toggle" />
     </div>
 
-    <qas-dialog v-model="show" v-bind="defaultProps" aria-label="Diálogo de texto completo" class="qas-text-truncate__dialog" max-width="500px" role="dialog" use-full-max-width>
+    <qas-dialog v-model="show" v-bind="defaultProps" aria-label="Diálogo de texto completo" max-width="500px" role="dialog" use-full-max-width>
       <template v-if="isCounterMode" #description>
         <component :is="dialogComponent.is" v-bind="dialogComponent.props" v-model:results="searchModel">
           <q-list separator>

--- a/ui/src/components/text-truncate/QasTextTruncate.vue
+++ b/ui/src/components/text-truncate/QasTextTruncate.vue
@@ -185,10 +185,10 @@ function useDialog ({ props, textContent }) {
     return props.useObjectList ? searchModel.value.map(({ label }) => label) : searchModel.value
   })
 
-  const hasSearchBox = computed(() => normalizedList.value.length > 12)
-
   const dialogComponent = computed(() => {
-    if (hasSearchBox.value) {
+    const hasSearchBox = normalizedList.value.length > 12
+
+    if (hasSearchBox) {
       return {
         is: 'qas-search-box',
         list: normalizedSearchModel.value,


### PR DESCRIPTION
## BREAKING CHANGE
- `QasSearchBox`: modificado prop `height` para `maxHeight`, pois o nome da prop era `maxHeight`, mas internamente adicionava o style como `maxHeight`.

### Adicionado
- `QasTextTruncate`: Adicionado campo de busca no dialog do componente ao conter mais de 12 itens na lista.
- `QasSearchBox`: Adicionado prop `maxHeight` para definir uma altura máxima para o componente.

### Modificado
- `QasSearchBox`: modificado prop `height` para `maxHeight`, pois o nome da prop era `maxHeight`, mas internamente adicionava o style como `maxHeight`.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [ ] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
