### PR TITLE
Ajustado alinhamento do botão

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,16 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Corrigido
+- `QasBtn`: corrigido alinhamento do botão no caso de usar a prop `useEllipsis`, antes acontecia do container estar sempre `justify-between`, agora existe um controle interno para isso, dando a possibilidade também de utilizar a prop `align` do próprio `QBtn`.
+
 ## [3.18.0-beta.8] - 10-06-2025
 ### Modificado
-- `QasCard`: Modificado espaçamento vertical do card, será `sm` somente caso tenha status ou o expansivo.
+- `QasCard`: modificado espaçamento vertical do card, será `sm` somente caso tenha status ou o expansivo.
 
 ### Corrigido
-- `QasCard`: Corrigido borda à esquerda dos cards que não possuem status.
+- `QasCard`: corrigido borda à esquerda dos cards que não possuem status.
 
 ## [3.18.0-beta.7] - 30-05-2025
 ### Corrigido

--- a/ui/src/components/btn/QasBtn.vue
+++ b/ui/src/components/btn/QasBtn.vue
@@ -5,19 +5,17 @@
       <slot :name="name" v-bind="context || {}" />
     </template>
 
-    <div class="items-center justify-between no-wrap row text-center" :class="containerClasses">
-      <q-spinner v-if="hasLeftSpinner" :class="iconClasses" size="sm" />
+    <q-spinner v-if="hasLeftSpinner" :class="iconClasses" size="sm" />
 
-      <q-icon v-if="hasIcon" :class="iconClasses" :name="props.icon" />
+    <q-icon v-if="hasIcon" :class="iconClasses" :name="props.icon" />
 
-      <div v-if="showLabel" :class="labelClasses">
-        {{ props.label }}
-      </div>
-
-      <q-spinner v-if="hasRightSpinner" :class="iconRightClasses" size="sm" />
-
-      <q-icon v-if="hasIconRight" :class="iconRightClasses" :name="props.iconRight" />
+    <div v-if="showLabel" :class="labelClasses">
+      {{ props.label }}
     </div>
+
+    <q-spinner v-if="hasRightSpinner" :class="iconRightClasses" size="sm" />
+
+    <q-icon v-if="hasIconRight" :class="iconRightClasses" :name="props.iconRight" />
 
     <slot />
   </q-btn>
@@ -109,7 +107,6 @@ const hasIconRight = computed(() => props.iconRight && !props.loading)
 const hasIcon = computed(() => props.icon && !props.loading)
 
 const labelClasses = computed(() => ({ ellipsis: props.useEllipsis }))
-const containerClasses = computed(() => ({ 'full-width': props.useEllipsis }))
 
 const iconClasses = computed(() => ({ 'on-left': !hasIconOnly.value }))
 const iconRightClasses = computed(() => ({ 'on-right': !hasIconOnly.value }))
@@ -134,12 +131,13 @@ const classes = computed(() => {
     'qas-btn--no-hover-on-white': !props.useHoverOnWhiteColor,
 
     // ellipsis
-    'full-width': props.useEllipsis
+    'qas-btn--ellipsis': props.useEllipsis
   }
 })
 
 const attributes = computed(() => {
   const {
+    align,
     class: externalClass,
     dense,
     disable,
@@ -166,7 +164,14 @@ const attributes = computed(() => {
   return {
     ...attributesPayload,
     disable: disable || props.loading,
-    class: [classes.value, externalClass]
+    class: [classes.value, externalClass],
+
+    /**
+     * Alinhamento do conteúdo do botão será sempre sobrescrito caso seja passado via prop
+     * ou caso ele seja ellipsis e do tipo tertiary, deverá ser alinhado a esquerda
+     * ou padrão ser alinhado ao centro.
+     */
+    align: align || (props.useEllipsis && isTertiary.value && 'left') || 'center'
   }
 })
 


### PR DESCRIPTION
### Corrigido
- `QasBtn`: corrigido alinhamento do botão no caso de usar a prop `useEllipsis`, antes acontecia do container estar sempre `justify-between`, agora existe um controle interno para isso, dando a possibilidade também de utilizar a prop `align` do próprio `QBtn`.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
