### PR TITLE
Ajuste na validação do `QasActions`

### DIFF
--- a/ui/src/components/actions/QasActions.vue
+++ b/ui/src/components/actions/QasActions.vue
@@ -100,9 +100,9 @@ const hasPrimarySlot = computed(() => !!slots.primary)
 const hasSecondarySlot = computed(() => !!slots.secondary)
 const hasTertiarySlot = computed(() => !!slots.tertiary)
 
-const hasPrimaryButton = computed(() => hasPrimarySlot.value || props.primaryButtonProps)
-const hasSecondaryButton = computed(() => hasSecondarySlot.value || props.secondaryButtonProps)
-const hasTertiaryButton = computed(() => hasTertiarySlot.value || props.tertiaryButtonProps)
+const hasPrimaryButton = computed(() => hasPrimarySlot.value || Object.keys(props.primaryButtonProps).length)
+const hasSecondaryButton = computed(() => hasSecondarySlot.value || Object.keys(props.secondaryButtonProps).length)
+const hasTertiaryButton = computed(() => hasTertiarySlot.value || Object.keys(props.tertiaryButtonProps).length)
 
 const formattedButtonsProps = computed(() => {
   return {


### PR DESCRIPTION
- Ajuste na validação do `QasActions`

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [ ] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
