### PR TITLE
Fixes ds changes 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 - [`QasActionsMenu`, `QasBtnDropdown`, `QasTreeGenerator`]: adicionado classe `qas-menu`para corrigir estilos.
 - `QasAlert`: removido da obrigatoriedade da prop `text` para quando for usado slot não gerar erros.
 - `QasAppMenu`: corrigido área de mouseover quando o menu list é pequeno.
-- `QasTableGenerator`: corrigido prop "text" default quando usando componente QasTextTruncate via `fieldsProps`.
+- `QasTableGenerator`:
+  - corrigido prop "text" default quando usando componente QasTextTruncate via `fieldsProps`.
+  - remove automaticamente sortable de todas colunas quando tem menos de 2 resultados, uma vez que não faz sentido ter sort nestes casos.
 - `QasUploader`: corrigido ação "removeUploadedFiles" que era usado via ref em um botão hidden, agora é usado via refs do QUploader.
 - `css/menu`: alterado tamanho do icon que estava errado.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- [`QasActionsMenu`, `QasBtnDropdown`, `QasTreeGenerator`]: adicionado classe `qas-menu`para corrigir estilos.
+- `QasAlert`: removido da obrigatoriedade da prop `text` para quando for usado slot não gerar erros.
+- `QasAppMenu`: corrigido área de mouseover quando o menu list é pequeno.
+- `QasTableGenerator`: corrigido prop "text" default quando usando componente QasTextTruncate via `fieldsProps`.
+- `QasUploader`: corrigido ação "removeUploadedFiles" que era usado via ref em um botão hidden, agora é usado via refs do QUploader.
+- `css/menu`: alterado tamanho do icon que estava errado.
+
 ## [3.18.0-beta.2] - 17-04-2025
 ## BREAKING CHANGE
 - `QasSearchBox`: modificado prop `height` para `maxHeight`, pois o nome da prop era `height`, mas internamente adicionava o style como `maxHeight`.

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="hasList" class="qas-actions-menu" data-cy="actions-menu">
     <qas-btn-dropdown v-bind="btnDropdownProps">
-      <q-list data-cy="actions-menu-list" separator>
+      <q-list data-cy="actions-menu-list">
         <slot v-for="(item, key) in formattedList.dropdownList" :item="item" :name="key">
           <q-item v-bind="getItemProps(item)" :key="key" active-class="primary" clickable data-cy="actions-menu-list-item" @click="setClickHandler(item)">
             <q-item-section avatar>

