### PR TITLE
`QasFormGenerator`: corrigido comportamento quando `fields` está vazio, agora não exibe nenhum campo ao invés de exibir todos os campos disponíveis.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+### Corrigido
+- `QasFormGenerator`: corrigido comportamento quando `fields` está vazio, agora não exibe nenhum campo ao invés de exibir todos os campos disponíveis.
+
 ## [3.19.0-beta.7] - 26-09-2025
 ## BREAKING CHANGES
 - Rever lugares que utilizam lazy loading nos campos, pois pode gerar breaking changes.

--- a/docs/src/pages/components/form-generator.md
+++ b/docs/src/pages/components/form-generator.md
@@ -16,7 +16,7 @@ Para saber mais sobre o **API Design Pattern** clice [aqui](https://www.notion.s
 
 ## Uso
 <doc-example file="QasFormGenerator/Basic" title="Básico" />
-<doc-example file="QasFormGenerator/Boxed" title="Com box" />
+<!-- <doc-example file="QasFormGenerator/Boxed" title="Com box" /> -->
 
 :::tip
 ##### Fieldset
@@ -53,8 +53,8 @@ Muitas vezes precisamos adicionar rótulos (label) e descrições (description) 
 ```
 :::
 
-<doc-example file="QasFormGenerator/Fieldset" title="Agrupando fields por rótulo (label)" />
-<doc-example file="QasFormGenerator/WithButton" title="Usando botão dentro do fieldset" />
+<!-- <doc-example file="QasFormGenerator/Fieldset" title="Agrupando fields por rótulo (label)" />
+<doc-example file="QasFormGenerator/WithButton" title="Usando botão dentro do fieldset" /> -->
 
 :::info
 ##### Subset
@@ -99,10 +99,10 @@ Exemplo:
 }
 ```
 :::
-<doc-example file="QasFormGenerator/WithSubsets" title="Usando com subseções" />
-<doc-example file="QasFormGenerator/WithSubsetsSlots" title="Acessando slots de subseções" />
+<!-- <doc-example file="QasFormGenerator/WithSubsets" title="Usando com subseções" />
+<doc-example file="QasFormGenerator/WithSubsetsSlots" title="Acessando slots de subseções" /> -->
 
 Em alguns casos, queremos acessar todo o conteúdo de um campo especifico para fazer uma logica um pouco mais detalhada, neste caso conseguimos acessar o slot de cada campo individualmente.
-<doc-example file="QasFormGenerator/CustomSlot" title="Acessando slots" />
+<!-- <doc-example file="QasFormGenerator/CustomSlot" title="Acessando slots" />
 <doc-example file="QasFormGenerator/CustomProps" title="Custom props" />
-<doc-example file="QasFormGenerator/ExFormCommonColumns" title="Common columns" />
+<doc-example file="QasFormGenerator/ExFormCommonColumns" title="Common columns" /> -->

--- a/docs/src/pages/components/form-generator.md
+++ b/docs/src/pages/components/form-generator.md
@@ -16,7 +16,7 @@ Para saber mais sobre o **API Design Pattern** clice [aqui](https://www.notion.s
 
 ## Uso
 <doc-example file="QasFormGenerator/Basic" title="Básico" />
-<!-- <doc-example file="QasFormGenerator/Boxed" title="Com box" /> -->
+<doc-example file="QasFormGenerator/Boxed" title="Com box" />
 
 :::tip
 ##### Fieldset
@@ -53,8 +53,8 @@ Muitas vezes precisamos adicionar rótulos (label) e descrições (description) 
 ```
 :::
 
-<!-- <doc-example file="QasFormGenerator/Fieldset" title="Agrupando fields por rótulo (label)" />
-<doc-example file="QasFormGenerator/WithButton" title="Usando botão dentro do fieldset" /> -->
+<doc-example file="QasFormGenerator/Fieldset" title="Agrupando fields por rótulo (label)" />
+<doc-example file="QasFormGenerator/WithButton" title="Usando botão dentro do fieldset" />
 
 :::info
 ##### Subset
@@ -99,10 +99,10 @@ Exemplo:
 }
 ```
 :::
-<!-- <doc-example file="QasFormGenerator/WithSubsets" title="Usando com subseções" />
-<doc-example file="QasFormGenerator/WithSubsetsSlots" title="Acessando slots de subseções" /> -->
+<doc-example file="QasFormGenerator/WithSubsets" title="Usando com subseções" />
+<doc-example file="QasFormGenerator/WithSubsetsSlots" title="Acessando slots de subseções" />
 
 Em alguns casos, queremos acessar todo o conteúdo de um campo especifico para fazer uma logica um pouco mais detalhada, neste caso conseguimos acessar o slot de cada campo individualmente.
-<!-- <doc-example file="QasFormGenerator/CustomSlot" title="Acessando slots" />
+<doc-example file="QasFormGenerator/CustomSlot" title="Acessando slots" />
 <doc-example file="QasFormGenerator/CustomProps" title="Custom props" />
-<doc-example file="QasFormGenerator/ExFormCommonColumns" title="Common columns" /> -->
+<doc-example file="QasFormGenerator/ExFormCommonColumns" title="Common columns" />

--- a/ui/src/composables/private/use-generator.js
+++ b/ui/src/composables/private/use-generator.js
@@ -185,8 +185,11 @@ export default function ({ props = {}, isGrid = false }) {
         __hasFieldset: true
       }
 
-      // Pegar os fields com base na key.
-      const fieldsByfieldsKeys = filterObject(params.fields, fields)
+      /**
+       * Pegar os fields com base na key. É feito essa lógica porque o filterObject no caso de passar um array vazio
+       * para as keys, ele retorna todos os fields, e o comportamento esperado é que retorne um objeto vazio.
+       */
+      const fieldsByfieldsKeys = fields.length ? filterObject(params.fields, fields) : {}
 
       /**
        * Foi adicionado essa lógica para o grid-generator, pois cada field deve ter o "formattedResult", onde o


### PR DESCRIPTION
### Corrigido
- `QasFormGenerator`: corrigido comportamento quando `fields` está vazio, agora não exibe nenhum campo ao invés de exibir todos os campos disponíveis.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [ ] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
