### PR TITLE
`QasStepper`: Opção para uso na vertical e ajustes na exibição das linhas de done/active (padronizado DS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 ### Adicionado
 - `QasActions`: adicionado possibilidade de passar props dos botões sem necessariamente precisar abrir slot. ([#1332](https://github.com/bildvitta/asteroid/issues/1332))
 - `QasInfiniteScroll`: adicionado função `fetchList` no expose. ([#1315](https://github.com/bildvitta/asteroid/issues/1315))
-- `QasStepper`: Adicionado prop `useVertical` para ter possibilidade de utilizá-lo na vertical.
+- `QasStepper`:
+  - Adicionado prop `useVertical` para ter possibilidade de utilizá-lo na vertical.
+  - Adicionado prop `headerNav` (substituído o attrs) para controle de navegação entre as steps.
 
 ### Modificado
 - `QasStepper`: Modificado exibição da cor primária nas linhas de cada step.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 ### Adicionado
 - `QasActions`: adicionado possibilidade de passar props dos botões sem necessariamente precisar abrir slot. ([#1332](https://github.com/bildvitta/asteroid/issues/1332))
 - `QasInfiniteScroll`: adicionado função `fetchList` no expose. ([#1315](https://github.com/bildvitta/asteroid/issues/1315))
+- `QasStepper`: Adicionado prop `useVertical` para ter possibilidade de utilizá-lo na vertical.
+
+### Modificado
+- `QasStepper`: Modificado cor da linha do primeiro stepper (do primeiro até o segundo) não ser `primary` quando não estiver finalizado.
 
 ## [3.19.0-beta.5] - 29-08-2025
 ### Corrigido

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 - `QasStepper`: Adicionado prop `useVertical` para ter possibilidade de utilizá-lo na vertical.
 
 ### Modificado
-- `QasStepper`: Modificado cor da linha do primeiro stepper (do primeiro até o segundo) não ser `primary` quando não estiver finalizado.
+- `QasStepper`: Modificado exibição da cor primária nas linhas de cada step.
 
 ## [3.19.0-beta.5] - 29-08-2025
 ### Corrigido

--- a/docs/src/examples/QasStepper/StepperWithError.vue
+++ b/docs/src/examples/QasStepper/StepperWithError.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container spaced">
-    <qas-stepper v-model="model" :header-nav="true">
+    <qas-stepper v-model="model" header-nav>
       <template #default="{ next, previous }">
         <q-step caption="example 1" :done="model > 1" icon="sym_r_article" :name="1" title="Página 1">
           <div class="q-mb-md">Conteúdo da Página 1</div>
@@ -19,8 +19,26 @@
           </div>
         </q-step>
 
-        <q-step caption="example 3" icon="sym_r_news" :name="3" title="Página 3">
+        <q-step caption="example 3" disable :done="model > 3" icon="sym_r_news" :name="3" title="Página 3">
           <div class="q-mb-md">Conteúdo da Página 3</div>
+
+          <div class="column items-start q-gutter-sm">
+            <qas-btn label="Voltar" @click="previous" />
+            <qas-btn label="Próximo" @click="next" />
+          </div>
+        </q-step>
+
+        <q-step caption="example 4" :done="model > 4" icon="sym_r_event" :name="4" title="Página 4">
+          <div class="q-mb-md">Conteúdo da Página 4</div>
+
+          <div class="column items-start q-gutter-sm">
+            <qas-btn label="Voltar" @click="previous" />
+            <qas-btn label="Próximo" @click="next" />
+          </div>
+        </q-step>
+
+        <q-step caption="example 5" :done="model > 5" icon="sym_r_check_circle" :name="5" title="Página 5">
+          <div class="q-mb-md">Conteúdo da Página 5</div>
 
           <div class="column items-start q-gutter-sm">
             <qas-btn label="Voltar" @click="previous" />

--- a/docs/src/examples/QasStepper/StepperWithError.vue
+++ b/docs/src/examples/QasStepper/StepperWithError.vue
@@ -24,6 +24,7 @@
 
           <div class="column items-start q-gutter-sm">
             <qas-btn label="Voltar" @click="previous" />
+
             <qas-btn label="Próximo" @click="next" />
           </div>
         </q-step>
@@ -33,6 +34,7 @@
 
           <div class="column items-start q-gutter-sm">
             <qas-btn label="Voltar" @click="previous" />
+
             <qas-btn label="Próximo" @click="next" />
           </div>
         </q-step>

--- a/docs/src/examples/QasStepper/Vertical.vue
+++ b/docs/src/examples/QasStepper/Vertical.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="container spaced">
-    <qas-stepper v-model="model">
+    <qas-stepper v-model="model" use-vertical>
       <template #default="{ next, previous }">
-        <q-step caption="example 1" :done="model > 1" icon="sym_r_article" :name="1" title="Página 1">
+        <q-step :done="model > 1" :name="1" prefix="1" title="Página 1">
           <div class="q-mb-md">Conteúdo da Página 1</div>
 
           <div class="column items-start q-gutter-sm">
@@ -10,7 +10,7 @@
           </div>
         </q-step>
 
-        <q-step caption="example 2" :done="model > 2" icon="sym_r_description" :name="2" title="Página 2">
+        <q-step :done="model > 2" :name="2" prefix="2" title="Página 2">
           <div class="q-mb-md">Conteúdo da Página 2</div>
 
           <div class="column items-start q-gutter-sm">
@@ -19,7 +19,7 @@
           </div>
         </q-step>
 
-        <q-step caption="example 3" icon="sym_r_news" :name="3" title="Página 3">
+        <q-step :name="3" prefix="3" title="Página 3">
           <div class="q-mb-md">Conteúdo da Página 3</div>
 
           <div class="column items-start q-gutter-sm">
@@ -34,7 +34,8 @@
 <script setup>
 import { ref } from 'vue'
 
-defineOptions({ name: 'Basic' })
+defineOptions({ name: 'Vertical' })
 
-const model = ref(2)
+// models
+const model = ref(1)
 </script>

--- a/docs/src/examples/QasStepper/Vertical.vue
+++ b/docs/src/examples/QasStepper/Vertical.vue
@@ -15,6 +15,7 @@
 
           <div class="column items-start q-gutter-sm">
             <qas-btn label="Voltar" @click="previous" />
+
             <qas-btn label="Próximo" @click="next" />
           </div>
         </q-step>

--- a/docs/src/pages/components/stepper.md
+++ b/docs/src/pages/components/stepper.md
@@ -12,6 +12,6 @@ Componente wrapper do [QStepper](https://quasar.dev/vue-components/stepper#qstep
 
 <doc-example file="QasStepper/Vertical" title="Vertical" />
 
-<doc-example file="QasStepper/StepperWithIcon" title="Com ícone e desabilitado" />
+<doc-example file="QasStepper/StepperWithIcon" title="Com ícone" />
 
 <doc-example file="QasStepper/StepperWithError" title="Com erro e header navegável" />

--- a/docs/src/pages/components/stepper.md
+++ b/docs/src/pages/components/stepper.md
@@ -10,6 +10,8 @@ Componente wrapper do [QStepper](https://quasar.dev/vue-components/stepper#qstep
 
 <doc-example file="QasStepper/Basic" title="Básico" />
 
-<doc-example file="QasStepper/StepperWithIcon" title="Com ícone" />
+<doc-example file="QasStepper/Vertical" title="Vertical" />
+
+<doc-example file="QasStepper/StepperWithIcon" title="Com ícone e desabilitado" />
 
 <doc-example file="QasStepper/StepperWithError" title="Com erro e header navegável" />

--- a/ui/src/components/stepper/QasStepper.vue
+++ b/ui/src/components/stepper/QasStepper.vue
@@ -121,6 +121,12 @@ function previous () {
       color: $grey-6;
     }
 
+    &__title,
+    &__caption,
+    &__dot {
+      transition: var(--qas-generic-transition);
+    }
+
     &__tab {
       padding: 0;
 
@@ -139,13 +145,28 @@ function previous () {
         cursor: not-allowed;
       }
 
-      &:not(.q-stepper__tab--active).q-stepper__tab--error-with-icon  {
+      &--navigation:hover {
+        .q-stepper__dot {
+          background-color: var(--q-primary-contrast) !important;
+        }
+
+        .q-stepper {
+          &__caption,
+          &__title {
+            color: var(--q-primary-contrast) !important;
+          }
+        }
+      }
+
+      &:not(.q-stepper__tab--active).q-stepper__tab--error-with-icon {
         .q-stepper__title {
           color: $grey-10;
         }
 
-        .q-stepper__dot {
-          background-color: $negative !important;
+        &:not(.q-stepper__tab--navigation:hover) {
+          .q-stepper__dot {
+            background-color: $negative !important;
+          }
         }
 
         .q-icon {

--- a/ui/src/components/stepper/QasStepper.vue
+++ b/ui/src/components/stepper/QasStepper.vue
@@ -21,6 +21,10 @@ const props = defineProps({
     type: Boolean
   },
 
+  headerNav: {
+    type: Boolean
+  },
+
   modelValue: {
     type: [String, Number],
     default: 0
@@ -69,7 +73,8 @@ const stepperProps = computed(() => {
     errorIcon: 'sym_r_close',
     errorColor: 'white',
     headerClass: `text-subtitle1 q-pb-${props.spacing}`,
-    inactiveColor: attrs['header-nav'] || (attrs.headerNav || attrs['header-nav'] === '') ? 'grey-10' : 'grey-6',
+    headerNav: props.headerNav,
+    inactiveColor: props.headerNav ? 'grey-10' : 'grey-6',
     vertical: props.useVertical
   }
 
@@ -118,6 +123,7 @@ function previous () {
 
     &__caption {
       @include set-typography($caption);
+
       color: $grey-6;
     }
 
@@ -217,8 +223,7 @@ function previous () {
               }
             }
 
-            // Quando a step está finalizada e é a primeira, seta a cor no after da linha
-            // Quando a step está finalizada e a próxima é ativa, seta a cor no after da linha.
+            // Seta a cor do after da linha quando a step está finalizada, é a primeira step ou a próxima é ativa.
             &:first-child,
             &:has(+ .q-stepper__tab.q-stepper__tab--active) {
               .q-stepper__line::after {

--- a/ui/src/components/stepper/QasStepper.vue
+++ b/ui/src/components/stepper/QasStepper.vue
@@ -182,15 +182,27 @@ function previous () {
       .q-stepper {
         &__tab {
           &--done {
-            .q-stepper__line::after,
-            .q-stepper__line::before {
-              background-color: var(--q-primary);
+            // Quando a step está finalizada e a próxima é ativa, seta a cor no before da linha.
+            & + .q-stepper__tab--active {
+              .q-stepper__line::before {
+                background-color: var(--q-primary);
+              }
             }
-          }
 
-          & + .q-stepper__tab--active {
-            .q-stepper__line::before {
-              background-color: var(--q-primary);
+            // Quando a step está finalizada e a próxima também está finalizada, seta a cor no before da linha.
+            & + .q-stepper__tab--done {
+              .q-stepper__line::before {
+                background-color: var(--q-primary);
+              }
+            }
+
+            // Quando a step está finalizada e é a primeira, seta a cor no after da linha
+            // Quando a step está finalizada e a próxima é ativa, seta a cor no after da linha.
+            &:first-child,
+            &:has(+ .q-stepper__tab.q-stepper__tab--active) {
+              .q-stepper__line::after {
+                 background-color: var(--q-primary);
+              }
             }
           }
         }
@@ -198,9 +210,9 @@ function previous () {
     }
 
     &--vertical {
-      .q-stepper {
-        padding: 0;
+      padding: 0;
 
+      .q-stepper {
         &__dot {
           margin-right: var(--qas-spacing-md);
         }

--- a/ui/src/components/stepper/QasStepper.vue
+++ b/ui/src/components/stepper/QasStepper.vue
@@ -30,6 +30,10 @@ const props = defineProps({
     default: Spacing.Lg,
     type: [String, Boolean],
     validator: gutterValidator
+  },
+
+  useVertical: {
+    type: Boolean
   }
 })
 
@@ -65,7 +69,8 @@ const stepperProps = computed(() => {
     errorIcon: 'sym_r_close',
     errorColor: 'white',
     headerClass: `text-subtitle1 q-pb-${props.spacing}`,
-    inactiveColor: attrs['header-nav'] || attrs.headerNav ? 'grey-10' : 'grey-6'
+    inactiveColor: attrs['header-nav'] || (attrs.headerNav || attrs['header-nav'] === '') ? 'grey-10' : 'grey-6',
+    vertical: props.useVertical
   }
 
   return {
@@ -107,6 +112,15 @@ function previous () {
   .q-stepper {
     background-color: transparent;
 
+    &__title {
+      @include set-typography($subtitle2);
+    }
+
+    &__caption {
+      @include set-typography($caption);
+      color: $grey-6;
+    }
+
     &__tab {
       padding: 0;
 
@@ -119,6 +133,10 @@ function previous () {
         .q-stepper__dot {
           background-color: var(--q-primary) !important;
         }
+      }
+
+      &--disabled {
+        cursor: not-allowed;
       }
 
       &:not(.q-stepper__tab--active).q-stepper__tab--error-with-icon  {
@@ -136,9 +154,65 @@ function previous () {
       }
     }
 
-    &__caption {
-      @include set-typography($caption);
-      color: $grey-6;
+    &__header {
+      &--standard-labels .q-stepper__tab {
+        min-height: auto;
+      }
+
+      &--contracted {
+        .q-stepper__tab:first-child .q-stepper__dot,
+        .q-stepper__tab:last-child .q-stepper__dot {
+          transform: translateX(0);
+        }
+      }
+    }
+
+    &__nav,
+    &__step-inner {
+      padding: 0;
+    }
+
+    &--horizontal {
+      .q-stepper__line::before,
+      .q-stepper__line::after {
+        height: 4px;
+        border-radius: var(--qas-generic-border-radius);
+      }
+
+      .q-stepper {
+        &__tab {
+          &--done {
+            .q-stepper__line::after,
+            .q-stepper__line::before {
+              background-color: var(--q-primary);
+            }
+          }
+
+          & + .q-stepper__tab--active {
+            .q-stepper__line::before {
+              background-color: var(--q-primary);
+            }
+          }
+        }
+      }
+    }
+
+    &--vertical {
+      .q-stepper {
+        padding: 0;
+
+        &__dot {
+          margin-right: var(--qas-spacing-md);
+        }
+
+        &__tab {
+          padding: var(--qas-spacing-sm) 0;
+        }
+
+        &__step-inner {
+          padding: var(--qas-spacing-sm) var(--qas-spacing-2xl) var(--qas-spacing-md);
+        }
+      }
     }
   }
 
@@ -154,42 +228,6 @@ function previous () {
         background-color: $grey-6 !important;
       }
     }
-  }
-
-  .q-stepper--horizontal .q-stepper__line::before,
-  .q-stepper--horizontal .q-stepper__line::after {
-    height: 4px;
-    border-radius: var(--qas-generic-border-radius);
-  }
-
-  .q-stepper__header--standard-labels .q-stepper__tab {
-    min-height: auto;
-  }
-
-  .q-stepper__tab:nth-child(1),
-  .q-stepper__tab--done {
-
-    .q-stepper__line::after,
-    .q-stepper__line::before {
-      background-color: var(--q-primary);
-    }
-  }
-
-  .q-stepper__tab:nth-child(2),
-  .q-stepper__tab--active {
-    .q-stepper__line::before {
-      background-color: var(--q-primary);
-    }
-  }
-
-  .q-stepper__nav,
-  .q-stepper__step-inner {
-    padding: 0;
-  }
-
-  .q-stepper__header--contracted .q-stepper__tab:first-child .q-stepper__dot,
-  .q-stepper__header--contracted .q-stepper__tab:last-child .q-stepper__dot {
-    transform: translateX(0);
   }
 
   .q-focus-helper {

--- a/ui/src/components/stepper/QasStepper.yml
+++ b/ui/src/components/stepper/QasStepper.yml
@@ -20,6 +20,11 @@ props:
     model: true
     type: [Number, String]
 
+  use-vertical:
+    desc: Define se o stepper deve ser exibido na vertical.
+    default: false
+    type: Boolean
+
 events:
   '@update:model-value -> function(value)':
     desc: Dispara quando o model-value altera, também usado para v-model.

--- a/ui/src/components/stepper/QasStepper.yml
+++ b/ui/src/components/stepper/QasStepper.yml
@@ -9,6 +9,11 @@ props:
     default: false
     type: Boolean
 
+  header-nav:
+    desc: Define se o stepper terá navegação no cabeçalho.
+    default: false
+    type: Boolean
+
   spacing:
     desc: Espaçamento entre o stepper e o conteúdo da página.
     default: lg


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

### Adicionado
- `QasStepper`: Adicionado prop `useVertical` para ter possibilidade de utilizá-lo na vertical.

### Modificado
- `QasStepper`: Modificado exibição da cor primária nas linhas de cada step.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [x] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
