### PR TITLE
`QasCard`: Alterado para ter bordas quando estiver dentro de um dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 
+## Não publicado
+### Modificado
+- `QasCard`: Modificado estilo do card para utilizar bordas ao invés de box quando estiver dentro de um `QasDialog`.
+
 ## [3.19.0-beta.0] - 11-07-2025
 ## BREAKING CHANGES
 - Todos locais que usarem component dinâmico `<component :is="QasBtn" />` do asteroid, precisa ser importado do asteroid `import { QasBtn } from 'asteroid'`, porque o auto import não consegue identificar o componente sozinho.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 
 ## Não publicado
 ### Modificado
-- `QasCard`: Modificado estilo do card para utilizar bordas ao invés de box quando estiver dentro de um `QasDialog`.
+- `QasCard`: Modificado estilo do card para utilizar bordas ao invés de box quando estiver dentro de um `QasDialog`. ([#1289](https://github.com/bildvitta/asteroid/issues/1289))
 
 ## [3.19.0-beta.2] - 01-08-2025 <!-- N/A -->
 ### Corrigido

--- a/docs/src/examples/QasCard/InsideDialog.vue
+++ b/docs/src/examples/QasCard/InsideDialog.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="container spaced">
+    <qas-btn
+      label="Abrir dialog"
+      @click="openDialog"
+    />
+
+    <qas-dialog v-model="showDialog">
+      <template #description>
+        <div class="q-mb-md">
+          Este exemplo de um QasCard dentro de um QasDialog.
+        </div>
+
+        <qas-card :route="{ name: 'Root' }" title="Titulo">
+          <template #default>
+            <div>
+              Meu conteúdo
+            </div>
+          </template>
+        </qas-card>
+      </template>
+    </qas-dialog>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+defineOptions({ name: 'InsideDialog' })
+
+// refs
+const showDialog = ref(false)
+
+// functions
+function openDialog () {
+  showDialog.value = true
+}
+</script>

--- a/docs/src/examples/QasCard/InsideDialog.vue
+++ b/docs/src/examples/QasCard/InsideDialog.vue
@@ -8,7 +8,7 @@
     <qas-dialog v-model="showDialog">
       <template #description>
         <div class="q-mb-md">
-          Este exemplo de um QasCard dentro de um QasDialog.
+          Este é um exemplo de um QasCard dentro de um QasDialog.
         </div>
 
         <qas-card :route="{ name: 'Root' }" title="Titulo">

--- a/docs/src/pages/components/card.md
+++ b/docs/src/pages/components/card.md
@@ -9,4 +9,5 @@ Componente de card.
 ## Uso
 
 <doc-example file="QasCard/Basic" title="Básico" />
-<doc-example file="QasCard/Box" title="Com box" />
+<doc-example file="QasCard/Box" title="Dentro de box" />
+<doc-example file="QasCard/InsideDialog" title="Dentro de dialog" />

--- a/ui/src/components/card/QasCard.vue
+++ b/ui/src/components/card/QasCard.vue
@@ -70,15 +70,21 @@ const props = defineProps({
 
 // consts
 const isInsideBox = inject('isBox', false)
+const isInsideDialog = inject('isDialog', false)
 
 // composables
 const slots = useSlots()
 
 // computeds
+/**
+ * Quando o card está dentro de um box ou dialog, ele terá bordas ao invés da box.
+ */
 const boxProps = computed(() => {
+  const useBorder = isInsideBox || isInsideDialog
+
   return {
-    outlined: isInsideBox,
-    unelevated: isInsideBox,
+    outlined: useBorder,
+    unelevated: useBorder,
 
     // Terá o padding vertical menor se for um card com status ou tiver o expansion.
     spacingY: (props.statusColor || hasExpansion.value) ? 'sm' : 'md',


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
### Modificado
- `QasCard`: Modificado estilo do card para utilizar bordas ao invés de box quando estiver dentro de um `QasDialog`.

Closes #1289

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
