### PR TITLE
`QasSelect`: Corrigido uso de badges no qual quebrava quando usado como objeto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 
 ## Não publicado
 ### Corrigido
-- `QasSelect`: Corrigido cor de foco nas opções durante a navegação com teclado (teclas de seta para cima/baixo).
+- `QasSelect`: 
+  - Corrigido cor de foco nas opções durante a navegação com teclado (teclas de seta para cima/baixo).
+  - Corrigido uso de badges na opção, no qual quebrava quando utilizado como objeto ao invés de função.
 - `QasNumericInput`: Corrigido foco do campo, pois quando utilizado via tab, o campo não focava.
 
 ## [3.19.0-beta.7] - 26-09-2025

--- a/docs/src/pages/components/select.md
+++ b/docs/src/pages/components/select.md
@@ -40,6 +40,8 @@ Quando o select for `required` ou tiver a prop `use-auto-select` e houver apenas
 <doc-example file="QasSelect/Searchable" title="Com pesquisa" />
 
 :::info
+Para usar opções customizadas, é necessário adicionar a prop `use-custom-options`.
+
 Caso queira usar badges nas opções, o back precisa retornar a chave em questão dizendo qual badge será mostrada, ex:
 ```js
 [

--- a/ui/src/components/select/QasSelect.vue
+++ b/ui/src/components/select/QasSelect.vue
@@ -489,7 +489,9 @@ export default {
     hasBadge (badge) {
       const model = Object.keys(badge)[0]
 
-      return badge[model] || this.badgeProps[model](badge[model]).show
+      const isFunction = typeof this.badgeProps[model] === 'function'
+
+      return badge[model] || (isFunction && this.badgeProps[model]?.(badge[model])?.show)
     },
 
     getCaptionArray (caption) {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

### Corrigido
- `QasSelect`: 
  - Corrigido uso de badges na opção, no qual quebrava quando utilizado como objeto ao invés de função.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
