### PR TITLE
Alterado token padrão do dateTime para ter `às` entre as date / horário

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 
 ## Não publicado
 ### Modificado
-- `dateTime | PvLayoutNotificationCard`: Alterado padrão de data para `"dd/MM/yyyy 'às' HH:mm:ss"` para melhorar a legibilidade.
+- `dateTime | PvLayoutNotificationCard`: Alterado padrão de data para `"dd/MM/yyyy 'às' HH:mm:ss"` para melhorar a legibilidade. #1294
 
 ## [3.19.0-beta.2] - 01-08-2025 <!-- N/A -->
 ### Corrigido

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+### Modificado
+- `dateTime | PvLayoutNotificationCard`: Alterado padrão de data para `"dd/MM/yyyy 'às' HH:mm:ss"` para melhorar a legibilidade.
+
 ## [3.19.0-beta.2] - 01-08-2025 <!-- N/A -->
 ### Corrigido
 `QasSelectListDialog`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,11 @@ Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não p
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
 ## Não publicado
+## BREAKING CHANGES
+- `dateTime`: Alguns lugares podem apresentar divergências na forma de exibição.
+
 ### Modificado
-- `dateTime | PvLayoutNotificationCard`: Alterado padrão de data para `"dd/MM/yyyy 'às' HH:mm:ss"` para melhorar a legibilidade. #1294
+- `dateTime | PvLayoutNotificationCard`: Alterado padrão de data para `"dd/MM/yyyy 'às' HH:mm:ss"` para melhorar a legibilidade. [#1294](https://github.com/bildvitta/asteroid/issues/1294)
 
 ## [3.19.0-beta.2] - 01-08-2025 <!-- N/A -->
 ### Corrigido

--- a/ui/src/components/layout/private/PvLayoutNotificationCard.vue
+++ b/ui/src/components/layout/private/PvLayoutNotificationCard.vue
@@ -64,7 +64,7 @@ const hasBadge = computed(() => isRecentNotification.value && !markedAsRead.valu
 const dateLabel = computed(() => {
   return isRecentNotification.value
     ? 'Agora mesmo'
-    : dateTime(props.notification.createdAt, 'dd/MM/yyyy HH:mm')
+    : dateTime(props.notification.createdAt)
 })
 
 const buttonProps = computed(() => {

--- a/ui/src/components/layout/private/PvLayoutNotificationCard.vue
+++ b/ui/src/components/layout/private/PvLayoutNotificationCard.vue
@@ -61,11 +61,7 @@ const isRecentNotification = computed(() => {
 
 const hasBadge = computed(() => isRecentNotification.value && !markedAsRead.value)
 
-const dateLabel = computed(() => {
-  return isRecentNotification.value
-    ? 'Agora mesmo'
-    : dateTime(props.notification.createdAt)
-})
+const dateLabel = computed(() => isRecentNotification.value ? 'Agora mesmo' : dateTime(props.notification.createdAt))
 
 const buttonProps = computed(() => {
   const { link } = props.notification

--- a/ui/src/helpers/filters.js
+++ b/ui/src/helpers/filters.js
@@ -23,7 +23,7 @@ function date (value, token = 'dd/MM/yyyy', options) {
   return __format(value, token, options)
 }
 
-function dateTime (value, token = 'dd/MM/yyyy HH:mm:ss', options) {
+function dateTime (value, token = "dd/MM/yyyy 'às' HH:mm:ss", options) {
   return __format(value, token, options)
 }
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
### Modificado
- `dateTime | PvLayoutNotificationCard`: Alterado padrão de data para `"dd/MM/yyyy 'às' HH:mm:ss"` para melhorar a legibilidade.
<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

closes #1294 

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [x] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
