### PR TITLE
`QasSelect | item.scss`: Corrigido cor de foco na opção quando utilizado teclado

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+### Corrigido
+- `QasSelect`: Corrigido cor de foco nas opções durante a navegação com teclado (teclas de seta para cima/baixo).
+
 ## [3.19.0-beta.7] - 26-09-2025
 ## BREAKING CHANGES
 - Rever lugares que utilizam lazy loading nos campos, pois pode gerar breaking changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 ## Não publicado
 ### Corrigido
 - `QasSelect`: Corrigido cor de foco nas opções durante a navegação com teclado (teclas de seta para cima/baixo).
+- `QasNumericInput`: Corrigido foco do campo, pois quando utilizado via tab, o campo não focava.
 
 ## [3.19.0-beta.7] - 26-09-2025
 ## BREAKING CHANGES

--- a/ui/src/components/numeric-input/QasNumericInput.vue
+++ b/ui/src/components/numeric-input/QasNumericInput.vue
@@ -1,7 +1,7 @@
 <template>
   <q-field class="qas-numeric-input" :class="classes" dense :label="formattedLabel" :model-value="modelValue" no-error-icon>
-    <template #control="{ floatingLabel, id }">
-      <input v-show="floatingLabel" :id="id" ref="input" class="q-field__input" :disabled="$attrs.disable" inputmode="numeric" :placeholder :readonly="$attrs.readonly" @blur="emitValue" @click="setSelect" @input="emitUpdateModel($event.target.value)">
+    <template #control="{ id }">
+      <input :id ref="input" class="q-field__input" :disabled="$attrs.disable" inputmode="numeric" :placeholder :readonly="$attrs.readonly" @blur="emitValue" @click="setSelect" @input="emitUpdateModel($event.target.value)">
     </template>
 
     <template v-if="icon" #prepend>

--- a/ui/src/css/components/item.scss
+++ b/ui/src/css/components/item.scss
@@ -10,12 +10,10 @@
     color: $grey-8;
   }
 
-  &.q-manual-focusable {
-  }
-
   &.q-manual-focusable--focused {
     color: var(--q-primary-contrast) !important;
   }
+
   &.q-router-link--active {
     background-color: transparent !important;
     font-weight: 600;

--- a/ui/src/css/components/item.scss
+++ b/ui/src/css/components/item.scss
@@ -11,11 +11,11 @@
   }
 
   &.q-manual-focusable {
-    &--focused {
-      color: var(--q-primary-contrast) !important;
-    }
   }
 
+  &.q-manual-focusable--focused {
+    color: var(--q-primary-contrast) !important;
+  }
   &.q-router-link--active {
     background-color: transparent !important;
     font-weight: 600;

--- a/ui/src/css/components/item.scss
+++ b/ui/src/css/components/item.scss
@@ -10,6 +10,12 @@
     color: $grey-8;
   }
 
+  &.q-manual-focusable {
+    &--focused {
+      color: var(--q-primary-contrast) !important;
+    }
+  }
+
   &.q-router-link--active {
     background-color: transparent !important;
     font-weight: 600;
@@ -27,7 +33,10 @@
   }
 
   &--clickable:not(&--active) {
-    color: $grey-10 !important;
+    &:not(.q-manual-focusable--focused) {
+      color: $grey-10 !important;
+    }
+
     transition: var(--qas-generic-transition);
 
     &:not(&.q-router-link--active):hover {
@@ -51,3 +60,4 @@
     padding-right: var(--qas-spacing-sm);
   }
 }
+

--- a/ui/src/css/components/item.scss
+++ b/ui/src/css/components/item.scss
@@ -60,4 +60,3 @@
     padding-right: var(--qas-spacing-sm);
   }
 }
-


### PR DESCRIPTION
### Corrigido
- `QasSelect`: Corrigido cor de foco nas opções durante a navegação com teclado (teclas de seta para cima/baixo).
- `QasNumericInput`: Corrigido foco do campo, pois quando utilizado via tab, o campo não focava.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [x] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [ ] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
