### PR TITLE
feat: fix actions menu loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ### Corrigido
 - `QasInput`: alterado ordem da prop `iconRight` que estava adicionando na esquerda e não na direita.
 - `QasSelectFilter`: corrigido atribuição do valor do model externo do componente.
+- `QasActionsMenu`: corrigido exibição de loading no componente dentro do dropdown ao ter uma prop `loading: true`.
 
 ### Modificado
 - `QasSelect`: ignorando propriedade `useChips` que vem através de `$attrs`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasToggle` modificado estilos.
 - `QasTreeGenerator`: adicionado separador nas ações.
 - `QasAlert/QasInfo`: modificado cor de error para `negative`.
+- `QasBtn`: modificado exibição do loading, agora o spinner ficará no lugar do ícone, mas mantendo a label do botão. 
 
 ### Removido
 - `QasAlert/QasInfo`: removido `QasInfo` que agora foi mesclado com o `QasAlert`, olhar documentação.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,13 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ### Corrigido
 - `QasHeader`: corrigido exibição do container de descrição em casos de não ter `label` e `description`.
 - `QasTableGenerator`: adicionado `@click.prevent.stop` para não chamar o `rowRouteFn` e `onRowClick` quando se tem ações com botão na tabela.
+- `QasActionsMenu`: corrigido exibição de loading no componente dentro do dropdown ao ter uma prop `loading: true`.
 
 ### Removido
 - `QasTableGenerator`: removido possibilidade de ter sort na tabela.
+
+### Modificado
+- `QasBtn`: modificado exibição do loading, agora o spinner ficará no lugar do ícone, mas mantendo a label do botão.
 
 ## [3.18.0-beta.3] - 24-04-2025
 ### Corrigido
@@ -94,7 +98,6 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
   - invertido ícone de toggle.
   - corrigido label que não ficava acima do ícone ao ter foco/ativo.
   - desabilitado botão de toggle enquanto não tem valor preenchido.
-- `QasActionsMenu`: corrigido exibição de loading no componente dentro do dropdown ao ter uma prop `loading: true`.
 
 ### Modificado
 - `QasAppMenu`:
@@ -118,7 +121,6 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasToggle` modificado estilos.
 - `QasTreeGenerator`: adicionado separador nas ações.
 - `QasAlert/QasInfo`: modificado cor de error para `negative`.
-- `QasBtn`: modificado exibição do loading, agora o spinner ficará no lugar do ícone, mas mantendo a label do botão. 
 
 ### Removido
 - `QasAlert/QasInfo`: removido `QasInfo` que agora foi mesclado com o `QasAlert`, olhar documentação.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ## Não publicado
 ## BREAKING CHANGE
-- `QasBtn`: modificado a forma de exibição do loading, agora é exibido no lugar do ícone. Poderá haver breaking change visual.
+- `QasBtn`: modificado a forma de exibição do loading, agora é exibido no lugar do ícone. Poderá haver breaking change visual. Verificar lugares onde é utilizado o `use-ellipsis` também.
 
 ### Corrigido
 - `QasActionsMenu`: 
@@ -27,7 +27,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasTableGenerator`: removido possibilidade de ter sort na tabela.
 
 ### Modificado
-- `QasBtn`: modificado a forma de exibição do loading, agora é exibido no lugar do ícone. Poderá haver breaking change visual.
+- `QasBtn`: modificado a forma de exibição do loading, agora é exibido no lugar do ícone. Poderá haver breaking change visual. Verificar lugares onde é utilizado o `use-ellipsis` também.
 
 ## [3.18.0-beta.3] - 24-04-2025
 ### Corrigido

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
 ## Não publicado
+## BREAKING CHANGE
+- `QasBtn`: modificado a forma de exibição do loading, agora é exibido no lugar do ícone. Poderá haver breaking change visual.
+
 ### Corrigido
 - `QasActionsMenu`: adicionado validação no `q-list` do `qas-actions-menu` pra não exibir um `q-list` vazio quando só há um item.
 - `QasHeader`: corrigido exibição do container de descrição em casos de não ter `label` e `description`.
@@ -21,7 +24,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasTableGenerator`: removido possibilidade de ter sort na tabela.
 
 ### Modificado
-- `QasBtn`: modificado exibição do loading, agora o spinner ficará no lugar do ícone, mas mantendo a label do botão.
+- `QasBtn`: modificado a forma de exibição do loading, agora é exibido no lugar do ícone. Poderá haver breaking change visual.
 
 ## [3.18.0-beta.3] - 24-04-2025
 ### Corrigido

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
   - invertido ícone de toggle.
   - corrigido label que não ficava acima do ícone ao ter foco/ativo.
   - desabilitado botão de toggle enquanto não tem valor preenchido.
+- `QasActionsMenu`: corrigido exibição de loading no componente dentro do dropdown ao ter uma prop `loading: true`.
 
 ### Modificado
 - `QasAppMenu`:
@@ -86,7 +87,6 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ### Corrigido
 - `QasInput`: alterado ordem da prop `iconRight` que estava adicionando na esquerda e não na direita.
 - `QasSelectFilter`: corrigido atribuição do valor do model externo do componente.
-- `QasActionsMenu`: corrigido exibição de loading no componente dentro do dropdown ao ter uma prop `loading: true`.
 
 ### Modificado
 - `QasSelect`: ignorando propriedade `useChips` que vem através de `$attrs`.

