### PR TITLE
QasHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasHeader`: corrigido exibição do container de descrição em casos de não ter `label` e `description`.
+
 ## [3.18.0-beta.3] - 24-04-2025
 ### Corrigido
 - [`QasActionsMenu`, `QasBtnDropdown`, `QasTreeGenerator`]: adicionado classe `qas-menu`para corrigir estilos.

--- a/docs/src/examples/QasHeader/HeaderWithBadges.vue
+++ b/docs/src/examples/QasHeader/HeaderWithBadges.vue
@@ -9,7 +9,7 @@ export default {
   computed: {
     headerProps () {
       return {
-        description: 'Algum texto de exemplo para ficar ao lado do botão de adicionar.',
+        description: 'Algum texto de descrição.',
 
         labelProps: {
           label: 'Título do header'

--- a/docs/src/examples/QasHeader/HeaderWithButton.vue
+++ b/docs/src/examples/QasHeader/HeaderWithButton.vue
@@ -9,7 +9,7 @@ export default {
   computed: {
     headerProps () {
       return {
-        description: 'Algum texto de exemplo para ficar ao lado do botão de adicionar.',
+        description: 'Algum texto de descrição.',
         labelProps: {
           label: 'Título do header'
         },

--- a/docs/src/examples/QasHeader/HeaderWithFilters.vue
+++ b/docs/src/examples/QasHeader/HeaderWithFilters.vue
@@ -16,6 +16,6 @@ const headerProps = {
     label: 'Com filtro'
   },
 
-  description: 'lorem ipsum dolor sit amet consectetur adipiscing elit'
+  description: 'Algum texto de descrição.'
 }
 </script>

--- a/docs/src/examples/QasHeader/HeaderWithoutActions.vue
+++ b/docs/src/examples/QasHeader/HeaderWithoutActions.vue
@@ -9,7 +9,7 @@ export default {
   computed: {
     headerProps () {
       return {
-        description: 'Algum texto de exemplo para ficar ao lado do botão de adicionar.',
+        description: 'Algum texto de descrição.',
         labelProps: {
           label: 'Título do header'
         }

--- a/ui/src/components/header/QasHeader.vue
+++ b/ui/src/components/header/QasHeader.vue
@@ -20,7 +20,7 @@
       </div>
     </div>
 
-    <div class="items-start no-wrap q-col-gutter-sm row" :class="descriptionSectionClasses">
+    <div v-if="hasDescriptionOrOnlyActionsSection" class="bg-red items-start no-wrap q-col-gutter-sm row" :class="descriptionSectionClasses">
       <div v-if="hasDescriptionSection" class="text-body1 text-grey-8">
         <slot name="description">
           {{ props.description }}
@@ -147,6 +147,15 @@ const hasLabel = computed(() => !!Object.keys(props.labelProps).length)
 const hasDefaultButton = computed(() => !!Object.keys(props.buttonProps).length)
 const hasDefaultFilters = computed(() => !!Object.keys(props.filtersProps).length)
 const hasDefaultActionsMenu = computed(() => !!Object.keys(props.actionsMenuProps).length)
-const hasDescriptionSection = computed(() => props.description || slots.description)
+const hasDescriptionSection = computed(() => !!props.description || !!slots.description)
 const hasLabelSection = computed(() => hasLabel.value || slots.label || hasBadges.value)
+
+/**
+ * Só exibo a seção de descrição com a seção de ações ao lado quando:
+ * - Tenha descrição;
+ * - OU não tenha seção da label E tenha componente de ações.
+ */
+const hasDescriptionOrOnlyActionsSection = computed(() => {
+  return hasDescriptionSection.value || (!hasLabelSection.value && hasActionsComponent.value)
+})
 </script>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
### Corrigido
- `QasHeader`: corrigido exibição do container de descrição em casos de não ter `label` e `description`.
## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [ ] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [ ] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [ ] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [ ] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [ ] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [ ] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [ ] Foi atualizada e testada a documentação;
- [ ] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [ ] Fiz meu próprio _code review_ antes de abrir este _pull request_.
