### PR TITLE
PvTableGeneratorTd: alterado o import dinamico

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `PvTableGeneratorTd`: corrigido forma de import dos componentes utilizados na tabela, os imports foram removidos da computada, o que fazia com que o componente fosse renderizado novamente sempre que a computada atualizava.
+
 ## [3.18.0-beta.6] - 27-05-2025
 ### Adicionado
 - `QasReportsFilters`: adicionado componente responsável por lidar com filtros em relatórios.

--- a/ui/src/components/btn-dropdown/QasBtnDropdown.vue
+++ b/ui/src/components/btn-dropdown/QasBtnDropdown.vue
@@ -33,7 +33,7 @@
 <script setup>
 import useScreen from '../../composables/use-screen'
 
-import { ref, watch, computed, useSlots, onMounted, onUnmounted } from 'vue'
+import { ref, watch, computed, useSlots } from 'vue'
 
 defineOptions({
   name: 'QasBtnDropdown',
@@ -121,16 +121,9 @@ const splittedButtonProps = computed(() => {
   }
 })
 
-console.log('created')
-
 watch(() => props.menu, value => {
-  console.log('<--- watch')
   isMenuOpened.value = value
 }, { immediate: true })
-
-onMounted(() => console.log('onMounted'))
-
-onUnmounted(() => console.log('onUnmounted'))
 
 function onUpdateMenuValue (value) {
   emit('update:menu', value)

--- a/ui/src/components/table-generator/_components/PvTableGeneratorTd.vue
+++ b/ui/src/components/table-generator/_components/PvTableGeneratorTd.vue
@@ -8,6 +8,12 @@ import { computed, defineAsyncComponent } from 'vue'
 defineOptions({ name: 'PvTableGeneratorProps' })
 
 const QasActionsMenu = defineAsyncComponent(() => import('../../actions-menu/QasActionsMenu.vue'))
+const QasBadge = defineAsyncComponent(() => import('../../badge/QasBadge.vue'))
+const QasBtn = defineAsyncComponent(() => import('../../btn/QasBtn.vue'))
+const QasCopy = defineAsyncComponent(() => import('../../copy/QasCopy.vue'))
+const QasStatus = defineAsyncComponent(() => import('../../status/QasStatus.vue'))
+const QasTextTruncate = defineAsyncComponent(() => import('../../text-truncate/QasTextTruncate.vue'))
+const QasToggleVisibility = defineAsyncComponent(() => import('../../toggle-visibility/QasToggleVisibility.vue'))
 
 const props = defineProps({
   componentData: {
@@ -41,33 +47,33 @@ const component = computed(() => {
     },
 
     QasBadge: {
-      component: () => import('../../badge/QasBadge.vue'),
+      component: QasBadge,
       props: {
         label: defaultValue
       }
     },
 
     QasBtn: {
-      component: () => import('../../btn/QasBtn.vue'),
+      component: QasBtn,
       props: {
         label: defaultValue
       }
     },
 
     QasCopy: {
-      component: () => import('../../copy/QasCopy.vue'),
+      component: QasCopy,
       props: {
         text: defaultValue
       }
     },
 
     QasStatus: {
-      component: () => import('../../status/QasStatus.vue'),
+      component: QasStatus,
       props: {}
     },
 
     QasTextTruncate: {
-      component: () => import('../../text-truncate/QasTextTruncate.vue'),
+      component: QasTextTruncate,
       props: {
         dialogTitle: props.label,
         maxWidth: 260,
@@ -78,7 +84,7 @@ const component = computed(() => {
     },
 
     QasToggleVisibility: {
-      component: () => import('../../toggle-visibility/QasToggleVisibility.vue'),
+      component: QasToggleVisibility,
       props: {
         text: defaultValue
       }
@@ -88,39 +94,22 @@ const component = computed(() => {
   // Os componentes abaixo precisam adicionar o stopPropagation e preventDefault no click para nao chamar o rowClick ou rowRouteFn
   const hasPreventEvent = ['QasActionsMenu', 'QasBtn'].includes(props.componentData.component)
 
-  if (hasPreventEvent) {
-    return {
-      is: QasActionsMenu,
-      props: {
-        ...componentPaths[props.componentData.component].props,
-        ...props.componentData.props,
-
-        ...(hasPreventEvent && {
-          onClick: event => {
-            event.stopPropagation()
-            event.preventDefault()
-
-            props.componentData.props?.onClick?.(event)
-          }
-        })
-      }
-    }
-  }
+  const componentPath = componentPaths[props.componentData.component]
 
   return {
-    is: defineAsyncComponent(componentPaths[props.componentData.component].component),
+    is: componentPath.component,
     props: {
-      ...componentPaths[props.componentData.component].props,
-      ...props.componentData.props
+      ...componentPath.props,
+      ...props.componentData.props,
 
-      // ...(hasPreventEvent && {
-      //   onClick: event => {
-      //     event.stopPropagation()
-      //     event.preventDefault()
+      ...(hasPreventEvent && {
+        onClick: event => {
+          event.stopPropagation()
+          event.preventDefault()
 
-      //     props.componentData.props?.onClick?.(event)
-      //   }
-      // })
+          props.componentData.props?.onClick?.(event)
+        }
+      })
     }
   }
 })


### PR DESCRIPTION
- `PvTableGeneratorTd`: corrigido forma de import dos componentes utilizados na tabela, os imports foram removidos da computada, o que fazia com que o componente fosse renderizado novamente sempre que a computada atualizava.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
