### PR TITLE
Ajustes `QasNestedField` | `QasSelectListDialog` | `QasNumericInput`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ### Modificado
 - `QasSelectListDialog`: Modificado header para utilizar o componente `QasHeader`.
-
+- `QasNumericInput`: Alterado input para aplicar estilo tanto de `readonly` quanto de `disabled`, sendo que antes só aplicava `disabled` mesmo quando enviasse a prop `readonly`.
 
 ## [3.18.0] - 02-07-2025
 ## BREAKING CHANGE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Adicionado
+- `QasNestedFields`: Adicionado nova prop `use-header` para controlar quando irá ter ou não o header em cada linha.
+
 ## [3.18.0] - 02-07-2025
 ## BREAKING CHANGE
 - `QasInput`: alterado ordem da prop `iconRight` que estava adicionando na esquerda e não na direita, verificar lugares.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 ## Não publicado
 ### Adicionado
 - `QasNestedFields`: Adicionado nova prop `use-header` para controlar quando irá ter ou não o header em cada linha.
+- `QasSelectListDialog`: Adicionado novo slot `content` para poder personalizar todos os itens adicionados.
+
+### Modificado
+- `QasSelectListDialog`: Modificado header para utilizar o componente `QasHeader`.
+
 
 ## [3.18.0] - 02-07-2025
 ## BREAKING CHANGE

--- a/docs/src/examples/QasNestedFields/SingleLabelAndNotHeader.vue
+++ b/docs/src/examples/QasNestedFields/SingleLabelAndNotHeader.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="container spaced">
+    <div class="full-width">
+      <div class="q-mt-lg text-center">
+        <div>
+          <qas-nested-fields v-model="model" class="full-width" v-bind="nestedFieldsProps" />
+        </div>
+
+        <div class="q-my-lg">
+          Model: <qas-debugger :inspect="[model]" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+defineOptions({ name: 'SingleLabelAndNotHeader' })
+
+// refs
+const model = ref([])
+
+// consts
+const nestedFieldsProps = {
+  field: {
+    name: 'nested',
+    type: 'nested',
+    label: 'Meu nested',
+    children: {
+      name: {
+        name: 'name',
+        type: 'text',
+        label: 'Nome'
+      },
+      email: {
+        name: 'email',
+        type: 'email',
+        label: 'E-mail'
+      },
+      cities: {
+        label: 'Cidades',
+        name: 'cities',
+        type: 'select',
+        options: [
+          { label: 'Cidade 1', value: 1 },
+          { label: 'Cidade 2', value: 2 },
+          { label: 'Cidade 3', value: 3 }
+        ]
+      }
+    }
+  },
+
+  formCommonColumns: { col: 4 },
+  useInlineActions: true,
+  useSingleLabel: true,
+  useHeader: false
+}
+
+</script>

--- a/docs/src/pages/components/nested-fields.md
+++ b/docs/src/pages/components/nested-fields.md
@@ -68,7 +68,13 @@ A propriedade `useDestroyAlways` caso não seja repassada ao componente, assume 
 <doc-example file="QasNestedFields/Basic" title="Básico" />
 <doc-example file="QasNestedFields/NestedFieldsWithHeaderProps" title="Header personalizável" />
 <doc-example file="QasNestedFields/CallbackFields" title="Propriedades fieldsHandlerFn e fieldsProps com função de callback" />
+
+:::tip
+Opte por usar o `use-single-label` apenas quando utilizar o `use-inline-actions`.
+:::
 <doc-example file="QasNestedFields/ExSingleLabel" title="Label única" />
+<doc-example file="QasNestedFields/SingleLabelAndNotHeader" title="Label única e sem header em todas as linhas" />
+
 <doc-example file="QasNestedFields/StartsEmptyFalse" title="Começando com formulário" />
 <doc-example file="QasNestedFields/DisabledRowsArray" title="Linhas desabilitadas com um array de uuids" />
 <doc-example file="QasNestedFields/DisabledRowsFunction" title="Linhas desabilitadas com uma função de callback" />

