### PR TITLE
feat: fix reports-filters/actions-menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+### Corrigido
+- `QasActionsMenu`: corrigido alinhamento quando está dentro de outro container, como por exemplo o `QasPageHeader`. [[#1337](https://github.com/bildvitta/asteroid/issues/1337)]
+- `QasReportsFilters`: corrigido imports dos componentes internos.
+
 ## [3.19.0-beta.4] - 28-08-2025
 ## BREAKING CHANGE
 - [`QasFormGenerator`, `QasGridGenerator`]: lógicas de fieldset/subset adicionadas no composable `useGenerator`, validar se nada quebra.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 
 ## Não publicado
 ### Corrigido
-- `QasActionsMenu`: corrigido alinhamento quando está dentro de outro container, como por exemplo o `QasPageHeader`. [[#1337](https://github.com/bildvitta/asteroid/issues/1337)]
+- `QasActionsMenu`: corrigido alinhamento quando está dentro de outro container, como por exemplo o `QasPageHeader`. ([#1337](https://github.com/bildvitta/asteroid/issues/1337))
 - `QasReportsFilters`: corrigido imports dos componentes internos.
 
 ## [3.19.0-beta.4] - 28-08-2025
@@ -24,7 +24,7 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 - [`QasFormGenerator`, `QasGridGenerator`]: lógicas de fieldset/subset adicionadas no composable `useGenerator`, validar se nada quebra.
 
 ### Adicionado
-- `QasGridGenerator`: [[#1325](https://github.com/bildvitta/asteroid/issues/1325)]
+- `QasGridGenerator`: ([#1325](https://github.com/bildvitta/asteroid/issues/1325))
  - Adicionado opção de separador entre fieldset ou subset.
  - Adicionado opção de tip nos títulos dos campos através do fieldsProps.
  - Adicionado opção de alterar a tipografia do valor do campos através do fieldsProps.
@@ -32,7 +32,7 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 - `QasToolTip`: Adicionado componente de tooltip.
 
 ### Corrigido
-- `QasGridGenerator`: Correção de espaçamento do gutter quando modo `useInline: true`. [[#1325](https://github.com/bildvitta/asteroid/issues/1325)]
+- `QasGridGenerator`: Correção de espaçamento do gutter quando modo `useInline: true`. ([#1325](https://github.com/bildvitta/asteroid/issues/1325))
 - `QasFormGenerator`: gutter entre subsets agora é `md`.
 
 ### Modificado
@@ -62,7 +62,7 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
   - Corrigido nome do slot para exibição do botão de filtrar, sendo o correto `actions`.
 
 ### Modificado
-- `QasAlert`: Modificado comportamento para não ter box quando estiver dentro de um `QasDialog`. [[#1288](https://github.com/bildvitta/asteroid/issues/1288)]
+- `QasAlert`: Modificado comportamento para não ter box quando estiver dentro de um `QasDialog`. ([#1288](https://github.com/bildvitta/asteroid/issues/1288))
 - `QasTableGenerator`: Alterado cor do título da coluna (th) para o `grey-10`. ([#1287](https://github.com/bildvitta/asteroid/issues/1287))
 - `dateTime | PvLayoutNotificationCard`: Alterado padrão de data para `"dd/MM/yyyy 'às' HH:mm:ss"` para melhorar a legibilidade. ([#1294](https://github.com/bildvitta/asteroid/issues/1294))
 - `QasCard`: Modificado estilo do card para utilizar bordas ao invés de box quando estiver dentro de um `QasDialog`. ([#1289](https://github.com/bildvitta/asteroid/issues/1289))

--- a/docs/src/examples/QasCard/Basic.vue
+++ b/docs/src/examples/QasCard/Basic.vue
@@ -23,8 +23,8 @@
 
       <div class="col-4">
         <qas-card
-          :actions-menu-props="actionsMenuProps" :expansion-props="expansionProps" :route="{ name: 'Root' }"
-          status-color="red-14" title="Titulo" use-expansion
+          :actions-menu-props="actionsMenuProps" :expansion-props="expansionProps"
+          :route="{ name: 'Root' }" status-color="red-14" title="Titulo" use-expansion
         >
           <template #default>
             <div>
@@ -42,14 +42,16 @@ export default {
   computed: {
     actionsMenuProps () {
       return {
-        show: {
-          label: 'Ir para detalhes',
-          icon: 'sym_r_visibility'
-        },
+        list: {
+          show: {
+            label: 'Ir para detalhes',
+            icon: 'sym_r_visibility'
+          },
 
-        edit: {
-          label: 'Editar',
-          icon: 'sym_r_edit'
+          edit: {
+            label: 'Editar',
+            icon: 'sym_r_edit'
+          }
         }
       }
     },

--- a/docs/src/examples/QasInput/Textarea.vue
+++ b/docs/src/examples/QasInput/Textarea.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container q-col-gutter-2xl q-py-lg row">
+  <div class="container q-col-gutter-sm q-py-lg row">
     <div class="col-4">
       <qas-input v-model="model" counter label="Meu input" :maxlength="30" />
     </div>

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="hasList" class="qas-actions-menu" data-cy="actions-menu">
+  <div v-if="hasList" class="flex qas-actions-menu" data-cy="actions-menu">
     <qas-btn-dropdown v-bind="btnDropdownProps" v-model:menu="menuModel">
       <q-list v-if="hasDropdownLength" data-cy="actions-menu-list">
         <slot v-for="(item, key) in formattedList.dropdownList" :item="item" :name="key">

--- a/ui/src/components/reports-filters/QasReportsFilters.vue
+++ b/ui/src/components/reports-filters/QasReportsFilters.vue
@@ -45,6 +45,12 @@
 </template>
 
 <script setup>
+import QasBox from '../box/QasBox.vue'
+import QasHeader from '../header/QasHeader.vue'
+import QasFormGenerator from '../form-generator/QasFormGenerator.vue'
+import QasActions from '../actions/QasActions.vue'
+import QasBtn from '../btn/QasBtn.vue'
+
 import { parseValue, promiseHandler, camelizeFieldsName } from '../../helpers'
 import { useContext } from '../../composables'
 


### PR DESCRIPTION
### Corrigido
- `QasActionsMenu`: corrigido alinhamento quando está dentro de outro container, como por exemplo o `QasPageHeader`. [[#1337](https://github.com/bildvitta/asteroid/issues/1337)]
- `QasReportsFilters`: corrigido imports dos componentes internos.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