--- a/docs/src/examples/QasActionsMenu/ExWithLoading.vue
+++ b/docs/src/examples/QasActionsMenu/ExWithLoading.vue
@@ -4,6 +4,24 @@
     <qas-actions-menu v-bind="props" />
 
     <qas-actions-menu v-bind="propsWithoutSplit" />
+
+    <qas-btn class="q-mt-md" icon="sym_r_person" label="Perfil" loading />
+
+    <br>
+
+    <qas-btn class="q-my-md" icon="sym_r_person" label="Perfil" loading variant="primary" />
+
+    <br>
+
+    <qas-btn icon="sym_r_person" label="Perfil" loading variant="secondary" />
+
+    <br>
+
+    <qas-btn class="q-mt-md" icon="sym_r_person" label="Perfil" variant="secondary" />
+
+    <br>
+
+    <qas-btn class="q-mt-md" icon="sym_r_person" :loading="loading.person" variant="secondary" @click="handleLoading('person')" />
   </div>
 </template>
 
@@ -51,15 +69,15 @@ const list = computed(() => {
 const props = computed(() => {
   return {
     list: list.value,
-    splitName: 'person'
+    splitName: 'edit'
   }
 })
 
-const propsWithoutSplit = computed(() => {
-  return {
-    list: list.value
-  }
-})
+// const propsWithoutSplit = computed(() => {
+//   return {
+//     list: list.value
+//   }
+// })
 
 // functions
 async function handleLoading (fieldKey) {

--- a/docs/src/examples/QasActionsMenu/ExWithLoading.vue
+++ b/docs/src/examples/QasActionsMenu/ExWithLoading.vue
@@ -4,24 +4,6 @@
     <qas-actions-menu v-bind="props" />
 
     <qas-actions-menu v-bind="propsWithoutSplit" />
-
-    <qas-btn class="q-mt-md" icon="sym_r_person" label="Perfil" loading />
-
-    <br>
-
-    <qas-btn class="q-my-md" icon="sym_r_person" label="Perfil" loading variant="primary" />
-
-    <br>
-
-    <qas-btn icon="sym_r_person" label="Perfil" loading variant="secondary" />
-
-    <br>
-
-    <qas-btn class="q-mt-md" icon="sym_r_person" label="Perfil" variant="secondary" />
-
-    <br>
-
-    <qas-btn class="q-mt-md" icon="sym_r_person" :loading="loading.person" variant="secondary" @click="handleLoading('person')" />
   </div>
 </template>
 
@@ -73,11 +55,11 @@ const props = computed(() => {
   }
 })
 
-// const propsWithoutSplit = computed(() => {
-//   return {
-//     list: list.value
-//   }
-// })
+const propsWithoutSplit = computed(() => {
+  return {
+    list: list.value
+  }
+})
 
 // functions
 async function handleLoading (fieldKey) {

--- a/docs/src/examples/QasActionsMenu/ExWithLoading.vue
+++ b/docs/src/examples/QasActionsMenu/ExWithLoading.vue
@@ -65,12 +65,12 @@ const propsWithoutSplit = computed(() => {
 async function handleLoading (fieldKey) {
   loading.value[fieldKey] = true
 
-  await promiseSimulator()
+  await sleepPromise()
 
   loading.value[fieldKey] = false
 }
 
-function promiseSimulator () {
+function sleepPromise () {
   return new Promise(resolve => setTimeout(() => resolve(), 3000))
 }
 </script>

--- a/docs/src/examples/QasActionsMenu/ExWithLoading.vue
+++ b/docs/src/examples/QasActionsMenu/ExWithLoading.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="container q-py-lg">
-    <div class="q-mb-sm text-body1">Clique em uma ação para visualizar o exemplo com loading</div>
+    <div class="q-mb-sm text-body1">
+      Clique em uma ação para visualizar o exemplo com loading
+    </div>
+
     <qas-actions-menu v-bind="props" />
 
     <qas-actions-menu v-bind="propsWithoutSplit" />

--- a/docs/src/examples/QasActionsMenu/ExWithLoading.vue
+++ b/docs/src/examples/QasActionsMenu/ExWithLoading.vue
@@ -2,6 +2,8 @@
   <div class="container q-py-lg">
     <div class="q-mb-sm text-body1">Clique em uma ação para visualizar o exemplo com loading</div>
     <qas-actions-menu v-bind="props" />
+
+    <qas-actions-menu v-bind="propsWithoutSplit" />
   </div>
 </template>
 
@@ -10,31 +12,38 @@ import { ref, computed } from 'vue'
 
 defineOptions({ name: 'ExWithLoading' })
 
+// refs
 const loading = ref({
   visibility: false,
   edit: false,
   person: false
 })
 
+// computeds
 const list = computed(() => {
   return {
     visibility: {
       icon: 'sym_r_visibility',
       label: 'Visualizar',
-      handler: () => { loading.value.visibility = !loading.value.visibility },
+      handler: () => handleLoading('visibility'),
       loading: loading.value.visibility
     },
     edit: {
       icon: 'sym_r_create',
       label: 'Editar',
-      handler: () => { loading.value.edit = !loading.value.edit },
+      handler: () => handleLoading('edit'),
       loading: loading.value.edit
     },
     person: {
       icon: 'sym_r_person',
       label: 'Perfil',
-      handler: () => { loading.value.person = !loading.value.person },
+      handler: () => handleLoading('person'),
       loading: loading.value.person
+    },
+    actionWithoutPromise: {
+      icon: 'sym_r_person',
+      label: 'Ação sem loading',
+      handler: () => {}
     }
   }
 })
@@ -45,4 +54,23 @@ const props = computed(() => {
     splitName: 'person'
   }
 })
+
+const propsWithoutSplit = computed(() => {
+  return {
+    list: list.value
+  }
+})
+
+// functions
+async function handleLoading (fieldKey) {
+  loading.value[fieldKey] = true
+
+  await promiseSimulator()
+
+  loading.value[fieldKey] = false
+}
+
+function promiseSimulator () {
+  return new Promise(resolve => setTimeout(() => resolve(), 3000))
+}
 </script>

--- a/docs/src/examples/QasActionsMenu/ExWithLoading.vue
+++ b/docs/src/examples/QasActionsMenu/ExWithLoading.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="container q-py-lg">
+    <div class="q-mb-sm text-body1">Clique em uma ação para visualizar o exemplo com loading</div>
+    <qas-actions-menu v-bind="props" />
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+
+defineOptions({ name: 'ExWithLoading' })
+
+const loading = ref({
+  visibility: false,
+  edit: false,
+  person: false
+})
+
+const list = computed(() => {
+  return {
+    visibility: {
+      icon: 'sym_r_visibility',
+      label: 'Visualizar',
+      handler: () => { loading.value.visibility = !loading.value.visibility },
+      loading: loading.value.visibility
+    },
+    edit: {
+      icon: 'sym_r_create',
+      label: 'Editar',
+      handler: () => { loading.value.edit = !loading.value.edit },
+      loading: loading.value.edit
+    },
+    person: {
+      icon: 'sym_r_person',
+      label: 'Perfil',
+      handler: () => { loading.value.person = !loading.value.person },
+      loading: loading.value.person
+    }
+  }
+})
+
+const props = computed(() => {
+  return {
+    list: list.value,
+    splitName: 'person'
+  }
+})
+</script>

--- a/docs/src/examples/QasBtn/ExWithLoading.vue
+++ b/docs/src/examples/QasBtn/ExWithLoading.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="container q-py-lg">
+    <div class="q-mb-sm text-body1">Clique em uma ação para visualizar o exemplo com loading</div>
+
+    <qas-btn class="q-mt-md" icon="sym_r_create" label="Visualizar" :loading="loading.visibility" @click="handleLoading('visibility')" />
+
+    <br>
+
+    <qas-btn class="q-my-md" icon="sym_r_person" label="Editar" :loading="loading.edit" variant="secondary" @click="handleLoading('edit')" />
+
+    <br>
+
+    <qas-btn icon="sym_r_person" label="Perfil" :loading="loading.person" variant="primary" @click="handleLoading('person')" />
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+defineOptions({ name: 'ExWithLoading' })
+
+// refs
+const loading = ref({
+  visibility: false,
+  edit: false,
+  person: false
+})
+
+// functions
+async function handleLoading (fieldKey) {
+  loading.value[fieldKey] = true
+
+  await promiseSimulator()
+
+  loading.value[fieldKey] = false
+}
+
+function promiseSimulator () {
+  return new Promise(resolve => setTimeout(() => resolve(), 3000))
+}
+</script>

--- a/docs/src/examples/QasBtn/ExWithLoading.vue
+++ b/docs/src/examples/QasBtn/ExWithLoading.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="container q-py-lg">
-    <div class="q-mb-sm text-body1">Clique em uma ação para visualizar o exemplo com loading</div>
+    <div class="q-mb-sm text-body1">
+      Clique em uma ação para visualizar o exemplo com loading
+    </div>
 
     <div class="column q-gutter-y-md">
       <div>

--- a/docs/src/examples/QasBtn/ExWithLoading.vue
+++ b/docs/src/examples/QasBtn/ExWithLoading.vue
@@ -42,12 +42,12 @@ const loading = ref({
 async function handleLoading (fieldKey) {
   loading.value[fieldKey] = true
 
-  await promiseSimulator()
+  await sleepPromise()
 
   loading.value[fieldKey] = false
 }
 
-function promiseSimulator () {
+function sleepPromise () {
   return new Promise(resolve => setTimeout(() => resolve(), 3000))
 }
 </script>

--- a/docs/src/examples/QasBtn/ExWithLoading.vue
+++ b/docs/src/examples/QasBtn/ExWithLoading.vue
@@ -2,15 +2,23 @@
   <div class="container q-py-lg">
     <div class="q-mb-sm text-body1">Clique em uma ação para visualizar o exemplo com loading</div>
 
-    <qas-btn class="q-mt-md" icon="sym_r_create" label="Visualizar" :loading="loading.visibility" @click="handleLoading('visibility')" />
+    <div class="column q-gutter-y-md">
+      <div>
+        <qas-btn icon="sym_r_create" label="Visualizar" :loading="loading.visibility" @click="handleLoading('visibility')" />
+      </div>
 
-    <br>
+      <div>
+        <qas-btn icon="sym_r_person" label="Editar" :loading="loading.edit" variant="secondary" @click="handleLoading('edit')" />
+      </div>
 
-    <qas-btn class="q-my-md" icon="sym_r_person" label="Editar" :loading="loading.edit" variant="secondary" @click="handleLoading('edit')" />
+      <div>
+        <qas-btn icon="sym_r_person" label="Perfil" :loading="loading.person" variant="primary" @click="handleLoading('person')" />
+      </div>
 
-    <br>
-
-    <qas-btn icon="sym_r_person" label="Perfil" :loading="loading.person" variant="primary" @click="handleLoading('person')" />
+      <div>
+        <qas-btn icon="sym_r_person" :loading="loading.person" variant="primary" @click="handleLoading('person')" />
+      </div>
+    </div>
   </div>
 </template>
 

--- a/docs/src/examples/QasBtn/ExWithLoading.vue
+++ b/docs/src/examples/QasBtn/ExWithLoading.vue
@@ -12,6 +12,10 @@
       </div>
 
       <div>
+        <qas-btn icon-right="sym_r_person" label="Editar" :loading="loading.edit" variant="secondary" @click="handleLoading('edit')" />
+      </div>
+
+      <div>
         <qas-btn icon="sym_r_person" label="Perfil" :loading="loading.person" variant="primary" @click="handleLoading('person')" />
       </div>
 

--- a/docs/src/pages/components/actions-menu.md
+++ b/docs/src/pages/components/actions-menu.md
@@ -53,12 +53,12 @@ Componente wrapper do `QasBtnDropdown` que implementa regras de negocio.
 - As labels dos tooltips vão ser as labels dentro da prop `list`.
 :::
 
-<!-- <doc-example file="QasActionsMenu/Basic" title="Básico" />
+<doc-example file="QasActionsMenu/Basic" title="Básico" />
 <doc-example file="QasActionsMenu/ExSplit" title="Split de 2 itens" />
 <doc-example file="QasActionsMenu/ExMultipleSplit" title="Split de vários itens" />
 <doc-example file="QasActionsMenu/ExDisable" title="Desabilitado" />
 <doc-example file="QasActionsMenu/ExOptions" title="Opções" />
 <doc-example file="QasActionsMenu/ExDelete" title="Com deleção" />
 <doc-example file="QasActionsMenu/ExNoLabel" title="Sem label" />
-<doc-example file="QasActionsMenu/ExTooltip" title="Sem label com tooltip" /> -->
+<doc-example file="QasActionsMenu/ExTooltip" title="Sem label com tooltip" />
 <doc-example file="QasActionsMenu/ExWithLoading" title="Com loading" />

--- a/docs/src/pages/components/actions-menu.md
+++ b/docs/src/pages/components/actions-menu.md
@@ -61,3 +61,4 @@ Componente wrapper do `QasBtnDropdown` que implementa regras de negocio.
 <doc-example file="QasActionsMenu/ExDelete" title="Com deleção" />
 <doc-example file="QasActionsMenu/ExNoLabel" title="Sem label" />
 <doc-example file="QasActionsMenu/ExTooltip" title="Sem label com tooltip" />
+<doc-example file="QasActionsMenu/ExWithLoading" title="Com loading" />

--- a/docs/src/pages/components/actions-menu.md
+++ b/docs/src/pages/components/actions-menu.md
@@ -53,12 +53,12 @@ Componente wrapper do `QasBtnDropdown` que implementa regras de negocio.
 - As labels dos tooltips vão ser as labels dentro da prop `list`.
 :::
 
-<doc-example file="QasActionsMenu/Basic" title="Básico" />
+<!-- <doc-example file="QasActionsMenu/Basic" title="Básico" />
 <doc-example file="QasActionsMenu/ExSplit" title="Split de 2 itens" />
 <doc-example file="QasActionsMenu/ExMultipleSplit" title="Split de vários itens" />
 <doc-example file="QasActionsMenu/ExDisable" title="Desabilitado" />
 <doc-example file="QasActionsMenu/ExOptions" title="Opções" />
 <doc-example file="QasActionsMenu/ExDelete" title="Com deleção" />
 <doc-example file="QasActionsMenu/ExNoLabel" title="Sem label" />
-<doc-example file="QasActionsMenu/ExTooltip" title="Sem label com tooltip" />
+<doc-example file="QasActionsMenu/ExTooltip" title="Sem label com tooltip" /> -->
 <doc-example file="QasActionsMenu/ExWithLoading" title="Com loading" />

--- a/docs/src/pages/components/button.md
+++ b/docs/src/pages/components/button.md
@@ -75,3 +75,5 @@ A cor "white" é usada quando necessita de um contraste, sendo possível ter ou 
 <doc-example file="QasBtn/ExBtnUseLabelOnSmallScreen" title="use-label-on-small-screen" />
 
 <doc-example file="QasBtn/ExBtnEllipsis" title="Com ellipsis" />
+
+<doc-example file="QasBtn/ExWithLoading" title="Com loading" />

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -255,10 +255,7 @@ const formattedList = computed(() => {
 
 const { showTooltip, tooltipLabels } = useTooltips({ formattedList, fullList, props })
 
-watch(
-  () => hasActiveLoading.value,
-  (newValue, oldValue) => handleMenuModel(newValue, oldValue)
-)
+watch(() => hasActiveLoading.value, handleMenuModel)
 // functions
 function getItemProps (item) {
   const { disable, loading, props: itemProps, to } = item

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -256,7 +256,7 @@ const { showTooltip, tooltipLabels } = useTooltips({ formattedList, fullList, pr
 watch(
   () => hasItemWithLoading.value,
   (newValue, oldValue) => {
-    // Fechar o menu após alguma ação passou de "loading: true" para "loading: false".
+    // Fecha o menu após o estado de loading do item passar de true para false
     if (oldValue && !newValue) {
       menuModel.value = false
     }

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -167,7 +167,7 @@ const defaultButtonPropsList = computed(() => {
  * Procura se alguma ação está com "loading: true", para o dropdown não fechar
  * automaticamente após clicar em alguma ação.
  */
-const hasItemWithLoading = computed(() => {
+const hasActiveLoading = computed(() => {
   return Object.values(formattedList.value.dropdownList)?.some(action => action.loading)
 })
 
@@ -178,7 +178,7 @@ const btnDropdownProps = computed(() => {
     buttonsPropsList: defaultButtonPropsList.value,
     disable: props.disable,
     useSplit: hasSplit.value,
-    useAutoClose: !hasItemWithLoading.value
+    useAutoClose: !hasActiveLoading.value
   }
 })
 
@@ -256,13 +256,8 @@ const formattedList = computed(() => {
 const { showTooltip, tooltipLabels } = useTooltips({ formattedList, fullList, props })
 
 watch(
-  () => hasItemWithLoading.value,
-  (newValue, oldValue) => {
-    // Fecha o menu após o estado de loading do item passar de true para false
-    if (oldValue && !newValue) {
-      menuModel.value = false
-    }
-  }
+  () => hasActiveLoading.value,
+  (newValue, oldValue) => handleMenuModel(newValue, oldValue)
 )
 // functions
 function getItemProps (item) {
@@ -272,6 +267,13 @@ function getItemProps (item) {
     disable: disable || loading, // ficará desabilitado se for passado a prop "disable" ou o "loading" seja true.
     to,
     ...itemProps
+  }
+}
+
+function handleMenuModel (newValue, oldValue) {
+  // Fecha o menu após o estado de loading do item passar de true para false
+  if (oldValue && !newValue) {
+    menuModel.value = false
   }
 }
 </script>

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -5,7 +5,7 @@
         <slot v-for="(item, key) in formattedList.dropdownList" :item="item" :name="key">
           <q-item v-bind="getItemProps(item)" :key="key" active-class="primary" clickable data-cy="actions-menu-list-item" @click="setClickHandler(item)">
             <q-item-section avatar>
-              <q-spinner v-if="item.loading" color="primary" size="sm" />
+              <q-spinner v-if="item.loading" size="sm" />
               <q-icon v-else :name="item.icon" />
             </q-item-section>
 

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -5,7 +5,8 @@
         <slot v-for="(item, key) in formattedList.dropdownList" :item="item" :name="key">
           <q-item v-bind="getItemProps(item)" :key="key" active-class="primary" clickable data-cy="actions-menu-list-item" @click="setClickHandler(item)">
             <q-item-section avatar>
-              <q-icon :name="item.icon" />
+              <q-spinner v-if="item.loading" color="primary" size="sm" />
+              <q-icon v-else :name="item.icon" />
             </q-item-section>
 
             <q-item-section>
@@ -240,10 +241,10 @@ const { showTooltip, tooltipLabels } = useTooltips({ formattedList, fullList, pr
 
 // functions
 function getItemProps (item) {
-  const { disable, props: itemProps, to } = item
+  const { disable, loading, props: itemProps, to } = item
 
   return {
-    disable,
+    disable: disable || loading, // ficará desabilitado se for passado a prop "disable" ou o "loading" seja true.
     to,
     ...itemProps
   }

--- a/ui/src/components/btn-dropdown/QasBtnDropdown.vue
+++ b/ui/src/components/btn-dropdown/QasBtnDropdown.vue
@@ -111,14 +111,6 @@ const hasMenuOnLeftSide = computed(() => hasDefaultSlot.value && !props.useSplit
 const splittedButtonProps = computed(() => {
   const iconKey = screen.isSmall ? 'icon' : 'iconRight'
 
-  console.log({
-    color: 'grey-10',
-    disable: props.disable,
-    [iconKey]: props.dropdownIcon,
-    variant: 'tertiary',
-    label: 'Opções',
-    useLabelOnSmallScreen: false
-  }, '<-- retorno')
   return {
     color: 'grey-10',
     disable: props.disable,

--- a/ui/src/components/btn-dropdown/QasBtnDropdown.vue
+++ b/ui/src/components/btn-dropdown/QasBtnDropdown.vue
@@ -4,7 +4,7 @@
       <div v-for="(buttonProps, key, index) in props.buttonsPropsList" :key="key">
         <div class="flex no-wrap">
           <qas-btn :disable="props.disable" v-bind="buttonProps" no-wrap variant="tertiary" @click="onClick">
-            <q-menu v-if="hasMenuOnLeftSide" v-model="isMenuOpened" anchor="bottom right" auto-close self="top right" @update:model-value="onUpdateMenuValue">
+            <q-menu v-if="hasMenuOnLeftSide" v-model="isMenuOpened" anchor="bottom right" :auto-close="props.useAutoClose" self="top right" @update:model-value="onUpdateMenuValue">
               <div :class="classes.menuContent">
                 <slot />
               </div>
@@ -20,7 +20,7 @@
 
     <div v-if="props.useSplit">
       <qas-btn v-bind="splittedButtonProps">
-        <q-menu v-if="hasDefaultSlot" anchor="bottom right" auto-close self="top right">
+        <q-menu v-if="hasDefaultSlot" v-model="isMenuOpened" anchor="bottom right" :auto-close="props.useAutoClose" self="top right" @update:model-value="onUpdateMenuValue">
           <div :class="classes.menuContent">
             <slot />
           </div>
@@ -68,6 +68,11 @@ const props = defineProps({
   },
 
   useTooltip: {
+    type: Boolean,
+    default: true
+  },
+
+  useAutoClose: {
     type: Boolean,
     default: true
   }

--- a/ui/src/components/btn-dropdown/QasBtnDropdown.vue
+++ b/ui/src/components/btn-dropdown/QasBtnDropdown.vue
@@ -111,6 +111,14 @@ const hasMenuOnLeftSide = computed(() => hasDefaultSlot.value && !props.useSplit
 const splittedButtonProps = computed(() => {
   const iconKey = screen.isSmall ? 'icon' : 'iconRight'
 
+  console.log({
+    color: 'grey-10',
+    disable: props.disable,
+    [iconKey]: props.dropdownIcon,
+    variant: 'tertiary',
+    label: 'Opções',
+    useLabelOnSmallScreen: false
+  }, '<-- retorno')
   return {
     color: 'grey-10',
     disable: props.disable,

--- a/ui/src/components/btn-dropdown/QasBtnDropdown.yml
+++ b/ui/src/components/btn-dropdown/QasBtnDropdown.yml
@@ -36,6 +36,11 @@ props:
     default: false
     type: Boolean
 
+  use-auto-close:
+    desc: Controla se o comportamento de click deve fechar o menu.
+    default: true
+    type: Boolean
+
 slots:
   default:
     desc: Slot para passar o conteúdo do dropdown (menu).

--- a/ui/src/components/btn/QasBtn.vue
+++ b/ui/src/components/btn/QasBtn.vue
@@ -103,7 +103,6 @@ const iconRightClasses = computed(() => ({ 'q-ml-xs': showLabel.value && props.l
 const loadingClasses = computed(() => ({ 'q-mr-xs': showLabel.value && props.label }))
 
 const classes = computed(() => {
-  console.log(props.label, '<--- props.label')
   return {
     'qas-btn--primary': isPrimary.value,
     'qas-btn--secondary': isSecondary.value,

--- a/ui/src/components/btn/QasBtn.vue
+++ b/ui/src/components/btn/QasBtn.vue
@@ -7,6 +7,7 @@
 
     <span class="items-center justify-center no-wrap row text-center">
       <q-spinner v-if="hasLeftSpinner" :class="iconClasses" size="sm" />
+
       <q-icon v-if="hasIcon" :class="iconClasses" :name="props.icon" size="xs" />
 
       <span v-if="showLabel">
@@ -14,6 +15,7 @@
       </span>
 
       <q-spinner v-if="hasRightSpinner" :class="iconRightClasses" size="sm" />
+
       <q-icon v-if="hasIconRight" :class="iconRightClasses" :name="props.iconRight" size="xs" />
     </span>
 

--- a/ui/src/components/btn/QasBtn.vue
+++ b/ui/src/components/btn/QasBtn.vue
@@ -1,8 +1,6 @@
 <template>
   <!-- "data-table-ignore-tr-hover" é para desabilitar o hover do tr no QasTableGenerator -->
   <q-btn ref="button" class="qas-btn" data-table-ignore-tr-hover v-bind="attributes">
-    <slot />
-
     <template v-for="(_, name) in nonDefaultSlots" #[name]="context">
       <slot :name="name" v-bind="context || {}" />
     </template>

--- a/ui/src/components/btn/QasBtn.vue
+++ b/ui/src/components/btn/QasBtn.vue
@@ -131,8 +131,6 @@ const classes = computed(() => {
 
 const attributes = computed(() => {
   const {
-    // icon,
-    // label,
     class: externalClass,
     dense,
     disable,
@@ -157,11 +155,7 @@ const attributes = computed(() => {
   } = attrs
 
   return {
-    // ...(showLabel.value && { label: props.label }),
-
     ...attributesPayload,
-    // icon: props.icon,
-    // iconRight: props.iconRight,
     disable: disable || props.loading,
     class: [classes.value, externalClass]
   }

--- a/ui/src/components/btn/QasBtn.vue
+++ b/ui/src/components/btn/QasBtn.vue
@@ -54,7 +54,6 @@ const props = defineProps({
   },
 
   loading: {
-    default: false,
     type: Boolean
   },
 

--- a/ui/src/components/btn/QasBtn.vue
+++ b/ui/src/components/btn/QasBtn.vue
@@ -9,7 +9,9 @@
       <q-spinner v-if="hasLeftSpinner" :class="iconClasses" size="sm" />
       <q-icon v-if="hasIcon" :class="iconClasses" :name="props.icon" size="xs" />
 
-      <span v-if="showLabel">{{ props.label }}</span>
+      <span v-if="showLabel">
+        {{ props.label }}
+      </span>
 
       <q-spinner v-if="hasRightSpinner" :class="iconRightClasses" size="sm" />
       <q-icon v-if="hasIconRight" :class="iconRightClasses" :name="props.iconRight" size="xs" />

--- a/ui/src/components/btn/QasBtn.vue
+++ b/ui/src/components/btn/QasBtn.vue
@@ -4,7 +4,7 @@
       <slot :name="name" v-bind="context || {}" />
     </template>
 
-    <span class="items-center justify-center row text-center">
+    <span class="items-center justify-center no-wrap row text-center">
       <q-spinner v-if="props.loading" :class="loadingClasses" size="sm" />
       <q-icon v-if="hasIcon" :class="iconClasses" :name="props.icon" size="xs" />
       <span v-if="showLabel">{{ props.label }}</span>
@@ -128,15 +128,16 @@ const classes = computed(() => {
 
 const attributes = computed(() => {
   const {
+    // icon,
+    // label,
     class: externalClass,
     dense,
+    disable,
     fab,
     fabMini,
     flat,
     glossy,
     loading,
-    // label,
-    // icon,
     noWrap,
     outline,
     padding,
@@ -158,6 +159,7 @@ const attributes = computed(() => {
     ...attributesPayload,
     // icon: props.icon,
     // iconRight: props.iconRight,
+    disable: disable || props.loading,
     class: [classes.value, externalClass]
   }
 })

--- a/ui/src/components/btn/QasBtn.vue
+++ b/ui/src/components/btn/QasBtn.vue
@@ -8,7 +8,7 @@
     <div class="items-center justify-center no-wrap row text-center" :class="containerClasses">
       <q-spinner v-if="hasLeftSpinner" :class="iconClasses" size="sm" />
 
-      <q-icon v-if="hasIcon" :class="iconClasses" :name="props.icon" size="xs" />
+      <q-icon v-if="hasIcon" :class="iconClasses" :name="props.icon" />
 
       <div v-if="showLabel" :class="labelClasses">
         {{ props.label }}
@@ -16,7 +16,7 @@
 
       <q-spinner v-if="hasRightSpinner" :class="iconRightClasses" size="sm" />
 
-      <q-icon v-if="hasIconRight" :class="iconRightClasses" :name="props.iconRight" size="xs" />
+      <q-icon v-if="hasIconRight" :class="iconRightClasses" :name="props.iconRight" />
     </div>
 
     <slot />
@@ -111,8 +111,8 @@ const hasIcon = computed(() => props.icon && !props.loading)
 const labelClasses = computed(() => ({ ellipsis: props.useEllipsis }))
 const containerClasses = computed(() => ({ 'full-width': props.useEllipsis }))
 
-const iconClasses = computed(() => ({ 'q-mr-xs': showLabel.value && props.label }))
-const iconRightClasses = computed(() => ({ 'q-ml-xs': showLabel.value && props.label }))
+const iconClasses = computed(() => ({ 'on-left': !hasIconOnly.value }))
+const iconRightClasses = computed(() => ({ 'on-right': !hasIconOnly.value }))
 
 const classes = computed(() => {
   return {

--- a/ui/src/components/btn/QasBtn.vue
+++ b/ui/src/components/btn/QasBtn.vue
@@ -1,10 +1,17 @@
 <template>
   <q-btn ref="button" class="qas-btn" v-bind="attributes">
-    <slot />
-
     <template v-for="(_, name) in nonDefaultSlots" #[name]="context">
       <slot :name="name" v-bind="context || {}" />
     </template>
+
+    <span class="items-center justify-center row text-center">
+      <q-spinner v-if="props.loading" :class="loadingClasses" size="sm" />
+      <q-icon v-if="hasIcon" :class="iconClasses" :name="props.icon" size="xs" />
+      <span v-if="showLabel">{{ props.label }}</span>
+      <q-icon v-if="hasIconRight" :class="iconRightClasses" :name="props.iconRight" size="xs" />
+    </span>
+
+    <slot />
   </q-btn>
 </template>
 
@@ -45,6 +52,11 @@ const props = defineProps({
     type: String
   },
 
+  loading: {
+    default: false,
+    type: Boolean
+  },
+
   variant: {
     default: 'tertiary',
     type: String,
@@ -83,7 +95,15 @@ const hasIconOnly = computed(() => {
   )
 })
 
+const hasIconRight = computed(() => props.iconRight && !props.loading)
+const hasIcon = computed(() => props.icon && !props.loading)
+
+const iconClasses = computed(() => ({ 'q-mr-xs': showLabel.value && props.label }))
+const iconRightClasses = computed(() => ({ 'q-ml-xs': showLabel.value && props.label }))
+const loadingClasses = computed(() => ({ 'q-mr-xs': showLabel.value && props.label }))
+
 const classes = computed(() => {
+  console.log(props.label, '<--- props.label')
   return {
     'qas-btn--primary': isPrimary.value,
     'qas-btn--secondary': isSecondary.value,
@@ -109,11 +129,15 @@ const classes = computed(() => {
 
 const attributes = computed(() => {
   const {
+    class: externalClass,
     dense,
     fab,
     fabMini,
     flat,
     glossy,
+    loading,
+    // label,
+    // icon,
     noWrap,
     outline,
     padding,
@@ -126,16 +150,15 @@ const attributes = computed(() => {
     stretch,
     textColor,
     unelevated,
-    class: externalClass,
     ...attributesPayload
   } = attrs
 
   return {
-    ...(showLabel.value && { label: props.label }),
+    // ...(showLabel.value && { label: props.label }),
 
     ...attributesPayload,
-    icon: props.icon,
-    iconRight: props.iconRight,
+    // icon: props.icon,
+    // iconRight: props.iconRight,
     class: [classes.value, externalClass]
   }
 })

--- a/ui/src/components/btn/QasBtn.vue
+++ b/ui/src/components/btn/QasBtn.vue
@@ -5,9 +5,10 @@
     </template>
 
     <span class="items-center justify-center no-wrap row text-center">
-      <q-spinner v-if="props.loading" :class="loadingClasses" size="sm" />
+      <q-spinner v-if="hasLeftSpinner" :class="iconClasses" size="sm" />
       <q-icon v-if="hasIcon" :class="iconClasses" :name="props.icon" size="xs" />
       <span v-if="showLabel">{{ props.label }}</span>
+      <q-spinner v-if="hasRightSpinner" :class="iconRightClasses" size="sm" />
       <q-icon v-if="hasIconRight" :class="iconRightClasses" :name="props.iconRight" size="xs" />
     </span>
 
@@ -95,12 +96,14 @@ const hasIconOnly = computed(() => {
   )
 })
 
+const hasLeftSpinner = computed(() => props.loading && !props.iconRight)
+const hasRightSpinner = computed(() => props.loading && props.iconRight)
+
 const hasIconRight = computed(() => props.iconRight && !props.loading)
 const hasIcon = computed(() => props.icon && !props.loading)
 
 const iconClasses = computed(() => ({ 'q-mr-xs': showLabel.value && props.label }))
 const iconRightClasses = computed(() => ({ 'q-ml-xs': showLabel.value && props.label }))
-const loadingClasses = computed(() => ({ 'q-mr-xs': showLabel.value && props.label }))
 
 const classes = computed(() => {
   return {

--- a/ui/src/components/btn/QasBtn.vue
+++ b/ui/src/components/btn/QasBtn.vue
@@ -5,19 +5,19 @@
       <slot :name="name" v-bind="context || {}" />
     </template>
 
-    <span class="items-center justify-center no-wrap row text-center">
+    <div class="items-center justify-center no-wrap row text-center" :class="containerClasses">
       <q-spinner v-if="hasLeftSpinner" :class="iconClasses" size="sm" />
 
       <q-icon v-if="hasIcon" :class="iconClasses" :name="props.icon" size="xs" />
 
-      <span v-if="showLabel">
+      <div v-if="showLabel" :class="labelClasses">
         {{ props.label }}
-      </span>
+      </div>
 
       <q-spinner v-if="hasRightSpinner" :class="iconRightClasses" size="sm" />
 
       <q-icon v-if="hasIconRight" :class="iconRightClasses" :name="props.iconRight" size="xs" />
-    </span>
+    </div>
 
     <slot />
   </q-btn>
@@ -108,6 +108,9 @@ const hasRightSpinner = computed(() => props.loading && props.iconRight)
 const hasIconRight = computed(() => props.iconRight && !props.loading)
 const hasIcon = computed(() => props.icon && !props.loading)
 
+const labelClasses = computed(() => ({ ellipsis: props.useEllipsis }))
+const containerClasses = computed(() => ({ 'full-width': props.useEllipsis }))
+
 const iconClasses = computed(() => ({ 'q-mr-xs': showLabel.value && props.label }))
 const iconRightClasses = computed(() => ({ 'q-ml-xs': showLabel.value && props.label }))
 
@@ -131,7 +134,7 @@ const classes = computed(() => {
     'qas-btn--no-hover-on-white': !props.useHoverOnWhiteColor,
 
     // ellipsis
-    'qas-btn--ellipsis': props.useEllipsis
+    'full-width': props.useEllipsis
   }
 })
 

--- a/ui/src/css/components/button.scss
+++ b/ui/src/css/components/button.scss
@@ -81,20 +81,6 @@
     }
   }
 
-  &--ellipsis {
-    width: 100%;
-
-    .q-btn__content {
-      flex-wrap: nowrap;
-
-      .block {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-    }
-  }
-
   &.q-btn {
     &::before {
       display: none;

--- a/ui/src/css/components/button.scss
+++ b/ui/src/css/components/button.scss
@@ -101,18 +101,12 @@
     }
   }
 
-  .q-icon.on-left {
-    margin-right: var(--qas-spacing-xs);
-  }
-
-  .q-icon.on-right {
-    margin-left: var(--qas-spacing-xs);
-  }
-
+  .q-icon.on-left,
   .q-spinner.on-left {
     margin-right: var(--qas-spacing-xs);
   }
 
+  .q-icon.on-right,
   .q-spinner.on-right {
     margin-left: var(--qas-spacing-xs);
   }

--- a/ui/src/css/components/button.scss
+++ b/ui/src/css/components/button.scss
@@ -81,6 +81,20 @@
     }
   }
 
+  &--ellipsis {
+    width: 100%;
+
+    .q-btn__content {
+      flex-wrap: nowrap;
+
+      .block {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+  }
+
   &.q-btn {
     &::before {
       display: none;
@@ -92,6 +106,14 @@
   }
 
   .q-icon.on-right {
+    margin-left: var(--qas-spacing-xs);
+  }
+
+  .q-spinner.on-left {
+    margin-right: var(--qas-spacing-xs);
+  }
+
+  .q-spinner.on-right {
     margin-left: var(--qas-spacing-xs);
   }
 

--- a/ui/src/css/mixins/set-button.scss
+++ b/ui/src/css/mixins/set-button.scss
@@ -19,8 +19,4 @@
   @if $no-hover-on-white {
     @extend .qas-btn--no-hover-on-white;
   }
-
-  @if $ellipsis {
-    @extend .qas-btn--ellipsis;
-  }
 }

--- a/ui/src/css/mixins/set-button.scss
+++ b/ui/src/css/mixins/set-button.scss
@@ -19,4 +19,8 @@
   @if $no-hover-on-white {
     @extend .qas-btn--no-hover-on-white;
   }
+
+  @if $ellipsis {
+    @extend .qas-btn--ellipsis;
+  }
 }


### PR DESCRIPTION
### Corrigido
- `QasActionsMenu`: corrigido exibição de loading no componente dentro do dropdown ao ter uma prop `loading: true`.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [X] Fiz meu próprio _code review_ antes de abrir este _pull request_.