--- a/ui/src/components/nested-fields/QasNestedFields.vue
+++ b/ui/src/components/nested-fields/QasNestedFields.vue
@@ -223,6 +223,11 @@ export default {
       default: true
     },
 
+    useHeader: {
+      type: Boolean,
+      default: true
+    },
+
     useIndexLabel: {
       type: Boolean
     },
@@ -541,7 +546,7 @@ export default {
     },
 
     hasHeader ({ row }) {
-      return this.hasBlockActions(row) || !this.useSingleLabel
+      return (this.hasBlockActions(row) || !this.useSingleLabel) && this.useHeader
     },
 
     getHeaderProps ({ index, row }) {

--- a/ui/src/components/nested-fields/QasNestedFields.yml
+++ b/ui/src/components/nested-fields/QasNestedFields.yml
@@ -169,6 +169,11 @@ props:
     default: true
     type: Boolean
 
+  use-header:
+    desc: Controla se vai ter um header em cada linha.
+    default: true
+    type: Boolean
+
   use-index-label:
     desc: Se tiver "rowLabel" esta prop controla se cada label da linha vai ter o index como sufixo.
     type: Boolean

--- a/ui/src/components/numeric-input/QasNumericInput.vue
+++ b/ui/src/components/numeric-input/QasNumericInput.vue
@@ -1,7 +1,7 @@
 <template>
   <q-field class="qas-numeric-input" :class="classes" dense :label="formattedLabel" :model-value="modelValue" no-error-icon>
-    <template #control="{ floatingLabel, id, editable }">
-      <input v-show="floatingLabel" :id="id" ref="input" class="q-field__input" :disabled="!editable" inputmode="numeric" :placeholder @blur="emitValue" @click="setSelect" @input="emitUpdateModel($event.target.value)">
+    <template #control="{ floatingLabel, id }">
+      <input v-show="floatingLabel" :id="id" ref="input" class="q-field__input" :disabled="$attrs.disable" inputmode="numeric" :placeholder :readonly="$attrs.readonly" @blur="emitValue" @click="setSelect" @input="emitUpdateModel($event.target.value)">
     </template>
 
     <template v-if="icon" #append>

--- a/ui/src/components/select-list-dialog/QasSelectListDialog.vue
+++ b/ui/src/components/select-list-dialog/QasSelectListDialog.vue
@@ -232,7 +232,7 @@ function useList () {
   /**
    * Valida se tenho opções ou se está carregando para mostrar o container da listagem.
    */
-  const canShowContainerList = computed(() => hasFilteredOptions.value || props.loading)
+  const canShowContainerList = computed(() => hasFilteredOptions.value || props.loading || !!slots.content)
   const hasFilteredOptions = computed(() => model.value.length)
 
   /*

--- a/ui/src/components/select-list-dialog/QasSelectListDialog.vue
+++ b/ui/src/components/select-list-dialog/QasSelectListDialog.vue
@@ -1,20 +1,6 @@
 <template>
   <div class="app-select-list-dialog full-width">
-    <header class="flex items-center justify-between no-wrap">
-      <qas-label v-bind="labelProps" />
-
-      <qas-btn
-        v-bind="defaultAddButtonProps"
-        @click="toggleDialog"
-      />
-    </header>
-
-    <div
-      v-if="props.description"
-      class="q-mt-md text-body1 text-grey-8"
-    >
-      {{ props.description }}
-    </div>
+    <qas-header v-bind="headerProps" />
 
     <component
       :is="containerListComponent"
@@ -25,17 +11,19 @@
         {{ props.listLabel }}
       </span>
 
-      <q-virtual-scroll #default="{ item, index }" class="app-select-list-dialog__list q-mt-md" :items="selectedOptions" separator>
-        <q-item class="q-px-none text-body1 text-grey-8">
-          <q-item-section>
-            {{ item.label }}
-          </q-item-section>
+      <slot name="content">
+        <q-virtual-scroll #default="{ item, index }" class="app-select-list-dialog__list q-mt-md" :items="selectedOptions" separator>
+          <q-item class="q-px-none text-body1 text-grey-8">
+            <q-item-section>
+              {{ item.label }}
+            </q-item-section>
 
-          <q-item-section avatar>
-            <qas-btn v-bind="getRemoveButtonProps({ index, option: item })" />
-          </q-item-section>
-        </q-item>
-      </q-virtual-scroll>
+            <q-item-section avatar>
+              <qas-btn v-bind="getRemoveButtonProps({ index, option: item })" />
+            </q-item-section>
+          </q-item>
+        </q-virtual-scroll>
+      </slot>
 
       <q-inner-loading :showing="props.loading">
         <q-spinner
@@ -140,16 +128,16 @@ const props = defineProps({
   }
 })
 
+// emits
 const emit = defineEmits(['add', 'remove', 'update:modelValue'])
 
+// slots
 const slots = useSlots()
 
+// globals
 const isBox = inject('isBox', false)
 
-const hasError = computed(() => Array.isArray(props.error) ? !!props.error.length : !!props.error)
-const errorMessage = computed(() => Array.isArray(props.error) ? props.error.join(' ') : props.error)
-const containerListComponent = computed(() => isBox ? 'div' : 'qas-box')
-
+// composables
 const {
   listModel,
   showDialog,
@@ -172,25 +160,37 @@ const {
   getRemoveButtonProps
 } = useList()
 
+// expose
 defineExpose({ add, removeAll, remove })
 
+// refs
 const model = ref([...props.modelValue])
 
-const defaultAddButtonProps = computed(() => {
-  return {
-    icon: 'sym_r_add',
-    useLabelOnSmallScreen: false,
-    ...props.addButtonProps,
-    disable: props.disable,
-    loading: props.loading
-  }
-})
+// computeds
+const hasError = computed(() => Array.isArray(props.error) ? !!props.error.length : !!props.error)
+const errorMessage = computed(() => Array.isArray(props.error) ? props.error.join(' ') : props.error)
+const containerListComponent = computed(() => isBox ? 'div' : 'qas-box')
 
-const labelProps = computed(() => {
+const headerProps = computed(() => {
   return {
-    label: props.label,
-    margin: 'none',
-    color: hasError.value ? 'negative' : 'grey-10'
+    labelProps: {
+      label: props.label,
+      margin: 'none',
+      color: hasError.value ? 'negative' : 'grey-10'
+    },
+
+    description: props.description,
+
+    buttonProps: {
+      icon: 'sym_r_add',
+      useLabelOnSmallScreen: false,
+      ...props.addButtonProps,
+      disable: props.disable,
+      loading: props.loading,
+
+      // events
+      onClick: toggleDialog
+    }
   }
 })
 
@@ -202,6 +202,7 @@ watch(() => props.modelValue, newValue => {
   model.value = [...newValue]
 })
 
+// functions
 function updateModel () {
   emit('update:modelValue', model.value)
 }

--- a/ui/src/components/select-list-dialog/QasSelectListDialog.yml
+++ b/ui/src/components/select-list-dialog/QasSelectListDialog.yml
@@ -66,6 +66,9 @@ props:
     type: Boolean
 
 slots:
+  content:
+    desc: Slot para personalizar o conteúdo dos itens adicionados.
+
   dialog-actions:
     desc: Slot para substituir ações do dialog.
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->


## Não publicado
### Adicionado
- `QasNestedFields`: Adicionado nova prop `use-header` para controlar quando irá ter ou não o header em cada linha.
- `QasSelectListDialog`: Adicionado novo slot `content` para poder personalizar todos os itens adicionados.

### Modificado
- `QasSelectListDialog`: Modificado header para utilizar o componente `QasHeader`.
- `QasNumericInput`: Alterado input para aplicar estilo tanto de `readonly` quanto de `disabled`, sendo que antes só aplicava `disabled` mesmo quando enviasse a prop `readonly`.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [ ] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [ ] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [ ] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [ ] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [ ] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [ ] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [ ] Foi atualizada e testada a documentação;
- [ ] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [ ] Fiz meu próprio _code review_ antes de abrir este _pull request_.
