### PR TITLE
QasTableGenerator changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,19 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ### Adicionado
 - `QasTextTruncate`: Adicionado campo de busca no dialog do componente ao conter mais de 12 itens na lista.
 - `QasSearchBox`: Adicionado prop `maxHeight` para definir uma altura máxima para o componente.
+- `QasTableGenerator`:
+  - adicionado propriedade `fieldsProps` para controle de componente interno sem uso de slot.
+  - adicionado propriedade `actionsMenuProps` para adicionar por padrão coluna `actions` com componente `QasActions` na ultima coluna com alinhamento á direita.
 
 ### Modificado
 - `QasSearchBox`: modificado prop `height` para `maxHeight`, pois o nome da prop era `height`, mas internamente adicionava o style como `maxHeight`.
+- `QasTextTruncate`: modificado espaçamento entre texto e botão "ver mais" de sm para xs.
+- `QasTableGenerator`:
+  - adicionado sort default em todas colunas.
+  - modificado estilos de hover nas linhas.
+- [`QasBtn`, `QasToggleVisibility`]: adicionado atributo `data-table-ignore-tr-hover`.
+- `QasCopy`: adicionado atributo `data-table-hover`.
+- `QasBadge`: adicionado atributo `data-table-ignore-hover`.
 
 ## [3.18.0-beta.1] - 16-04-2025
 ## BREAKING CHANGE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,9 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasSearchBox`: modificado prop `height` para `maxHeight`, pois o nome da prop era `height`, mas internamente adicionava o style como `maxHeight`.
 - `QasTextTruncate`: modificado espaçamento entre texto e botão "ver mais" de sm para xs.
 - `QasTableGenerator`: modificado estilos e estilos de hover nas linhas
-- [`QasBtn`, `QasToggleVisibility`]: adicionado atributo `data-table-ignore-tr-hover`.
-- `QasCopy`: adicionado atributo `data-table-hover`.
-- `QasBadge`: adicionado atributo `data-table-ignore-hover`.
+- [`QasBtn`, `QasToggleVisibility`]: adicionado atributo `data-table-ignore-tr-hover` para uso no QasTableGenerator.
+- `QasCopy`: adicionado atributo `data-table-hover` para uso no QasTableGenerator.
+- `QasBadge`: adicionado atributo `data-table-ignore-hover` para uso no QasTableGenerator.
 
 ## [3.18.0-beta.1] - 16-04-2025
 ## BREAKING CHANGE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,13 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - `QasTableGenerator`:
   - adicionado propriedade `fieldsProps` para controle de componente interno sem uso de slot.
   - adicionado propriedade `actionsMenuProps` para adicionar por padrão coluna `actions` com componente `QasActions` na ultima coluna com alinhamento á direita.
+  - adicionado sort default em todas colunas.
+  - adicionado scroll gradiente no eixo x.
 
 ### Modificado
 - `QasSearchBox`: modificado prop `height` para `maxHeight`, pois o nome da prop era `height`, mas internamente adicionava o style como `maxHeight`.
 - `QasTextTruncate`: modificado espaçamento entre texto e botão "ver mais" de sm para xs.
-- `QasTableGenerator`:
-  - adicionado sort default em todas colunas.
-  - modificado estilos de hover nas linhas.
+- `QasTableGenerator`: modificado estilos e estilos de hover nas linhas
 - [`QasBtn`, `QasToggleVisibility`]: adicionado atributo `data-table-ignore-tr-hover`.
 - `QasCopy`: adicionado atributo `data-table-hover`.
 - `QasBadge`: adicionado atributo `data-table-ignore-hover`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ## Não publicado
 ## BREAKING CHANGE
 - `QasSearchBox`: modificado prop `height` para `maxHeight`, pois o nome da prop era `height`, mas internamente adicionava o style como `maxHeight`.
+- `QasTableGenerator`:
+  - olhar todos lugares que usam slot de actions/componentes e passar a utilizar pelas propriedades `fieldsProps` e `actionsMenuProps`.
+  - por padrão toda coluna terá `sort`, mas nem toda coluna precisa de sort, então é necessário olhar caso a caso e remover quando desnecessário.
 
 ### Adicionado
 - `QasTextTruncate`: Adicionado campo de busca no dialog do componente ao conter mais de 12 itens na lista.

--- a/docs/src/examples/QasTableGenerator/Basic.vue
+++ b/docs/src/examples/QasTableGenerator/Basic.vue
@@ -1,60 +1,63 @@
 <template>
-  <!-- Utilizando o list-view apenas para facilitar para recuperar os dados dos dados. -->
-  <qas-list-view v-model:fields="viewState.fields" v-model:results="viewState.results" :entity :use-filter="false">
-    <template #default>
-      <qas-table-generator :fields="viewState.fields" :results="viewState.results" v-bind="tableGeneratorProps">
-      <!-- <qas-table-generator :columns :fields="fields" :fields-props :results="results" row-key="uuid"> -->
-        <!-- <template #body-cell-name>
-          <qas-toggle-visibility data-table-ignore-hover text="64.829.511/0001-01" />
-        </template> -->
-      </qas-table-generator>
+  <qas-table-generator :fields :results v-bind="tableGeneratorProps">
+    <!-- <qas-table-generator :columns :fields="fields" :fields-props :results="results" row-key="uuid"> -->
+    <template #body-cell-name>
+      <qas-toggle-visibility data-table-ignore-hover text="64.829.511/0001-01" />
     </template>
-  </qas-list-view>
+  </qas-table-generator>
 </template>
 
 <script setup>
-import { useView } from '@bildvitta/composables'
+import { fields, results } from 'src/mocks/users'
 
 defineOptions({ name: 'Basic' })
 
