### PR TITLE
`QasAlert`: Modificado comportamento para não ter box quando estivar dentro de um dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 
 ## Não publicado
 ### Modificado
-- `QasAlert`: Modificado comportamento para não ter box quando estivar dentro de um `QasDialog`.
+- `QasAlert`: Modificado comportamento para não ter box quando estiver dentro de um `QasDialog`.
 
 ## [3.19.0-beta.0] - 11-07-2025
 ## BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `QasAlert`: Modificado comportamento para não ter box quando estivar dentro de um `QasDialog`.
+
 ## [3.19.0-beta.0] - 11-07-2025
 ## BREAKING CHANGES
 - Todos locais que usarem component dinâmico `<component :is="QasBtn" />` do asteroid, precisa ser importado do asteroid `import { QasBtn } from 'asteroid'`, porque o auto import não consegue identificar o componente sozinho.

--- a/docs/src/examples/QasAlert/InsideDialog.vue
+++ b/docs/src/examples/QasAlert/InsideDialog.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="container q-py-lg">
+    <qas-btn label="Abrir dialog" @click="openDialog" />
+
+    <qas-dialog v-model="showDialog">
+      <template #description>
+        <div class="q-mb-md">
+          Texto de descrição dentro do dialog
+        </div>
+
+        <qas-alert v-bind="alertProps" />
+      </template>
+    </qas-dialog>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+defineOptions({ name: 'InsideDialog' })
+
+// refs
+const showDialog = ref(false)
+
+// consts
+const alertProps = {
+  buttonProps: {
+    onClick: () => alert('Button clicked')
+  },
+
+  text: 'Usuário incompleto, [clique aqui] para completar.',
+
+  useRegex: true
+}
+
+// functions
+const openDialog = () => {
+  showDialog.value = true
+}
+</script>

--- a/docs/src/pages/components/alert.md
+++ b/docs/src/pages/components/alert.md
@@ -18,9 +18,10 @@ Componente para informações.
 <doc-example file="QasAlert/Basic" title="Básico" />
 
 :::info
-- Quando o componente é chamado dentro de um QasBox ele automaticamente fica sem box, para não ter box dentro de box.
+- Quando o componente é chamado dentro de um QasBox ou QasDialog ele automaticamente fica sem box, para não ter box dentro de box.
 - É possível configurar manualmente a prop "useBox", porém só use em casos muito específicos e quando realmente é necessário.
 :::
 <doc-example file="QasAlert/InsideBox" title="Dentro de box" />
+<doc-example file="QasAlert/InsideDialog" title="Dentro de dialog" />
 <doc-example file="QasAlert/Button" title="Com botão" />
 <doc-example file="QasAlert/ExternalLink" title="Link externo" />

--- a/ui/src/components/alert/QasAlert.vue
+++ b/ui/src/components/alert/QasAlert.vue
@@ -89,6 +89,7 @@ const model = defineModel({ type: Boolean, default: true })
 
 // globals
 const isBox = inject('isBox', false)
+const isDialog = inject('isDialog', false)
 
 // composables
 const { displayAlert, close } = useStorageClosed()
@@ -106,13 +107,13 @@ const iconProps = computed(() => {
 })
 
 /**
- * Por padrão, quando este componente estiver dentro de um QasBox, ele não terá
+ * Por padrão, quando este componente estiver dentro de um QasBox | QasDialog, ele não terá
  * shadow, terá padding e não terá margin.
  */
 const defaultBoxProps = computed(() => {
   const hasBoxProps = props.useBox !== undefined
 
-  const useBox = hasBoxProps ? props.useBox : !isBox
+  const useBox = hasBoxProps ? props.useBox : !isBox && !isDialog
 
   return {
     unelevated: !useBox,

--- a/ui/src/components/alert/QasAlert.vue
+++ b/ui/src/components/alert/QasAlert.vue
@@ -113,6 +113,7 @@ const iconProps = computed(() => {
 const defaultBoxProps = computed(() => {
   const hasBoxProps = props.useBox !== undefined
 
+  // Se não tiver a prop useBox, assume que está dentro de um QasBox ou QasDialog
   const useBox = hasBoxProps ? props.useBox : !isBox && !isDialog
 
   return {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

### Modificado
- `QasAlert`: Modificado comportamento para não ter box quando estivar dentro de um `QasDialog`.

Closes #1288  

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
