### PR TITLE
`QasListView`: Adicionado propriedade use-store para controlar quando utilizar store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasListView`: Adicionado propriedade `use-store` para dar a possibilidade de utilizar o componente sem a store do vuex/pinia.
+
 ## [3.18.0-beta.8] - 10-06-2025
 ### Modificado
 - `QasCard`: Modificado espaçamento vertical do card, será `sm` somente caso tenha status ou o expansivo.

--- a/ui/src/components/list-view/QasListView.vue
+++ b/ui/src/components/list-view/QasListView.vue
@@ -156,6 +156,9 @@ export default {
       return !!(this.resultsModel || []).length
     },
 
+    /**
+     * Em casos de não utilizar store, utiliza o data do mixin.
+     */
     resultsModel () {
       if (this.useStore) return getState.call(this, { entity: this.entity, key: 'list' })
 
@@ -234,12 +237,17 @@ export default {
         const { errors, fields, metadata, results, count } = response.data
 
         this.resultsQuantity = results.length
-        this.count = count
+
+        // Seta o count com a quantidade de resultados, se não estiver usando store.
+        if (!this.useStore) {
+          this.count = count
+        }
 
         this.mx_setErrors(errors)
         this.mx_setFields(fields)
         this.mx_setMetadata(metadata)
 
+        // Em casos de não utilizar store, seta os results no data do mixin.
         !this.useStore && this.mx_setResults(results)
 
         this.mx_updateModels({
@@ -279,6 +287,7 @@ export default {
 
       const limit = payloadLimit || this.itemsPerPage
 
+      // Define os parâmetros que serão enviados para a API
       const params = {
         ...filters,
         ...othersPayload,

--- a/ui/src/components/list-view/QasListView.yml
+++ b/ui/src/components/list-view/QasListView.yml
@@ -45,6 +45,11 @@ props:
     default: {}
     type: Object
 
+  items-per-page:
+    desc: Quantidade de itens por pagina que será enviada no limit (somente será aplicado em casos de não utilizar store).
+    default: 36
+    type: Number
+
   metadata:
     model: true
     desc: Model de metadata, utilizado para recuperar os metadata fora do template.
@@ -93,6 +98,11 @@ props:
 
   use-results-area-only:
     desc: Controla se irá sempre ser exibido os resultados independente se não há nenhum resultado a ser exibido.
+    type: Boolean
+
+  use-store:
+    desc: Controla se vai utilizar a store.
+    default: true
     type: Boolean
 
 slots:

--- a/ui/src/components/list-view/QasListView.yml
+++ b/ui/src/components/list-view/QasListView.yml
@@ -45,7 +45,7 @@ props:
     default: {}
     type: Object
 
-  items-per-page:
+  results-per-page:
     desc: Quantidade de itens por pagina que será enviada no limit (somente será aplicado em casos de não utilizar store).
     default: 36
     type: Number

--- a/ui/src/mixins/view.js
+++ b/ui/src/mixins/view.js
@@ -55,7 +55,6 @@ export default {
       mx_errors: {},
       mx_fields: {},
       mx_metadata: {},
-      mx_results: [],
       mx_cancelBeforeFetch: false,
       mx_isFetching: false,
       mx_hasFetchError: false
@@ -128,10 +127,6 @@ export default {
 
     mx_setMetadata (metadata = {}) {
       this.mx_metadata = markRaw(metadata)
-    },
-
-    mx_setResults (results = []) {
-      this.mx_results = results
     },
 
     mx_updateModels (models) {

--- a/ui/src/mixins/view.js
+++ b/ui/src/mixins/view.js
@@ -55,6 +55,7 @@ export default {
       mx_errors: {},
       mx_fields: {},
       mx_metadata: {},
+      mx_results: [],
       mx_cancelBeforeFetch: false,
       mx_isFetching: false,
       mx_hasFetchError: false
@@ -127,6 +128,10 @@ export default {
 
     mx_setMetadata (metadata = {}) {
       this.mx_metadata = markRaw(metadata)
+    },
+
+    mx_setResults (results = []) {
+      this.mx_results = results
     },
 
     mx_updateModels (models) {


### PR DESCRIPTION
### Adicionado
- `QasListView`: Adicionado propriedade `use-store` para dar a possibilidade de utilizar o componente sem a store do vuex/pinia.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
