### PR TITLE
fix(QasTableGenerator): fix hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ## Não publicado
 ### Corrigido
-- `QasTableGenerator`: corrigido hover da linha onde que no Safari pegava a tabela toda ao invés da própria linha.
+- `QasTableGenerator`: corrigido hover da linha no Safari onde era pego toda tabela ao invés da própria linha.
 
 ## [3.18.0-beta.3] - 24-04-2025
 ### Corrigido

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasTableGenerator`: corrigido hover da linha onde que no Safari pegava a tabela toda ao invés da própria linha.
+
 ## [3.18.0-beta.3] - 24-04-2025
 ### Corrigido
 - [`QasActionsMenu`, `QasBtnDropdown`, `QasTreeGenerator`]: adicionado classe `qas-menu`para corrigir estilos.

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -489,7 +489,7 @@ export default {
       padding-left: 0;
       padding-top: var(--qas-spacing-sm);
       position: relative;
-      z-index: 1;
+      z-index: 0;
 
       &:not(:last-child) {
         padding-right: var(--qas-spacing-md);

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -504,6 +504,8 @@ export default {
       padding-bottom: var(--qas-spacing-sm);
       padding-left: 0;
       padding-top: var(--qas-spacing-sm);
+      position: relative;
+      z-index: 1;
 
       &:not(:last-child) {
         padding-right: var(--qas-spacing-md);
@@ -514,8 +516,25 @@ export default {
       }
 
       &::before {
-        display: none;
+        position: absolute;
+        content: '';
+        top: 0;
+        left: 0;
+        z-index: -1;
+        background-color: transparent;
       }
+
+      &:first-child::before {
+        left: calc(var(--qas-spacing-md) * -1);
+      }
+
+      &:last-child::before {
+        right: calc(var(--qas-spacing-md) * -1);
+      }
+    }
+
+    tr:hover td::before {
+      background-color: var(--qas-background-color);
     }
 
     &__middle {
@@ -523,31 +542,7 @@ export default {
       padding-right: var(--qas-spacing-md);
     }
 
-    tr {
-      position: relative;
-
-      &::before {
-        background-color: transparent;
-        bottom: 0;
-        content: '';
-        left: calc(var(--qas-spacing-md) * -1);
-        pointer-events: none;
-        position: absolute;
-        right: calc(var(--qas-spacing-md) * -1);
-        top: 0;
-        transition: background-color var(--qas-generic-transition);
-      }
-    }
-
     tbody tr {
-      &::before {
-        display: block;
-      }
-
-      &:hover::before {
-        background-color: var(--qas-background-color);
-      }
-
       /*
         A regra só é aplicada se nenhum elemento filho com o atributo "data-table-ignore-tr-hover"
         estiver também em estado de hover, impedindo que estilos conflitantes sejam aplicados.


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- (Remova este texto de descrição.) -->
### Corrigido
- `QasTableGenerator`: corrigido hover da linha onde que no Safari pegava a tabela toda ao invés da própria linha.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [x] CSS
- [ ] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [ ] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [ ] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [ ] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [ ] Foi atualizada e testada a documentação;
- [ ] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [ ] Fiz meu próprio _code review_ antes de abrir este _pull request_.
