### PR TITLE
Fix query cache handling

### DIFF
--- a/docs/src/pages/composables/use-query-cache.md
+++ b/docs/src/pages/composables/use-query-cache.md
@@ -8,7 +8,7 @@ Composable para manipular a persistência de query através da `SessionStorage`.
 import { useQueryCache } from 'asteroid'
 
 const {
-  addOnde,
+  addOne,
   addMany,
   findOne,
   findAll,

--- a/ui/src/composables/use-query-cache.js
+++ b/ui/src/composables/use-query-cache.js
@@ -9,6 +9,8 @@ function updateSessionStorage () {
 
 export default function () {
   function addOne (key, { label, value }) {
+    if (!cachedFilters[key]) cachedFilters[key] = {}
+
     cachedFilters[key][label] = value
     updateSessionStorage()
   }
@@ -27,6 +29,8 @@ export default function () {
   }
 
   function clearOne (key, filter) {
+    if (!cachedFilters[key]) return
+
     delete cachedFilters[key][filter]
     updateSessionStorage()
   }


### PR DESCRIPTION
## Summary
- handle initialization for `useQueryCache`
- fix doc typo
- add empty line after initializing new entry