-// composables
-const { viewState } = useView({ mode: 'list' })
-
-const entity = 'users'
-
 const tableGeneratorProps = {
-  columns: ['document', 'name', 'email', 'phone'],
+  columns: ['isActive', 'document', 'companies', 'createdAt', { sortable: false, name: 'date' }],
 
-  fieldsProps: {
-    document: {
-      component: 'QasStatus'
-    },
-
-    name: {
-      component: 'QasTextTruncate',
-      props: {
-        maxWidth: 150
-      }
-    },
-
-    email: {
-      component: 'QasCopy',
-      props: {}
-    },
-
-    sla: {
-      component: 'QasBtn',
-      props: {
-        onClick: () => {
+  actionsMenuProps (row) {
+    return {
+      list: {
+        visibility: {
+          label: 'Visibilidade',
+          icon: 'sym_r_person',
+          handler: () => alert(row.uuid)
         }
       }
     }
   },
 
-  rowRouteFn: row => {
-    return ''
-  },
+  fieldsProps (row) {
+    return {
+      companies: {
+        component: 'QasTextTruncate',
+        props: {
+          list: row.companies,
+          maxVisibleItems: 1
+        }
+      },
 
-  onRowClick: () => ({})
+      document: {
+        component: 'QasCopy'
+      },
+
+      name: {
+        component: 'QasTextTruncate',
+        props: {
+          maxWidth: 150
+        }
+      },
+
+      email: {
+        component: 'QasCopy'
+      }
+    }
+  }
+
+  // rowRouteFn: row => {
+  //   return ''
+  // },
+
+  // onRowClick: () => ({})
 }
 </script>

--- a/docs/src/examples/QasTableGenerator/Basic.vue
+++ b/docs/src/examples/QasTableGenerator/Basic.vue
@@ -7,5 +7,10 @@ import { fields, results } from 'src/mocks/users'
 
 defineOptions({ name: 'Basic' })
 
-const columns = [{ sortable: false, name: 'isActive' }, 'name', 'createdAt', 'date']
+const columns = [
+  { sortable: false, name: 'isActive' },
+  'name',
+  'createdAt',
+  'date'
+]
 </script>

--- a/docs/src/examples/QasTableGenerator/Basic.vue
+++ b/docs/src/examples/QasTableGenerator/Basic.vue
@@ -2,7 +2,11 @@
   <!-- Utilizando o list-view apenas para facilitar para recuperar os dados dos dados. -->
   <qas-list-view v-model:fields="fields" v-model:results="results" :entity="entity" :use-filter="false">
     <template #default>
-      <qas-table-generator :fields="fields" :results="results" row-key="uuid" />
+      <qas-table-generator :columns="['email']" :fields="fields" :results="results" row-key="uuid">
+        <template #body-cell-name>
+          <qas-toggle-visibility data-ignore-hover text="64.829.511/0001-01" />
+        </template>
+      </qas-table-generator>
     </template>
   </qas-list-view>
 </template>

--- a/docs/src/examples/QasTableGenerator/Basic.vue
+++ b/docs/src/examples/QasTableGenerator/Basic.vue
@@ -1,83 +1,60 @@
 <template>
   <!-- Utilizando o list-view apenas para facilitar para recuperar os dados dos dados. -->
-  <qas-list-view v-model:fields="fields" v-model:results="results" :entity="entity" :use-filter="false">
+  <qas-list-view v-model:fields="viewState.fields" v-model:results="viewState.results" :entity :use-filter="false">
     <template #default>
-      <qas-table-generator :columns :fields="fields" :fields-props :results="results" row-key="uuid">
+      <qas-table-generator :fields="viewState.fields" :results="viewState.results" v-bind="tableGeneratorProps">
+      <!-- <qas-table-generator :columns :fields="fields" :fields-props :results="results" row-key="uuid"> -->
         <!-- <template #body-cell-name>
-          <qas-toggle-visibility data-ignore-hover text="64.829.511/0001-01" />
+          <qas-toggle-visibility data-table-ignore-hover text="64.829.511/0001-01" />
         </template> -->
       </qas-table-generator>
     </template>
   </qas-list-view>
 </template>
 
-<script>
-export default {
-  name: 'UsersList',
+<script setup>
+import { useView } from '@bildvitta/composables'
 
-  data () {
-    return {
-      fields: {},
-      results: []
-    }
-  },
+defineOptions({ name: 'Basic' })
 
-  computed: {
-    entity () {
-      return 'users'
+// composables
+const { viewState } = useView({ mode: 'list' })
+
+const entity = 'users'
+
+const tableGeneratorProps = {
+  columns: ['document', 'name', 'email', 'phone'],
+
+  fieldsProps: {
+    document: {
+      component: 'QasStatus'
     },
 
-    columns () {
-      return [
-        'document',
-        'name',
-        'email'
-      ]
-    }
-  },
-
-  methods: {
-    fieldsProps (row) {
-      return {
-        document: {
-          component: 'QasBtn',
-          props: {
-            // color: 'negative'
-          }
-        },
-
-        name: {
-          component: 'QasTextTruncate',
-          props: {
-            maxWidth: 100
-          }
-        },
-
-        email: {
-          component: 'QasCopy',
-          props: {}
-        }
-
-        // document: {
-        //   component: 'QasToggleVisibility',
-        //   props: {}
-        // }
+    name: {
+      component: 'QasTextTruncate',
+      props: {
+        maxWidth: 150
       }
     },
 
-    actionsMenuProps (row) {
-      console.log('TCL: actionsMenuProps -> row', row)
-      // console.log('TCL: actionsMenuProps -> row', row)
-      return {
-        list: {
-          visibility: {
-            icon: 'sym_r_visibility',
-            label: row.name,
-            handler: () => alert('handler ativado')
-          }
+    email: {
+      component: 'QasCopy',
+      props: {}
+    },
+
+    sla: {
+      component: 'QasBtn',
+      props: {
+        onClick: () => {
         }
       }
     }
-  }
+  },
+
+  rowRouteFn: row => {
+    return ''
+  },
+
+  onRowClick: () => ({})
 }
 </script>

--- a/docs/src/examples/QasTableGenerator/Basic.vue
+++ b/docs/src/examples/QasTableGenerator/Basic.vue
@@ -2,10 +2,10 @@
   <!-- Utilizando o list-view apenas para facilitar para recuperar os dados dos dados. -->
   <qas-list-view v-model:fields="fields" v-model:results="results" :entity="entity" :use-filter="false">
     <template #default>
-      <qas-table-generator :columns="['email']" :fields="fields" :results="results" row-key="uuid">
-        <template #body-cell-name>
+      <qas-table-generator :columns :fields="fields" :fields-props :results="results" row-key="uuid">
+        <!-- <template #body-cell-name>
           <qas-toggle-visibility data-ignore-hover text="64.829.511/0001-01" />
-        </template>
+        </template> -->
       </qas-table-generator>
     </template>
   </qas-list-view>
@@ -25,6 +25,58 @@ export default {
   computed: {
     entity () {
       return 'users'
+    },
+
+    columns () {
+      return [
+        'document',
+        'name',
+        'email'
+      ]
+    }
+  },
+
+  methods: {
+    fieldsProps (row) {
+      return {
+        document: {
+          component: 'QasBtn',
+          props: {
+            // color: 'negative'
+          }
+        },
+
+        name: {
+          component: 'QasTextTruncate',
+          props: {
+            maxWidth: 100
+          }
+        },
+
+        email: {
+          component: 'QasCopy',
+          props: {}
+        }
+
+        // document: {
+        //   component: 'QasToggleVisibility',
+        //   props: {}
+        // }
+      }
+    },
+
+    actionsMenuProps (row) {
+      console.log('TCL: actionsMenuProps -> row', row)
+      // console.log('TCL: actionsMenuProps -> row', row)
+      return {
+        list: {
+          visibility: {
+            icon: 'sym_r_visibility',
+            label: row.name,
+            handler: () => alert('handler ativado')
+          }
+        }
+      }
     }
   }
 }

--- a/docs/src/examples/QasTableGenerator/Basic.vue
+++ b/docs/src/examples/QasTableGenerator/Basic.vue
@@ -1,5 +1,5 @@
 <template>
-  <qas-table-generator :fields :results v-bind="tableGeneratorProps" />
+  <qas-table-generator :columns :fields :results />
 </template>
 
 <script setup>
@@ -7,7 +7,5 @@ import { fields, results } from 'src/mocks/users'
 
 defineOptions({ name: 'Basic' })
 
-const tableGeneratorProps = {
-  columns: [{ sortable: false, name: 'isActive' }, 'name', 'createdAt', 'date']
-}
+const columns = [{ sortable: false, name: 'isActive' }, 'name', 'createdAt', 'date']
 </script>

--- a/docs/src/examples/QasTableGenerator/Basic.vue
+++ b/docs/src/examples/QasTableGenerator/Basic.vue
@@ -1,10 +1,5 @@
 <template>
-  <qas-table-generator :fields :results v-bind="tableGeneratorProps">
-    <!-- <qas-table-generator :columns :fields="fields" :fields-props :results="results" row-key="uuid"> -->
-    <template #body-cell-name>
-      <qas-toggle-visibility data-table-ignore-hover text="64.829.511/0001-01" />
-    </template>
-  </qas-table-generator>
+  <qas-table-generator :fields :results v-bind="tableGeneratorProps" />
 </template>
 
 <script setup>
@@ -13,6 +8,6 @@ import { fields, results } from 'src/mocks/users'
 defineOptions({ name: 'Basic' })
 
 const tableGeneratorProps = {
-  columns: [{ sortable: false, name: 'isActive' }, 'document', 'createdAt', 'date']
+  columns: [{ sortable: false, name: 'isActive' }, 'name', 'createdAt', 'date']
 }
 </script>

--- a/docs/src/examples/QasTableGenerator/Basic.vue
+++ b/docs/src/examples/QasTableGenerator/Basic.vue
@@ -13,51 +13,6 @@ import { fields, results } from 'src/mocks/users'
 defineOptions({ name: 'Basic' })
 
 const tableGeneratorProps = {
-  columns: ['isActive', 'document', 'companies', 'createdAt', { sortable: false, name: 'date' }],
-
-  actionsMenuProps (row) {
-    return {
-      list: {
-        visibility: {
-          label: 'Visibilidade',
-          icon: 'sym_r_person',
-          handler: () => alert(row.uuid)
-        }
-      }
-    }
-  },
-
-  fieldsProps (row) {
-    return {
-      companies: {
-        component: 'QasTextTruncate',
-        props: {
-          list: row.companies,
-          maxVisibleItems: 1
-        }
-      },
-
-      document: {
-        component: 'QasCopy'
-      },
-
-      name: {
-        component: 'QasTextTruncate',
-        props: {
-          maxWidth: 150
-        }
-      },
-
-      email: {
-        component: 'QasCopy'
-      }
-    }
-  }
-
-  // rowRouteFn: row => {
-  //   return ''
-  // },
-
-  // onRowClick: () => ({})
+  columns: [{ sortable: false, name: 'isActive' }, 'document', 'createdAt', 'date']
 }
 </script>

--- a/docs/src/examples/QasTableGenerator/ClickableRow.vue
+++ b/docs/src/examples/QasTableGenerator/ClickableRow.vue
@@ -2,7 +2,7 @@
   <!-- Utilizando o list-view apenas para facilitar para recuperar os dados. -->
   <qas-list-view v-model:fields="fields" v-model:results="results" :entity="entity" use-auto-handle-on-delete :use-filter="false">
     <template #default>
-      <qas-table-generator :columns="columns" :fields="fields" :results="results" row-key="uuid" @row-click="rowClick" />
+      <qas-table-generator :columns="columns" :fields :results row-key="uuid" @row-click="rowClick" />
     </template>
   </qas-list-view>
 </template>

--- a/docs/src/examples/QasTableGenerator/ClickableRow.vue
+++ b/docs/src/examples/QasTableGenerator/ClickableRow.vue
@@ -2,7 +2,7 @@
   <!-- Utilizando o list-view apenas para facilitar para recuperar os dados. -->
   <qas-list-view v-model:fields="fields" v-model:results="results" :entity="entity" use-auto-handle-on-delete :use-filter="false">
     <template #default>
-      <qas-table-generator :columns="columns" :fields :results row-key="uuid" @row-click="rowClick" />
+      <qas-table-generator :columns :fields :results row-key="uuid" @row-click="rowClick" />
     </template>
   </qas-list-view>
 </template>

--- a/docs/src/examples/QasTableGenerator/ClickableRow.vue
+++ b/docs/src/examples/QasTableGenerator/ClickableRow.vue
@@ -2,13 +2,7 @@
   <!-- Utilizando o list-view apenas para facilitar para recuperar os dados. -->
   <qas-list-view v-model:fields="fields" v-model:results="results" :entity="entity" use-auto-handle-on-delete :use-filter="false">
     <template #default>
-      <qas-table-generator :columns="columns" :fields="fields" :results="results" row-key="uuid" @row-click="rowClick">
-        <template #body-cell-actions="{ row }">
-          <div class="flex justify-end no-wrap q-gutter-x-sm">
-            <qas-delete :custom-id="row.uuid" entity="users" icon="sym_r_delete" />
-          </div>
-        </template>
-      </qas-table-generator>
+      <qas-table-generator :columns="columns" :fields="fields" :results="results" row-key="uuid" @row-click="rowClick" />
     </template>
   </qas-list-view>
 </template>
@@ -30,8 +24,7 @@ export default {
     columns () {
       return [
         'isActive',
-        'name',
-        { align: 'right', name: 'actions' }
+        'name'
       ]
     }
   },

--- a/docs/src/examples/QasTableGenerator/CustomSlot.vue
+++ b/docs/src/examples/QasTableGenerator/CustomSlot.vue
@@ -8,7 +8,7 @@
         </template>
         <template #body-cell-actions="{ row }">
           <div class="flex justify-end no-wrap q-gutter-x-sm">
-            <qas-delete :custom-id="row.uuid" data-ignore-hover entity="users" icon="sym_r_delete" />
+            <qas-delete :custom-id="row.uuid" entity="users" icon="sym_r_delete" />
           </div>
         </template>
       </qas-table-generator>

--- a/docs/src/examples/QasTableGenerator/CustomSlot.vue
+++ b/docs/src/examples/QasTableGenerator/CustomSlot.vue
@@ -8,7 +8,7 @@
         </template>
         <template #body-cell-actions="{ row }">
           <div class="flex justify-end no-wrap q-gutter-x-sm">
-            <qas-delete :custom-id="row.uuid" entity="users" icon="sym_r_delete" />
+            <qas-delete :custom-id="row.uuid" data-ignore-hover entity="users" icon="sym_r_delete" />
           </div>
         </template>
       </qas-table-generator>

--- a/docs/src/examples/QasTableGenerator/CustomSlot.vue
+++ b/docs/src/examples/QasTableGenerator/CustomSlot.vue
@@ -6,11 +6,6 @@
         <template #body-cell-isActive="{ row }">
           <div class="text-weight-bold">{{ row.isActive }}</div>
         </template>
-        <template #body-cell-actions="{ row }">
-          <div class="flex justify-end no-wrap q-gutter-x-sm">
-            <qas-delete :custom-id="row.uuid" entity="users" icon="sym_r_delete" />
-          </div>
-        </template>
       </qas-table-generator>
     </template>
   </qas-list-view>
@@ -33,8 +28,7 @@ export default {
     columns () {
       return [
         'isActive',
-        'name',
-        { align: 'right', name: 'actions' }
+        'name'
       ]
     }
   }

--- a/docs/src/examples/QasTableGenerator/WithFieldsProps.vue
+++ b/docs/src/examples/QasTableGenerator/WithFieldsProps.vue
@@ -1,0 +1,56 @@
+<template>
+  <qas-table-generator :fields :results v-bind="tableGeneratorProps">
+    <template #body-cell-name>
+      <qas-toggle-visibility data-table-ignore-hover text="64.829.511/0001-01" />
+    </template>
+  </qas-table-generator>
+</template>
+
+<script setup>
+import { fields, results } from 'src/mocks/users'
+
+defineOptions({ name: 'WithFieldsProps' })
+
+const tableGeneratorProps = {
+  columns: ['isActive', 'document', 'companies', 'createdAt', 'date'],
+
+  actionsMenuProps (row) {
+    return {
+      list: {
+        visibility: {
+          label: 'Visibilidade',
+          icon: 'sym_r_person',
+          handler: () => alert(row.uuid)
+        }
+      }
+    }
+  },
+
+  fieldsProps (row) {
+    return {
+      companies: {
+        component: 'QasTextTruncate',
+        props: {
+          list: row.companies,
+          maxVisibleItems: 1
+        }
+      },
+
+      document: {
+        component: 'QasCopy'
+      },
+
+      name: {
+        component: 'QasTextTruncate',
+        props: {
+          maxWidth: 150
+        }
+      },
+
+      email: {
+        component: 'QasCopy'
+      }
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QasTableGenerator/WithFieldsProps.vue
+++ b/docs/src/examples/QasTableGenerator/WithFieldsProps.vue
@@ -1,5 +1,5 @@
 <template>
-  <qas-table-generator :fields :results v-bind="tableGeneratorProps" />
+  <qas-table-generator v-bind="tableGeneratorProps" />
 </template>
 
 <script setup>
@@ -8,6 +8,9 @@ import { fields, results } from 'src/mocks/users'
 defineOptions({ name: 'WithFieldsProps' })
 
 const tableGeneratorProps = {
+  fields,
+  results,
+
   columns: [
     'isActive',
     'document',

--- a/docs/src/examples/QasTableGenerator/WithFieldsProps.vue
+++ b/docs/src/examples/QasTableGenerator/WithFieldsProps.vue
@@ -1,9 +1,5 @@
 <template>
-  <qas-table-generator :fields :results v-bind="tableGeneratorProps">
-    <template #body-cell-name>
-      <qas-toggle-visibility data-table-ignore-hover text="64.829.511/0001-01" />
-    </template>
-  </qas-table-generator>
+  <qas-table-generator :fields :results v-bind="tableGeneratorProps" />
 </template>
 
 <script setup>
@@ -12,7 +8,7 @@ import { fields, results } from 'src/mocks/users'
 defineOptions({ name: 'WithFieldsProps' })
 
 const tableGeneratorProps = {
-  columns: ['isActive', 'document', 'companies', 'createdAt', 'date'],
+  columns: ['isActive', 'document', 'companies', 'createdAt', 'company', 'date', 'email', 'observation'],
 
   actionsMenuProps (row) {
     return {
@@ -28,6 +24,17 @@ const tableGeneratorProps = {
 
   fieldsProps (row) {
     return {
+      isActive: {
+        component: 'QasStatus',
+        props: {
+          color: row.default.isActive ? 'green' : 'red'
+        }
+      },
+
+      createdAt: {
+        component: 'QasBadge'
+      },
+
       companies: {
         component: 'QasTextTruncate',
         props: {
@@ -37,7 +44,7 @@ const tableGeneratorProps = {
       },
 
       document: {
-        component: 'QasCopy'
+        component: 'QasToggleVisibility'
       },
 
       name: {
@@ -47,10 +54,20 @@ const tableGeneratorProps = {
         }
       },
 
+      company: {
+        component: 'QasTextTruncate'
+      },
+
       email: {
         component: 'QasCopy'
+      },
+
+      observation: {
+        component: 'QasTextTruncate'
       }
     }
-  }
+  },
+
+  onRowClick: () => ({})
 }
 </script>

--- a/docs/src/examples/QasTableGenerator/WithFieldsProps.vue
+++ b/docs/src/examples/QasTableGenerator/WithFieldsProps.vue
@@ -8,7 +8,16 @@ import { fields, results } from 'src/mocks/users'
 defineOptions({ name: 'WithFieldsProps' })
 
 const tableGeneratorProps = {
-  columns: ['isActive', 'document', 'companies', 'createdAt', 'company', 'date', 'email', 'observation'],
+  columns: [
+    'isActive',
+    'document',
+    'companies',
+    'createdAt',
+    'company',
+    'date',
+    'email',
+    'observation'
+  ],
 
   actionsMenuProps (row) {
     return {

--- a/docs/src/examples/QasTableGenerator/WithHeader.vue
+++ b/docs/src/examples/QasTableGenerator/WithHeader.vue
@@ -26,5 +26,4 @@ const headerProps = {
     label: 'Novo usuário'
   }
 }
-
 </script>

--- a/docs/src/mocks/users.js
+++ b/docs/src/mocks/users.js
@@ -1,0 +1,267 @@
+export const fields = {
+  isActive: {
+    name: 'isActive',
+    label: 'Usuário ativo?',
+    type: 'boolean',
+    default: false
+  },
+
+  company: {
+    name: 'company',
+    label: 'Empresa',
+    type: 'select',
+    options: [
+      {
+        label: 'Empresa 1',
+        value: 'empresa-1'
+      },
+      {
+        label: 'Empresa 2',
+        value: 'empresa-2'
+      },
+      {
+        label: 'Empresa 3',
+        value: 'empresa-3'
+      },
+      {
+        label: 'Empresa 4',
+        value: 'empresa-4'
+      },
+      {
+        label: 'Empresa 5',
+        value: 'empresa-5'
+      },
+      {
+        label: 'Empresa 6',
+        value: 'empresa-6'
+      },
+      {
+        label: 'Empresa 7',
+        value: 'empresa-7'
+      },
+      {
+        label: 'Empresa 8',
+        value: 'empresa-8'
+      },
+      {
+        label: 'Empresa 9',
+        value: 'empresa-9'
+      },
+      {
+        label: 'Empresa 10',
+        value: 'empresa-10'
+      },
+      {
+        label: 'Empresa 11',
+        value: 'empresa-11'
+      }
+    ]
+  },
+
+  companies: {
+    name: 'companies',
+    label: 'Empresa',
+    type: 'select',
+    multiple: true,
+    options: [
+      {
+        label: 'Empresa 1',
+        value: 'empresa-1'
+      },
+      {
+        label: 'Empresa 2',
+        value: 'empresa-2'
+      },
+      {
+        label: 'Empresa 3',
+        value: 'empresa-3'
+      },
+      {
+        label: 'Empresa 4',
+        value: 'empresa-4'
+      },
+      {
+        label: 'Empresa 5',
+        value: 'empresa-5'
+      },
+      {
+        label: 'Empresa 6',
+        value: 'empresa-6'
+      },
+      {
+        label: 'Empresa 7',
+        value: 'empresa-7'
+      },
+      {
+        label: 'Empresa 8',
+        value: 'empresa-8'
+      },
+      {
+        label: 'Empresa 9',
+        value: 'empresa-9'
+      },
+      {
+        label: 'Empresa 10',
+        value: 'empresa-10'
+      }
+    ]
+  },
+
+  name: {
+    name: 'name',
+    label: 'Nome',
+    type: 'string'
+  },
+
+  email: {
+    name: 'email',
+    label: 'Email',
+    type: 'email'
+  },
+
+  document: {
+    name: 'document',
+    label: 'Documento',
+    type: 'string',
+    mask: 'document'
+  },
+
+  phone: {
+    name: 'phone',
+    label: 'Telefone',
+    type: 'string',
+    mask: 'phone'
+  },
+
+  createdAt: {
+    name: 'createdAt',
+    label: 'Criado em',
+    type: 'datetime'
+  },
+
+  date: {
+    name: 'date',
+    label: 'date',
+    type: 'date'
+  }
+}
+
+export const results = [
+  {
+    uuid: '31362c39-2cb5-4fe2-982a-c270f88d2462',
+    isActive: true,
+    company: 'empresa-1',
+    companies: ['empresa-1', 'empresa-2'],
+    name: 'John Doe',
+    email: 'Mervin76@gmail.com',
+    document: '12345678901',
+    phone: '11912345678',
+    createdAt: '2022-03-18T03:54:11.000Z',
+    updatedAt: '2022-03-18T09:22:11.000Z',
+    date: '2022-03-19'
+  },
+  {
+    uuid: '3102fad5-f14c-45d4-98e9-46ef0aa9580e',
+    isActive: true,
+    company: '',
+    companies: ['empresa-3', 'empresa-4', 'empresa-5'],
+    name: 'Jane Smith',
+    email: 'Esta.Bernier@hotmail.com',
+    document: '12345678902',
+    phone: '21987654321',
+    createdAt: '2022-03-18T11:34:24.000Z',
+    updatedAt: '2022-03-17T19:51:40.000Z',
+    date: '2022-03-20'
+  },
+  {
+    uuid: '1dad94b3-a0e0-4829-a7e1-be2af95348201',
+    isActive: true,
+    company: 'Qui eius dolor sapiente provident saepe.',
+    companies: ['empresa-6'],
+    name: 'Alice Johnson',
+    email: 'Alyce_Dooley45@hotmail.com',
+    document: '12345678903',
+    phone: '31912349876',
+    createdAt: '2022-03-18T10:03:01.000Z',
+    updatedAt: '2022-03-18T06:46:42.000Z',
+    date: '2022-03-21'
+  },
+  {
+    uuid: 'ac72e8a8-fcf9-4258-8ea2-bc49b612324dacb',
+    isActive: true,
+    company: 'Ab saepe aperiam.',
+    companies: ['empresa-7', 'empresa-8'],
+    name: 'Bob Martin',
+    email: 'Tracy_Glover74@hotmail.com',
+    document: '12345678904',
+    phone: '41998761234',
+    createdAt: '2022-03-18T04:12:22.000Z',
+    updatedAt: '2022-03-18T02:47:44.000Z',
+    date: '2022-03-22'
+  },
+  {
+    uuid: 'ce2e298a-be37-408f-a789-4c7b18b4315bc',
+    isActive: true,
+    company: 'Atque cum illum debitis consequatur exercitationem dolorum corporis.',
+    companies: ['empresa-9', 'empresa-10', 'empresa-11'],
+    name: 'Carol King',
+    email: 'Heloise_Hegmann@hotmail.com',
+    document: '12345678905',
+    phone: '51912345678',
+    createdAt: '2022-03-18T00:00:44.000Z',
+    updatedAt: '2022-03-17T23:34:47.000Z',
+    date: '2022-03-23'
+  },
+  {
+    uuid: '62fc0a79-ddea-45b5-8d21-be6f0502923296',
+    isActive: false,
+    company: 'Sed occaecati cupiditate.',
+    companies: ['empresa-10'],
+    name: 'David Brown',
+    email: 'Jillian_Wilkinson97@gmail.com',
+    document: '12345678906',
+    phone: '61987654321',
+    createdAt: '2022-03-17T17:54:34.000Z',
+    updatedAt: '2022-03-18T13:14:01.000Z',
+    date: '2022-03-24'
+  },
+  {
+    uuid: '2f8856d0-8eca-4e41-8146-63ed2a4f23ff4c',
+    isActive: false,
+    company: 'Dolores minus iusto quo et dolorem eveniet nesciunt.',
+    companies: ['empresa-1', 'empresa-3'],
+    name: 'Emily Davis',
+    email: 'Rafael91@hotmail.com',
+    document: '12345678907',
+    phone: '71912345678',
+    createdAt: '2022-03-17T23:50:31.000Z',
+    updatedAt: '2022-03-18T02:03:29.000Z',
+    date: '2022-03-25'
+  },
+  {
+    uuid: '5bda242f-5e99-43dd-af6a-093d68cee1235f',
+    isActive: false,
+    company: 'Excepturi ad nihil est.',
+    companies: ['empresa-4', 'empresa-5', 'empresa-6'],
+    name: 'Frank Wilson',
+    email: 'Katelyn_Bernhard76@gmail.com',
+    document: '12345678908',
+    phone: '81987654321',
+    createdAt: '2022-03-17T20:21:06.000Z',
+    updatedAt: '2022-03-18T15:06:04.000Z',
+    date: '2022-03-26'
+  },
+  {
+    uuid: '620c8045-acc8-4c53-b083-fe7ed991233cf5',
+    isActive: false,
+    company: 'Quis ea voluptas recusandae omnis.',
+    companies: ['empresa-7', 'empresa-8'],
+    name: 'Grace Lee',
+    email: 'Syble42@yahoo.com',
+    document: '12345678909',
+    phone: '91912345678',
+    createdAt: '2022-03-17T22:51:23.000Z',
+    updatedAt: '2022-03-18T03:13:33.000Z',
+    date: '2022-03-27'
+  }
+]

--- a/docs/src/mocks/users.js
+++ b/docs/src/mocks/users.js
@@ -143,6 +143,12 @@ export const fields = {
     name: 'date',
     label: 'date',
     type: 'date'
+  },
+
+  observation: {
+    name: 'observation',
+    label: 'Observação',
+    type: 'textarea'
   }
 }
 
@@ -158,7 +164,8 @@ export const results = [
     phone: '11912345678',
     createdAt: '2022-03-18T03:54:11.000Z',
     updatedAt: '2022-03-18T09:22:11.000Z',
-    date: '2022-03-19'
+    date: '2022-03-19',
+    observation: 'Observação 1: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
   },
   {
     uuid: '3102fad5-f14c-45d4-98e9-46ef0aa9580e',
@@ -171,7 +178,8 @@ export const results = [
     phone: '21987654321',
     createdAt: '2022-03-18T11:34:24.000Z',
     updatedAt: '2022-03-17T19:51:40.000Z',
-    date: '2022-03-20'
+    date: '2022-03-20',
+    observation: 'Observação 2: BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
   },
   {
     uuid: '1dad94b3-a0e0-4829-a7e1-be2af95348201',
@@ -184,7 +192,8 @@ export const results = [
     phone: '31912349876',
     createdAt: '2022-03-18T10:03:01.000Z',
     updatedAt: '2022-03-18T06:46:42.000Z',
-    date: '2022-03-21'
+    date: '2022-03-21',
+    observation: 'Observação 3: CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC'
   },
   {
     uuid: 'ac72e8a8-fcf9-4258-8ea2-bc49b612324dacb',
@@ -197,12 +206,14 @@ export const results = [
     phone: '41998761234',
     createdAt: '2022-03-18T04:12:22.000Z',
     updatedAt: '2022-03-18T02:47:44.000Z',
-    date: '2022-03-22'
+    date: '2022-03-22',
+    observation: 'Observação 4: DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD'
   },
   {
     uuid: 'ce2e298a-be37-408f-a789-4c7b18b4315bc',
     isActive: true,
-    company: 'Atque cum illum debitis consequatur exercitationem dolorum corporis.',
+    company:
+      'Atque cum illum debitis consequatur exercitationem dolorum corporis.',
     companies: ['empresa-9', 'empresa-10', 'empresa-11'],
     name: 'Carol King',
     email: 'Heloise_Hegmann@hotmail.com',
@@ -210,7 +221,8 @@ export const results = [
     phone: '51912345678',
     createdAt: '2022-03-18T00:00:44.000Z',
     updatedAt: '2022-03-17T23:34:47.000Z',
-    date: '2022-03-23'
+    date: '2022-03-23',
+    observation: 'Observação 5: EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE'
   },
   {
     uuid: '62fc0a79-ddea-45b5-8d21-be6f0502923296',
@@ -223,7 +235,8 @@ export const results = [
     phone: '61987654321',
     createdAt: '2022-03-17T17:54:34.000Z',
     updatedAt: '2022-03-18T13:14:01.000Z',
-    date: '2022-03-24'
+    date: '2022-03-24',
+    observation: 'Observação 6: FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF'
   },
   {
     uuid: '2f8856d0-8eca-4e41-8146-63ed2a4f23ff4c',
@@ -236,7 +249,8 @@ export const results = [
     phone: '71912345678',
     createdAt: '2022-03-17T23:50:31.000Z',
     updatedAt: '2022-03-18T02:03:29.000Z',
-    date: '2022-03-25'
+    date: '2022-03-25',
+    observation: 'Observação 7: GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG'
   },
   {
     uuid: '5bda242f-5e99-43dd-af6a-093d68cee1235f',
@@ -249,7 +263,8 @@ export const results = [
     phone: '81987654321',
     createdAt: '2022-03-17T20:21:06.000Z',
     updatedAt: '2022-03-18T15:06:04.000Z',
-    date: '2022-03-26'
+    date: '2022-03-26',
+    observation: 'Observação 8: HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH'
   },
   {
     uuid: '620c8045-acc8-4c53-b083-fe7ed991233cf5',
@@ -262,6 +277,7 @@ export const results = [
     phone: '91912345678',
     createdAt: '2022-03-17T22:51:23.000Z',
     updatedAt: '2022-03-18T03:13:33.000Z',
-    date: '2022-03-27'
+    date: '2022-03-27',
+    observation: 'Observação 9: IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII'
   }
 ]

--- a/docs/src/pages/components/table-generator.md
+++ b/docs/src/pages/components/table-generator.md
@@ -10,7 +10,7 @@ Componente para criação de tabela dinâmica usando o `QTable` do Quasar.
 ##### data-* para lidar com hover em tabela
 | Nome | Descrição |
 |---------------------|-----------|
-| `data-table-hover` | habilita hover quando utilizada junto dos outros data, exemplo no `QasCopy` |
+| `data-table-hover` | quando utilizamos `data-table-ignore-tr-hover` em um componente, ele vai remover todo o hover do componente como um todo, porém pode ter alguma área que queira o hover, então utilize este data na área desejada, exemplo no `QasCopy` |
 | `data-table-ignore-hover` | ignora o hover no item especifico, exemplo no `QasBadge` |
 | `data-table-ignore-tr-hover` | ignora o hover em todo tr, exemplo no `QasBtn` |
 :::

--- a/docs/src/pages/components/table-generator.md
+++ b/docs/src/pages/components/table-generator.md
@@ -6,6 +6,15 @@ Componente para criação de tabela dinâmica usando o `QTable` do Quasar.
 
 <doc-api file="table-generator/QasTableGenerator" name="QasTableGenerator" />
 
+:::info
+##### Datas para lidar com hover em tabela
+| Nome | Descrição |
+|---------------------|-----------|
+| `data-table-hover` | habilita hover quando utilizada junto dos outros data, exemplo no `QasCopy` |
+| `data-table-ignore-hover` | ignora o hover no item especifico, exemplo no `QasBadge` |
+| `data-table-ignore-tr-hover` | ignora o hover em todo tr, exemplo no `QasBtn` |
+:::
+
 :::tip
 Ao utilizar o evento `@row-click` caso tenha algum componente / elemento HTML dentro do slot `body-cell-[field-name]` que queira ignorar, adicione o seguinte evento `@click.stop`.
 

--- a/docs/src/pages/components/table-generator.md
+++ b/docs/src/pages/components/table-generator.md
@@ -7,12 +7,45 @@ Componente para criação de tabela dinâmica usando o `QTable` do Quasar.
 <doc-api file="table-generator/QasTableGenerator" name="QasTableGenerator" />
 
 :::info
-##### Datas para lidar com hover em tabela
+##### data-* para lidar com hover em tabela
 | Nome | Descrição |
 |---------------------|-----------|
 | `data-table-hover` | habilita hover quando utilizada junto dos outros data, exemplo no `QasCopy` |
 | `data-table-ignore-hover` | ignora o hover no item especifico, exemplo no `QasBadge` |
 | `data-table-ignore-tr-hover` | ignora o hover em todo tr, exemplo no `QasBtn` |
+:::
+
+:::info
+##### propriedade "fieldsProps"
+É possível adicionar/personalizar componentes sem abrir slot via prop, componentes aceitos:
+
+- QasActionsMenu
+- QasBadge
+- QasBtn
+- QasCopy
+- QasStatus
+- QasTextTruncate
+- QasToggleVisibility
+
+Exemplo:
+```js
+fieldsProps: {
+  document: {
+    component: 'QasTextTruncate'
+  },
+
+  name: {
+    component: 'QasTextTruncate',
+    props: {
+      maxWidth: 150
+    }
+  },
+
+  email: {
+    component: 'QasCopy'
+  },
+}
+```
 :::
 
 :::tip

--- a/docs/src/pages/components/table-generator.md
+++ b/docs/src/pages/components/table-generator.md
@@ -81,7 +81,7 @@ fieldsProps: {
 }
 ```
 :::
-<doc-example file="QasTableGenerator/WithFieldsProps" title="Com componentes por props e ação na ultima linha" />
+<doc-example file="QasTableGenerator/WithFieldsProps" title="Com componentes por props e ação na ultima coluna" />
 <doc-example file="QasTableGenerator/WithHeader" title="Com header" />
 <doc-example file="QasTableGenerator/HeaderSlot" title="Acessando slot do header" />
 <doc-example file="QasTableGenerator/NoBox" title="Sem box" />

--- a/docs/src/pages/components/table-generator.md
+++ b/docs/src/pages/components/table-generator.md
@@ -16,8 +16,42 @@ Componente para criação de tabela dinâmica usando o `QTable` do Quasar.
 :::
 
 :::info
-##### propriedade "fieldsProps"
-É possível adicionar/personalizar componentes sem abrir slot via prop, componentes aceitos:
+#### sort em tabela
+É possível remover/personalizar o sort através da propriedade "columns", por padrão, todas colunas tem sort, é preciso olhar caso a caso e remover em colunas que não são necessários.
+
+```js
+columns: [
+  'name',
+  'email',
+  'document',
+  { name: 'status', sortable: false } // remove sort da coluna "status"
+  { name: 'document', sort: (a, b, rowA, rowB) => parseInt(a, 10) - parseInt(b, 10) } // olhar documentação do quasar
+  { name: 'createdAt', rawSort: (a, b, rowA, rowB) => parseInt(a, 10) - parseInt(b, 10) } // olhar documentação do quasar
+]
+:::
+
+:::tip
+Ao utilizar o evento `@row-click` caso tenha algum componente / elemento HTML dentro do slot `body-cell-[field-name]` que queira ignorar, adicione o seguinte evento `@click.stop`.
+
+Exemplo:
+```html
+<template #body-cell-actions="{ row }">
+  <div class="flex justify-end no-wrap q-gutter-x-sm">
+    <!-- aqui o @click.stop vai fazer com que este botão não dispare o evento: @row-click -->
+    <qas-btn label="alguma ação!" @click.stop="alert('fui clicado')" />
+  </div>
+</template>
+```
+:::
+
+## Uso
+
+<doc-example file="QasTableGenerator/Basic" title="Básico" />
+
+:::info
+A propriedade "actionsMenuProps" adiciona automaticamente uma coluna "actions" na tabela e renderiza o `QasActionsMenu` por callback, é a maneira **correta** de se usar ação na ultima coluna.
+
+A propriedade "fieldsProps" pode ser uma função ou objeto, é possível adicionar/personalizar componentes sem abrir slot via prop, componentes aceitos:
 
 - QasActionsMenu
 - QasBadge
@@ -43,47 +77,22 @@ fieldsProps: {
 
   email: {
     component: 'QasCopy'
-  },
+  }
 }
 ```
 :::
-
-:::tip
-Ao utilizar o evento `@row-click` caso tenha algum componente / elemento HTML dentro do slot `body-cell-[field-name]` que queira ignorar, adicione o seguinte evento `@click.stop`.
-
-Exemplo:
-```html
-<template #body-cell-actions="{ row }">
-  <div class="flex justify-end no-wrap q-gutter-x-sm">
-    <!-- aqui o @click.stop vai fazer com que este botão não dispare o evento: @row-click -->
-    <qas-btn label="alguma ação!" @click.stop="alert('fui clicado')" />
-  </div>
-</template>
-```
-:::
-
-:::warning
-Este componente repassa **todos** os slots do [QTable](https://quasar.dev/vue-components/table#qtable-api), **exceto** o `body` que é um slot customizado.
-:::
-
-:::tip
-Componente implementa o `QasBox` repassando todas propriedades.
-:::
-
-## Uso
-
-<doc-example file="QasTableGenerator/Basic" title="Básico" />
-<!-- <doc-example file="QasTableGenerator/WithHeader" title="Com header" />
+<doc-example file="QasTableGenerator/WithFieldsProps" title="Com componentes por props e ação na ultima linha" />
+<doc-example file="QasTableGenerator/WithHeader" title="Com header" />
 <doc-example file="QasTableGenerator/HeaderSlot" title="Acessando slot do header" />
-<doc-example file="QasTableGenerator/NoBox" title="Sem box" /> -->
+<doc-example file="QasTableGenerator/NoBox" title="Sem box" />
 
 Este componente renderiza componentes dinamicamente através da prop `fields`, cada field dentro de fields tem um `name`, através dele, você consegue acessar os slots dinâmicos.
 
-<!-- <doc-example file="QasTableGenerator/CustomSlot" title="Slots personalizados" /> -->
+<doc-example file="QasTableGenerator/CustomSlot" title="Slots personalizados" />
 
 Também é possível configurar o componente para executar uma ação ao clicar em uma linha, para isso, basta escutar o evento `row-click`.
 
-<!-- <doc-example file="QasTableGenerator/ClickableRow" title="Linha clicável" /> -->
+<doc-example file="QasTableGenerator/ClickableRow" title="Linha clicável" />
 
 Caso queira que ao clicar em uma linha vá para outra rota, é possível utilizar a prop `row-route-fn` na qual o retorno deve ser com a estrutura aceita pelo vue-router.(a linha passa ser um `<a>` internamente, habilitando a opção de abrir em uma nova aba)
 
@@ -102,7 +111,7 @@ rowExternalRouteFn () {
 ```
 :::
 
-<!-- <doc-example file="QasTableGenerator/TableLink" title="Tabela com links" /> -->
+<doc-example file="QasTableGenerator/TableLink" title="Tabela com links" />
 
 Funcionalidade que permite que o cabeçalho da tabela permaneça visível na parte superior enquanto o usuário faz rolagem do conteúdo da tabela. Para utilizar atribua a prop `use-sticky-header`.
 
@@ -110,10 +119,10 @@ Funcionalidade que permite que o cabeçalho da tabela permaneça visível na par
 É possível alterar a altura máxima da tabela utilizando a prop `max-height`.
 :::
 
-<!-- <doc-example file="QasTableGenerator/StickyHeader" title="Header fixo" /> -->
+<doc-example file="QasTableGenerator/StickyHeader" title="Header fixo" />
 
 :::warning
 O virtual scroll renderiza dinamicamente as linhas a serem exibidas na tabela.
 Apenas utilize virtual scroll quando realmente houver comportamentos no qual não se pode ter paginação e tiver muitos dados na tabela.
 :::
-<!-- <doc-example file="QasTableGenerator/WithVirtualScroll" title="Com virtual scroll" /> -->
+<doc-example file="QasTableGenerator/WithVirtualScroll" title="Com virtual scroll" />

--- a/docs/src/pages/components/table-generator.md
+++ b/docs/src/pages/components/table-generator.md
@@ -31,17 +31,17 @@ Componente implementa o `QasBox` repassando todas propriedades.
 ## Uso
 
 <doc-example file="QasTableGenerator/Basic" title="Básico" />
-<doc-example file="QasTableGenerator/WithHeader" title="Com header" />
+<!-- <doc-example file="QasTableGenerator/WithHeader" title="Com header" />
 <doc-example file="QasTableGenerator/HeaderSlot" title="Acessando slot do header" />
-<doc-example file="QasTableGenerator/NoBox" title="Sem box" />
+<doc-example file="QasTableGenerator/NoBox" title="Sem box" /> -->
 
 Este componente renderiza componentes dinamicamente através da prop `fields`, cada field dentro de fields tem um `name`, através dele, você consegue acessar os slots dinâmicos.
 
-<doc-example file="QasTableGenerator/CustomSlot" title="Slots personalizados" />
+<!-- <doc-example file="QasTableGenerator/CustomSlot" title="Slots personalizados" /> -->
 
 Também é possível configurar o componente para executar uma ação ao clicar em uma linha, para isso, basta escutar o evento `row-click`.
 
-<doc-example file="QasTableGenerator/ClickableRow" title="Linha clicável" />
+<!-- <doc-example file="QasTableGenerator/ClickableRow" title="Linha clicável" /> -->
 
 Caso queira que ao clicar em uma linha vá para outra rota, é possível utilizar a prop `row-route-fn` na qual o retorno deve ser com a estrutura aceita pelo vue-router.(a linha passa ser um `<a>` internamente, habilitando a opção de abrir em uma nova aba)
 
@@ -60,7 +60,7 @@ rowExternalRouteFn () {
 ```
 :::
 
-<doc-example file="QasTableGenerator/TableLink" title="Tabela com links" />
+<!-- <doc-example file="QasTableGenerator/TableLink" title="Tabela com links" /> -->
 
 Funcionalidade que permite que o cabeçalho da tabela permaneça visível na parte superior enquanto o usuário faz rolagem do conteúdo da tabela. Para utilizar atribua a prop `use-sticky-header`.
 
@@ -68,10 +68,10 @@ Funcionalidade que permite que o cabeçalho da tabela permaneça visível na par
 É possível alterar a altura máxima da tabela utilizando a prop `max-height`.
 :::
 
-<doc-example file="QasTableGenerator/StickyHeader" title="Header fixo" />
+<!-- <doc-example file="QasTableGenerator/StickyHeader" title="Header fixo" /> -->
 
 :::warning
 O virtual scroll renderiza dinamicamente as linhas a serem exibidas na tabela.
 Apenas utilize virtual scroll quando realmente houver comportamentos no qual não se pode ter paginação e tiver muitos dados na tabela.
 :::
-<doc-example file="QasTableGenerator/WithVirtualScroll" title="Com virtual scroll" />
+<!-- <doc-example file="QasTableGenerator/WithVirtualScroll" title="Com virtual scroll" /> -->

--- a/ui/src/components/badge/QasBadge.vue
+++ b/ui/src/components/badge/QasBadge.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- "data-table-ignore-hover" é para não habilitar hover no texto no QasTableGenerator -->
   <component :is="component.is" v-bind="component.props" class="q-px-sm qas-badge text-body2" data-table-ignore-hover>
     <slot />
   </component>

--- a/ui/src/components/badge/QasBadge.vue
+++ b/ui/src/components/badge/QasBadge.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="component.is" v-bind="component.props" class="q-px-sm qas-badge text-body2">
+  <component :is="component.is" v-bind="component.props" class="q-px-sm qas-badge text-body2" data-table-ignore-hover>
     <slot />
   </component>
 </template>

--- a/ui/src/components/btn/QasBtn.vue
+++ b/ui/src/components/btn/QasBtn.vue
@@ -1,5 +1,4 @@
 <template>
-  <!-- "data-table-ignore-tr-hover" é para desabilitar o hover do tr no QasTableGenerator -->
   <q-btn ref="button" class="qas-btn" data-table-ignore-tr-hover v-bind="attributes">
     <slot />
 

--- a/ui/src/components/btn/QasBtn.vue
+++ b/ui/src/components/btn/QasBtn.vue
@@ -1,5 +1,6 @@
 <template>
-  <q-btn ref="button" class="qas-btn" data-ignore-hover v-bind="attributes">
+  <!-- "data-table-ignore-tr-hover" é para desabilitar o hover do tr no QasTableGenerator -->
+  <q-btn ref="button" class="qas-btn" data-table-ignore-tr-hover v-bind="attributes">
     <slot />
 
     <template v-for="(_, name) in nonDefaultSlots" #[name]="context">

--- a/ui/src/components/btn/QasBtn.vue
+++ b/ui/src/components/btn/QasBtn.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-btn ref="button" class="qas-btn" v-bind="attributes">
+  <q-btn ref="button" class="qas-btn" data-ignore-hover v-bind="attributes">
     <slot />
 
     <template v-for="(_, name) in nonDefaultSlots" #[name]="context">

--- a/ui/src/components/btn/QasBtn.vue
+++ b/ui/src/components/btn/QasBtn.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- "data-table-ignore-tr-hover" é para desabilitar o hover do tr no QasTableGenerator -->
   <q-btn ref="button" class="qas-btn" data-table-ignore-tr-hover v-bind="attributes">
     <slot />
 

--- a/ui/src/components/copy/QasCopy.vue
+++ b/ui/src/components/copy/QasCopy.vue
@@ -1,6 +1,5 @@
 <template>
   <span>
-    <!-- "data-table-hover" é para habilitar hover no texto no QasTableGenerator -->
     <span data-table-hover>
       <slot v-if="props.useText">
         {{ props.text }}

--- a/ui/src/components/copy/QasCopy.vue
+++ b/ui/src/components/copy/QasCopy.vue
@@ -1,5 +1,6 @@
 <template>
   <span>
+    <!-- "data-table-hover" é para habilitar hover no texto no QasTableGenerator -->
     <span data-table-hover>
       <slot v-if="props.useText">
         {{ props.text }}

--- a/ui/src/components/copy/QasCopy.vue
+++ b/ui/src/components/copy/QasCopy.vue
@@ -1,6 +1,11 @@
 <template>
   <span>
-    <slot v-if="props.useText">{{ props.text }}</slot>
+    <!-- "data-table-hover" é para habilitar hover no texto no QasTableGenerator -->
+    <span data-table-hover>
+      <slot v-if="props.useText">
+        {{ props.text }}
+      </slot>
+    </span>
 
     <qas-btn class="q-ml-xs" color="primary" :icon="props.icon" :loading="isLoading" variant="tertiary" @click.stop.prevent="copy">
       <q-tooltip>Copiar</q-tooltip>

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -21,15 +21,23 @@
     </q-table>
 
     <qas-empty-result-text v-if="!hasResults" />
+
+    <PvTableGeneratorTd component-name="QasCopy" name="email" :row="{ email: 'text@example.com' }" />
   </component>
 </template>
 
 <script>
+import PvTableGeneratorTd from './_components/PvTableGeneratorTd.vue'
+
 import { extend } from 'quasar'
-import { isEmpty, humanize, setScrollOnGrab } from '../../helpers'
+import { isEmpty, humanize, setScrollOnGrab, setScrollGradient } from '../../helpers'
 
 export default {
   name: 'QasTableGenerator',
+
+  components: {
+    PvTableGeneratorTd
+  },
 
   props: {
     columns: {
@@ -101,7 +109,8 @@ export default {
       scrollableElement: null,
       scrollOnGrab: {},
       elementToObserve: null,
-      resizeObserver: null
+      resizeObserver: null,
+      scrollGradientX: setScrollGradient({ orientation: 'x' })
     }
   },
 
@@ -250,15 +259,26 @@ export default {
     parentComponent () {
       return {
         is: this.useBox ? 'qas-box' : 'div'
+        // is: this.useBox ? 'qas-box' : 'div'
       }
     },
 
     hasHeaderProps () {
       return !!Object.keys(this.headerProps).length
+    },
+
+    hasAutoScrollY () {
+      return this.useStickyHeader || this.useVirtualScroll
     }
   },
 
   mounted () {
+    if (!this.hasAutoScrollY) {
+      // const scrollElement = this.getScrollElement()
+
+      // this.scrollGradientX.initializeScrollGradient(scrollElement)
+    }
+
     if (!this.useScrollOnGrab) return
 
     this.setObserver()
@@ -266,6 +286,12 @@ export default {
   },
 
   onUnmounted () {
+    if (!this.hasAutoScrollY) {
+      const scrollElement = this.getScrollElement()
+
+      this.scrollGradientX.removeScrollGradient(scrollElement)
+    }
+
     if (!this.hasScrollOnGrab) return
 
     this.destroyObserver()
@@ -284,6 +310,10 @@ export default {
 
     getTableElementComponent () {
       return this.$refs?.table?.$el
+    },
+
+    getScrollElement () {
+      return this.getTableElementComponent().querySelector('.q-table__middle.scroll')
     },
 
     getTableElement () {
@@ -349,6 +379,7 @@ export default {
   .q-table {
     thead tr {
       height: 24px;
+      position: unset !important;
     }
 
     th {
@@ -369,28 +400,71 @@ export default {
       @include set-typography($body1);
 
       height: 40px;
-      padding-left: calc(var(--qas-spacing-lg) / 2);
-      padding-right: calc(var(--qas-spacing-lg) / 2);
+      padding-left: 0;
+      padding-right: 0;
+      // padding-left: calc(var(--qas-spacing-lg) / 2);
+      // padding-right: calc(var(--qas-spacing-lg) / 2);
+      padding-top: var(--qas-spacing-sm);
+      padding-bottom: var(--qas-spacing-sm);
 
       &:before {
         transition: background-color var(--qas-generic-transition);
       }
     }
 
+    &__middle {
+      margin-left: -16px;
+      padding-left: 16px;
+      margin-right: -16px;
+      // padding-right: 16px;
+      // box-shadow: 0 4px 8px var(--q-accent);
+      // padding: 16px;
+    }
+
     tr {
-      &:hover {
-        td:before {
-          background-color: var(--qas-background-color);
-        }
+      transition: background-image var(--qas-generic-transition);
+      position: relative;
+
+      &::before {
+        position: absolute;
+        content: '';
+        top: 0;
+        left: -16px;
+        right: -16px;
+        bottom: 0;
+        background-color: transparent;
+        // width: 100%;
+
       }
 
-      &:last-child td {
-        padding-bottom: 0;
+      &:hover:not(:has(td *[data-ignore-hover]:hover)) {
+        td:not(:has(*[data-ignore-hover])) * {
+          // color: var(--q-primary-contrast) !important;
+        }
+
+        // background-image: linear-gradient(90deg, rgba(15, 84, 174, 0.00) 0%, rgba(15, 84, 174, 0.05) 0.54%, rgba(15, 84, 174, 0.05) 99.48%, rgba(15, 84, 174, 0.00) 100%);
+      }
+
+      &:hover::before {
+        // background-image: linear-gradient(90deg, rgba(15, 84, 174, 0.00) 0%, rgba(15, 84, 174, 0.05) 0.54%, rgba(15, 84, 174, 0.05) 99.48%, rgba(15, 84, 174, 0.00) 100%);
+
+        background-color: red;
+        // background-color: var(--qas-background-color);
+
+        // td {
+        //   border-bottom: 1px solid var(--q-primary-contrast);;
+        // }
+
+      }
+
+      td::before {
+        // background-color: var(--qas-background-color);
+        display: none;
       }
     }
 
     thead tr:hover {
-      background-color: white;
+      // background-color: white;
     }
   }
 

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -23,7 +23,7 @@
         <q-td :class="getTdClasses(context.row)">
           <component :is="tdChildComponent" class="qas-table-generator__td-item" v-bind="getTdChildComponentProps(context.row)">
             <slot :name="`body-cell-${fieldName}`" v-bind="context || {}">
-              <pv-table-generator-td v-if="getFieldsProps(context.row)[fieldName]" :component-data="getFieldsProps(context.row)[fieldName]" :label="fields[fieldName]?.label" :name="fieldName" :row="context.row" />
+              <pv-table-generator-td v-if="getFieldsProps(context.row, context.rowIndex)[fieldName]" :component-data="getFieldsProps(context.row, context.rowIndex)[fieldName]" :label="fields[fieldName]?.label" :name="fieldName" :row="context.row" />
 
               <template v-else>
                 {{ context.row?.[fieldName] }}
@@ -429,11 +429,11 @@ export default {
       this.$attrs.onRowClick(...arguments)
     },
 
-    getFieldsProps (row) {
+    getFieldsProps (row, index) {
       const isFieldsPropsFunction = typeof this.fieldsProps === 'function'
 
       return {
-        ...(isFieldsPropsFunction ? this.fieldsProps(row) : this.fieldsProps),
+        ...(isFieldsPropsFunction ? this.fieldsProps(row, index) : this.fieldsProps),
 
         /**
          * caso tenha a prop "actionsMenuProps" é adicionado automaticamente a prop "actionsMenuProps"
@@ -442,7 +442,7 @@ export default {
         ...(this.hasActionsMenu && {
           actions: {
             component: 'QasActionsMenu',
-            props: this.actionsMenuProps?.(row)
+            props: this.actionsMenuProps?.(row, index)
           }
         })
       }

--- a/ui/src/components/table-generator/QasTableGenerator.yml
+++ b/ui/src/components/table-generator/QasTableGenerator.yml
@@ -4,6 +4,11 @@ meta:
   desc: Componente para criação de tabela dinâmica usando o `QTable` do quasar.
 
 props:
+  actions-menu-props:
+    desc: Propriedades repassadas para o "QasActionsMenu" que adiciona uma coluna "actions" de forma automática.
+    default: undefined
+    type: Function
+
   columns:
     desc: Colunas que vão ter na tabela.
     default: []
@@ -19,6 +24,12 @@ props:
     default: {}
     type: Object
     examples: ["{ email: { name: 'email', type: 'email', label: 'E-mail' } }"]
+
+  fields-props:
+    desc: Propriedade para controlar o uso de componentes dentro das row sem necessidade de abrir slot.
+    default: {}
+    type: [Object, Function]
+    examples: ["{ email: { component: 'QasCopy' } }"]
 
   header-props:
     desc: Propriedades repassadas para o componente `QasHeader`.

--- a/ui/src/components/table-generator/QasTableGenerator.yml
+++ b/ui/src/components/table-generator/QasTableGenerator.yml
@@ -8,6 +8,13 @@ props:
     desc: Propriedades repassadas para o "QasActionsMenu" que adiciona uma coluna "actions" de forma automática.
     default: undefined
     type: Function
+    params:
+      row:
+        desc: Payload da linha da tabela.
+        type: Object
+      index:
+        desc: Índice da linha da tabela.
+        type: Number
 
   columns:
     desc: Colunas que vão ter na tabela.
@@ -30,6 +37,13 @@ props:
     default: {}
     type: [Object, Function]
     examples: ["{ email: { component: 'QasCopy' } }"]
+    params:
+      row:
+        desc: Payload da linha da tabela.
+        type: Object
+      index:
+        desc: Índice da linha da tabela.
+        type: Number
 
   header-props:
     desc: Propriedades repassadas para o componente `QasHeader`.

--- a/ui/src/components/table-generator/_components/PvTableGeneratorTd.vue
+++ b/ui/src/components/table-generator/_components/PvTableGeneratorTd.vue
@@ -69,7 +69,9 @@ const component = computed(() => {
       props: {
         dialogTitle: props.label,
         maxWidth: 400,
-        text: defaultValue
+
+        // caso personalize o componente passando "list", não pode enviar "text" senão vai ter erro de tipo
+        text: props.componentData.props?.list?.length ? '' : defaultValue
       }
     },
 

--- a/ui/src/components/table-generator/_components/PvTableGeneratorTd.vue
+++ b/ui/src/components/table-generator/_components/PvTableGeneratorTd.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="component.is" data-ignore-hover v-bind="component.props" />
+  <component :is="component.is" v-bind="component.props" />
 </template>
 
 <script setup>

--- a/ui/src/components/table-generator/_components/PvTableGeneratorTd.vue
+++ b/ui/src/components/table-generator/_components/PvTableGeneratorTd.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="component.is" v-bind="component.props" />
+  <component :is="component.is" data-ignore-hover v-bind="component.props" />
 </template>
 
 <script setup>
@@ -8,14 +8,14 @@ import { computed, defineAsyncComponent } from 'vue'
 defineOptions({ name: 'PvTableGeneratorProps' })
 
 const props = defineProps({
-  componentName: {
-    type: String,
-    default: 'QasTextTruncate'
-  },
-
-  componentProps: {
+  componentData: {
     type: Object,
     default: () => ({})
+  },
+
+  label: {
+    type: String,
+    default: ''
   },
 
   row: {
@@ -25,37 +25,67 @@ const props = defineProps({
 
   name: {
     type: String,
-    default: 'name'
+    default: ''
   }
 })
 
 const component = computed(() => {
+  const defaultValue = props.row?.[props.name]
+
   const componentPaths = {
-    QasTextTruncate: {
-      component: () => import('../../text-truncate/QasTextTruncate.vue'),
+    QasActionsMenu: {
+      component: () => import('../../actions-menu/QasActionsMenu.vue'),
+      props: {}
+    },
+
+    QasBadge: {
+      component: () => import('../../badge/QasBadge.vue'),
       props: {
-        text: props.row[props.name],
-        maxWidth: 400
+        label: defaultValue
       }
     },
 
-    QasToggleVisibility: {
-      component: () => import('../../toggle-visibility/QasToggleVisibility.vue'),
-      props: {}
+    QasBtn: {
+      component: () => import('../../btn/QasBtn.vue'),
+      props: {
+        label: defaultValue
+      }
     },
 
     QasCopy: {
       component: () => import('../../copy/QasCopy.vue'),
       props: {
-        text: props.row[props.name]
+        text: defaultValue
+      }
+    },
+
+    QasStatus: {
+      component: () => import('../../status/QasStatus.vue'),
+      props: {}
+    },
+
+    QasTextTruncate: {
+      component: () => import('../../text-truncate/QasTextTruncate.vue'),
+      props: {
+        dialogTitle: props.label,
+        maxWidth: 400,
+        text: defaultValue
+      }
+    },
+
+    QasToggleVisibility: {
+      component: () => import('../../toggle-visibility/QasToggleVisibility.vue'),
+      props: {
+        text: defaultValue
       }
     }
   }
 
   return {
-    is: defineAsyncComponent(componentPaths[props.componentName].component),
+    is: defineAsyncComponent(componentPaths[props.componentData.component].component),
     props: {
-      ...componentPaths[props.componentName].props
+      ...componentPaths[props.componentData.component].props,
+      ...props.componentData.props
     }
   }
 })

--- a/ui/src/components/table-generator/_components/PvTableGeneratorTd.vue
+++ b/ui/src/components/table-generator/_components/PvTableGeneratorTd.vue
@@ -1,0 +1,62 @@
+<template>
+  <component :is="component.is" v-bind="component.props" />
+</template>
+
+<script setup>
+import { computed, defineAsyncComponent } from 'vue'
+
+defineOptions({ name: 'PvTableGeneratorProps' })
+
+const props = defineProps({
+  componentName: {
+    type: String,
+    default: 'QasTextTruncate'
+  },
+
+  componentProps: {
+    type: Object,
+    default: () => ({})
+  },
+
+  row: {
+    type: Object,
+    default: () => ({})
+  },
+
+  name: {
+    type: String,
+    default: 'name'
+  }
+})
+
+const component = computed(() => {
+  const componentPaths = {
+    QasTextTruncate: {
+      component: () => import('../../text-truncate/QasTextTruncate.vue'),
+      props: {
+        text: props.row[props.name],
+        maxWidth: 400
+      }
+    },
+
+    QasToggleVisibility: {
+      component: () => import('../../toggle-visibility/QasToggleVisibility.vue'),
+      props: {}
+    },
+
+    QasCopy: {
+      component: () => import('../../copy/QasCopy.vue'),
+      props: {
+        text: props.row[props.name]
+      }
+    }
+  }
+
+  return {
+    is: defineAsyncComponent(componentPaths[props.componentName].component),
+    props: {
+      ...componentPaths[props.componentName].props
+    }
+  }
+})
+</script>

--- a/ui/src/components/table-generator/_components/PvTableGeneratorTd.vue
+++ b/ui/src/components/table-generator/_components/PvTableGeneratorTd.vue
@@ -68,7 +68,7 @@ const component = computed(() => {
       component: () => import('../../text-truncate/QasTextTruncate.vue'),
       props: {
         dialogTitle: props.label,
-        maxWidth: 400,
+        maxWidth: 260,
 
         // caso personalize o componente passando "list", não pode enviar "text" senão vai ter erro de tipo
         text: props.componentData.props?.list?.length ? '' : defaultValue

--- a/ui/src/components/text-truncate/QasTextTruncate.vue
+++ b/ui/src/components/text-truncate/QasTextTruncate.vue
@@ -15,7 +15,7 @@
         </slot>
       </div>
 
-      <qas-btn v-if="hasButton" class="q-ml-sm" :label="buttonLabel" @click.stop.prevent="toggle" />
+      <qas-btn v-if="hasButton" class="q-ml-xs" :label="buttonLabel" @click.stop.prevent="toggle" />
     </div>
 
     <qas-dialog v-model="show" v-bind="defaultProps" aria-label="Diálogo de texto completo" max-width="500px" role="dialog" use-full-max-width>

--- a/ui/src/components/text-truncate/QasTextTruncate.vue
+++ b/ui/src/components/text-truncate/QasTextTruncate.vue
@@ -1,6 +1,7 @@
 <template>
   <div ref="parent" :class="classes">
     <div class="no-wrap row text-no-wrap">
+      <!-- "data-table-hover" habilita o hover no texto dentro do QasTableGenerator -->
       <div ref="truncate" class="ellipsis" data-table-hover>
         <slot>
           <div v-if="hasBadges" class="items-center q-col-gutter-sm row" :class="badgeParentClasses">

--- a/ui/src/components/text-truncate/QasTextTruncate.vue
+++ b/ui/src/components/text-truncate/QasTextTruncate.vue
@@ -1,7 +1,7 @@
 <template>
   <div ref="parent" :class="classes">
     <div class="no-wrap row text-no-wrap">
-      <div ref="truncate" class="ellipsis">
+      <div ref="truncate" class="ellipsis" data-table-hover>
         <slot>
           <div v-if="hasBadges" class="items-center q-col-gutter-sm row" :class="badgeParentClasses">
             <div v-for="(item, index) in normalizedBadgesList" :key="index">

--- a/ui/src/components/toggle-visibility/QasToggleVisibility.vue
+++ b/ui/src/components/toggle-visibility/QasToggleVisibility.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="qas-toggle-visibility">
+    <!-- "data-table-ignore-tr-hover" é para desabilitar o hover do tr no QasTableGenerator -->
     <div :aria-expanded="isVisible" aria-label="Alternar visibilidade do conteúdo" class="cursor-pointer items-center no-wrap qas-toggle-visibility__container row" data-table-ignore-tr-hover role="button" :style @click.prevent.stop="toggleVisibility">
       <div class="ellipsis qas-toggle-visibility__content">
         <div

--- a/ui/src/components/toggle-visibility/QasToggleVisibility.vue
+++ b/ui/src/components/toggle-visibility/QasToggleVisibility.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="qas-toggle-visibility">
-    <div :aria-expanded="isVisible" aria-label="Alternar visibilidade do conteúdo" class="cursor-pointer items-center no-wrap qas-toggle-visibility__container row" role="button" :style @click.prevent.stop="toggleVisibility">
+    <div :aria-expanded="isVisible" aria-label="Alternar visibilidade do conteúdo" class="cursor-pointer items-center no-wrap qas-toggle-visibility__container row" data-table-ignore-tr-hover role="button" :style @click.prevent.stop="toggleVisibility">
       <div class="ellipsis qas-toggle-visibility__content">
         <div
           v-if="isVisible"


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
## BREAKING CHANGE
- `QasTableGenerator`:
  - olhar todos lugares que usam slot de actions/componentes e passar a utilizar pelas propriedades `fieldsProps` e `actionsMenuProps`.
  - por padrão toda coluna terá `sort`, mas nem toda coluna precisa de sort, então é necessário olhar caso a caso e remover quando desnecessário.

### Adicionado
- `QasTableGenerator`:
  - adicionado propriedade `fieldsProps` para controle de componente interno sem uso de slot.
  - adicionado propriedade `actionsMenuProps` para adicionar por padrão coluna `actions` com componente `QasActions` na ultima coluna com alinhamento á direita.

### Modificado
- `QasTextTruncate`: modificado espaçamento entre texto e botão "ver mais" de sm para xs.
- `QasTableGenerator`:
  - adicionado sort default em todas colunas.
  - modificado estilos de hover nas linhas.
- [`QasBtn`, `QasToggleVisibility`]: adicionado atributo `data-table-ignore-tr-hover`.
- `QasCopy`: adicionado atributo `data-table-hover`.
- `QasBadge`: adicionado atributo `data-table-ignore-hover`.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