--- a/ui/src/components/alert/QasAlert.vue
+++ b/ui/src/components/alert/QasAlert.vue
@@ -61,7 +61,7 @@ const props = defineProps({
 
   text: {
     type: String,
-    required: true
+    default: ''
   },
 
   useBox: {

--- a/ui/src/components/app-menu/QasAppMenu.vue
+++ b/ui/src/components/app-menu/QasAppMenu.vue
@@ -83,17 +83,17 @@
         </q-list>
 
         <!-- usuário + chat ajuda -->
-        <div v-if="showAppUser" class="q-mt-auto" @mouseenter="onMouseEvent" @mouseleave="onMouseEvent">
+        <div v-if="showAppUser" class="column justify-end no-wrap qas-app-menu__user-chat" @mouseenter="onMouseEvent" @mouseleave="onMouseEvent">
           <!-- Chat Ajuda -->
           <q-list v-if="useChat" class="q-mt-md">
-            <q-item class="q-pb-none" clickable @click="toggleChat">
-              <q-item-section avatar>
-                <q-icon color="primary" name="sym_r_chat" />
+            <q-item class="q-pb-none qas-app-menu__chat-item" clickable @click="toggleChat">
+              <q-item-section avatar class="qas-app-menu__chat-item-section text-primary">
+                <q-icon name="sym_r_chat" />
               </q-item-section>
 
-              <q-item-section>
+              <q-item-section class="qas-app-menu__chat-item-section text-primary">
                 <q-item-label>
-                  <div class="ellipsis text-primary text-subtitle2">
+                  <div class="ellipsis text-subtitle2">
                     Solicitar ajuda
                   </div>
                 </q-item-label>
@@ -428,6 +428,8 @@ function useChatMenu () {
 
 <style lang="scss" scoped>
 .qas-app-menu {
+  $root: &;
+
   // Workaround para alterar o padding interno do QSelect sem influenciar na caixa de opções.
   &__module {
     .q-field__native {
@@ -476,6 +478,19 @@ function useChatMenu () {
   &__item--label-mini {
     padding-left: 0 !important;
     padding-right: 0 !important;
+  }
+
+  // Faz com que essa área ocupe todo o tamanho restante até o QList, adicionando o evento de mouseover.
+  &__user-chat {
+    flex: 1 1 auto;
+  }
+
+  &__chat-item:hover &__chat-item-section {
+    color: var(--qas-primary-contrast) !important;
+  }
+
+  &__chat-item-section {
+    transition: color var(--qas-generic-transition);
   }
 
   .q-item:not(&__item--label-mini) {

--- a/ui/src/components/app-menu/QasAppMenu.vue
+++ b/ui/src/components/app-menu/QasAppMenu.vue
@@ -428,8 +428,6 @@ function useChatMenu () {
 
 <style lang="scss" scoped>
 .qas-app-menu {
-  $root: &;
-
   // Workaround para alterar o padding interno do QSelect sem influenciar na caixa de opções.
   &__module {
     .q-field__native {

--- a/ui/src/components/btn-dropdown/QasBtnDropdown.vue
+++ b/ui/src/components/btn-dropdown/QasBtnDropdown.vue
@@ -4,7 +4,7 @@
       <div v-for="(buttonProps, key, index) in props.buttonsPropsList" :key="key">
         <div class="flex no-wrap">
           <qas-btn :disable="props.disable" v-bind="buttonProps" no-wrap variant="tertiary" @click="onClick">
-            <q-menu v-if="hasMenuOnLeftSide" v-model="isMenuOpened" anchor="bottom right" auto-close self="top right" @update:model-value="onUpdateMenuValue">
+            <q-menu v-if="hasMenuOnLeftSide" v-model="isMenuOpened" anchor="bottom right" auto-close class="qas-menu" self="top right" @update:model-value="onUpdateMenuValue">
               <div :class="classes.menuContent">
                 <slot />
               </div>

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -193,6 +193,8 @@ export default {
     },
 
     columnsByFields () {
+      const hasMultipleResults = this.rowsPerPage > 1
+
       if (!this.hasFields) {
         return this.normalizedColumns.filter(column => column instanceof Object)
       }
@@ -208,7 +210,7 @@ export default {
           label,
           name,
           headerClasses: 'text-grey-10',
-          sortable: sortable ?? true,
+          sortable: sortable ?? hasMultipleResults,
           sort,
           rawSort
         })

--- a/ui/src/components/table-generator/_components/PvTableGeneratorTd.vue
+++ b/ui/src/components/table-generator/_components/PvTableGeneratorTd.vue
@@ -71,7 +71,7 @@ const component = computed(() => {
         maxWidth: 260,
 
         // caso personalize o componente passando "list", não pode enviar "text" senão vai ter erro de tipo
-        text: props.componentData.props?.list?.length ? '' : defaultValue
+        text: 'list' in (props.componentData.props || {}) ? '' : defaultValue
       }
     },
 

--- a/ui/src/components/tree-generator/QasTreeGenerator.vue
+++ b/ui/src/components/tree-generator/QasTreeGenerator.vue
@@ -10,8 +10,8 @@
           <span v-if="hasMenuButton(node)" class="q-ml-sm">
             <!-- TODO: rever para o uso QasActionsMenu -->
             <qas-btn color="grey-10" icon="sym_r_more_vert" variant="tertiary" @click.stop.prevent>
-              <q-menu auto-close>
-                <q-list separator>
+              <q-menu auto-close class="qas-menu">
+                <q-list>
                   <q-item v-if="useAddButton" v-ripple class="qas-tree-generator__item" clickable @click="handleTreeFormDialog(node, true, tree)">
                     <q-item-section avatar>
                       <q-icon name="sym_r_add_circle_outline" />

--- a/ui/src/components/uploader/QasUploader.vue
+++ b/ui/src/components/uploader/QasUploader.vue
@@ -336,8 +336,8 @@ export default {
     },
 
     dispatchUpload () {
-      this.uploader.removeUploadedFiles()
-      this.hiddenInputElement.click()
+      this.uploader?.removeUploadedFiles?.()
+      this.hiddenInputElement?.click?.()
     },
 
     async factory ([file]) {
@@ -360,7 +360,7 @@ export default {
       }
     },
 
-    factoryFailed (context) {
+    factoryFailed () {
       this.hasError = true
 
       this.updateUploading(false)
@@ -659,8 +659,7 @@ export default {
 <style lang="scss">
 .qas-uploader {
   &__input {
-    // display: none;
-    visibility: hidden;
+    display: none;
   }
 
   .q-uploader {

--- a/ui/src/components/uploader/QasUploader.vue
+++ b/ui/src/components/uploader/QasUploader.vue
@@ -17,7 +17,6 @@
 
           <!-- ------------------------------------ tags hidden -------------------------------------- -->
           <input ref="hiddenInput" :accept="attributes.accept" class="qas-uploader__input" :multiple="isMultiple" type="file">
-          <qas-btn ref="buttonCleanFiles" class="hidden" @click="scope.removeUploadedFiles" />
         </slot>
       </template>
 
@@ -337,13 +336,13 @@ export default {
     },
 
     dispatchUpload () {
-      this.$refs.buttonCleanFiles.$el.click()
+      this.uploader.removeUploadedFiles()
       this.hiddenInputElement.click()
     },
 
     async factory ([file]) {
       if (!this.isMultiple && !this.hasHeaderSlot) {
-        this.$refs.buttonCleanFiles.$el.click()
+        this.uploader.removeUploadedFiles()
       }
 
       const name = `${uid()}.${file.name.split('.').pop()}`
@@ -361,7 +360,7 @@ export default {
       }
     },
 
-    factoryFailed () {
+    factoryFailed (context) {
       this.hasError = true
 
       this.updateUploading(false)
@@ -660,7 +659,8 @@ export default {
 <style lang="scss">
 .qas-uploader {
   &__input {
-    display: none;
+    // display: none;
+    visibility: hidden;
   }
 
   .q-uploader {

--- a/ui/src/css/components/menu.scss
+++ b/ui/src/css/components/menu.scss
@@ -10,7 +10,7 @@
       min-height: 36px !important;
 
       .q-icon {
-        font-size: 18px !important;
+        font-size: 24px !important;
       }
     }
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Corrigido
- [`QasActionsMenu`, `QasBtnDropdown`, `QasTreeGenerator`]: adicionado classe `qas-menu`para corrigir estilos.
- `QasAlert`: removido da obrigatoriedade da prop `text` para quando for usado slot não gerar erros.
- `QasAppMenu`: corrigido área de mouseover quando o menu list é pequeno.
- `QasTableGenerator`:
  - corrigido prop "text" default quando usando componente QasTextTruncate via `fieldsProps`.
  - remove automaticamente sortable de todas colunas quando tem menos de 2 resultados, uma vez que não faz sentido ter sort nestes casos.
- `QasUploader`: corrigido ação "removeUploadedFiles" que era usado via ref em um botão hidden, agora é usado via refs do QUploader.
- `css/menu`: alterado tamanho do icon que estava errado.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
