### PR TITLE
`QasAlert`: Adicionado possibilidade de ter multiplos botoes e links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não p
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
 ## Não publicado
+### Adicionado
+- `QasAlert`: Adicionado possibilidade do componente ter vários `QasBtn` ou `RouterLink`.
+
 ### Corrigido
 - `QasFormGenerator`: corrigido comportamento quando `fields` está vazio, agora não exibe nenhum campo ao invés de exibir todos os campos disponíveis.
 - `QasSelect`: Corrigido cor de foco nas opções durante a navegação com teclado (teclas de seta para cima/baixo).

--- a/docs/src/examples/QasAlert/MultipleButtons.vue
+++ b/docs/src/examples/QasAlert/MultipleButtons.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="container q-py-lg">
+    <qas-alert v-bind="multipleButtonsAlertProps" />
+
+    <qas-alert v-bind="multipleLinksAlertProps" class="q-mt-md" />
+  </div>
+</template>
+
+<script setup>
+defineOptions({ name: 'MultipleButtons' })
+
+const multipleButtonsAlertProps = {
+  useRegex: true,
+  text: 'Exemplo com [botão 1], e também com [botão 2]',
+  buttonProps: [
+    {
+      onClick: () => alert('Botão 1 clicado')
+    },
+    {
+      onClick: () => alert('Botão 2 clicado')
+    }
+  ]
+}
+
+const multipleLinksAlertProps = {
+  useRegex: true,
+  text: 'Vou redirecionar para [home], e aqui para a [página de alertas]',
+  routerLinkProps: [
+    {
+      to: '/'
+    },
+    {
+      to: '/components/alert'
+    }
+  ]
+}
+</script>

--- a/docs/src/pages/components/alert.md
+++ b/docs/src/pages/components/alert.md
@@ -24,4 +24,5 @@ Componente para informações.
 <doc-example file="QasAlert/InsideBox" title="Dentro de box" />
 <doc-example file="QasAlert/InsideDialog" title="Dentro de dialog" />
 <doc-example file="QasAlert/Button" title="Com botão" />
+<doc-example file="QasAlert/MultipleButtons" title="Com múltiplos botões / links" />
 <doc-example file="QasAlert/ExternalLink" title="Link externo" />

--- a/ui/src/components/alert/QasAlert.vue
+++ b/ui/src/components/alert/QasAlert.vue
@@ -41,12 +41,12 @@ defineOptions({ name: 'QasAlert' })
 
 const props = defineProps({
   buttonProps: {
-    type: Object,
+    type: [Object, Array],
     default: () => ({})
   },
 
   routerLinkProps: {
-    type: Object,
+    type: [Object, Array],
     default: () => ({})
   },
 
@@ -123,88 +123,87 @@ const defaultBoxProps = computed(() => {
 })
 
 const textComponent = computed(() => {
-  /**
-   * regex para encontrar caracteres que estiverem dentro de [].
-   */
+
+  // Regex para encontrar caracteres que estiverem dentro de [].
   const regex = /\[.*?\]/g
 
-  const [content] = props.text.match(regex)
+  const matches = props.text.match(regex) || []
+
+  if (!matches.length) return h('span', props.text)
+
+  let processedText = props.text
 
   /**
-   * dado o texto: Para saber mais, [Clique aqui].
-   *
-   * retorna: 'Clique aqui'
+   * Substitui cada match por um placeholder único na ordem correta
+   * Exemplo: "Clique [aqui] para [ver mais]" vira "Clique $0 para $1"
    */
-  const routerLabel = content.replaceAll(/[[\]]/g, '')
+  matches.forEach((match, index) => {
+    processedText = processedText.replace(match, `$${index}`)
+  })
 
-  /**
-   * dado o texto: Para saber mais, [Clique aqui].
-   *
-   * retorna: 'Para saber mais, $.'
-   */
-  const replacedText = props.text.replaceAll(regex, '$')
+  // Divide o texto pelos placeholders
+  const parts = processedText.split(/\$\d+/)
 
-  /**
-   * É necessário usar o regex ao invés de '$' para ele não remover o carácter
-   * ao fazer o split
-   *
-   * dado o texto: 'Para saber mais, [Clique aqui].'
-   *
-   * retorna: ['Para saber mais,', '$', '.']
-   *
-   */
-  const splitted = replacedText.split(/(\$)/)
+  const placeholders = processedText.match(/\$\d+/g) || []
 
-  const index = splitted.findIndex(item => item === '$')
+  const result = []
 
-  const hasButtonProps = !!Object.keys(props.buttonProps).length
+  parts.forEach((part, index) => {
+    if (part) result.push(part)
 
-  const getRouterLinkRender = () => {
-    return h(
-      RouterLink,
-      {
-        ...props.routerLinkProps,
-        class: 'text-primary text-subtitle1 qas-alert__link'
-      },
-      {
-        default: () => routerLabel
+    if (index < placeholders.length) {
+      // Pega o índice do placeholder para encontrar o match correto
+      const placeholderIndex = parseInt(placeholders[index].replace('$', ''))
+
+      // Pega o texto original do match. Ex: '[Clique aqui]'
+      const match = matches[placeholderIndex]
+
+      // Remove os colchetes do match. Ex: [Clique aqui] para Clique aqui
+      const routerLabel = match.replaceAll(/[[\]]/g, '')
+
+      // Determina as props do botão/link baseado no índice
+      const isButtonPropsArray = Array.isArray(props.buttonProps)
+      const isRouterPropsArray = Array.isArray(props.routerLinkProps)
+
+      const buttonPropsForIndex = isButtonPropsArray
+        ? props.buttonProps[placeholderIndex]
+        : props.buttonProps
+
+      const routerLinkPropsForIndex = isRouterPropsArray
+        ? props.routerLinkProps[placeholderIndex]
+        : props.routerLinkProps
+
+      const hasButtonProps = buttonPropsForIndex && !!Object.keys(buttonPropsForIndex).length
+
+      const getRouterLinkRender = () => {
+        return h(
+          RouterLink,
+          {
+            ...routerLinkPropsForIndex,
+            class: 'text-primary text-subtitle1 qas-alert__link'
+          },
+          {
+            default: () => routerLabel
+          }
+        )
       }
-    )
-  }
 
-  const getQasBtnRender = () => {
-    return h(
-      QasBtn,
-      {
-        variant: 'tertiary',
-        label: routerLabel,
-        ...props.buttonProps
+      const getQasBtnRender = () => {
+          return h(
+          QasBtn,
+          {
+            variant: 'tertiary',
+            label: routerLabel,
+            ...buttonPropsForIndex
+          }
+        )
       }
-    )
-  }
 
-  /**
-   * Cria um render do router link ou QasBtn
-   *
-   * @example
-   *
-   * ```html
-   * <router-link
-   *  class="text-primary text-subtitle1 qas-alert__link"
-   *  :to="props.route"
-   * >
-   *  Clique aqui
-   * </router-link>
-   * ```
-   */
-  const renderComponent = hasButtonProps ? getQasBtnRender() : getRouterLinkRender()
+      result.push(hasButtonProps ? getQasBtnRender() : getRouterLinkRender())
+    }
+  })
 
-  splitted.splice(index, 1, renderComponent)
-
-  return h(
-    'span',
-    splitted
-  )
+  return h('span', result)
 })
 
 // composable definitions

--- a/ui/src/components/alert/QasAlert.vue
+++ b/ui/src/components/alert/QasAlert.vue
@@ -123,7 +123,6 @@ const defaultBoxProps = computed(() => {
 })
 
 const textComponent = computed(() => {
-
   // Regex para encontrar caracteres que estiverem dentro de [].
   const regex = /\[.*?\]/g
 
@@ -189,7 +188,7 @@ const textComponent = computed(() => {
       }
 
       const getQasBtnRender = () => {
-          return h(
+        return h(
           QasBtn,
           {
             variant: 'tertiary',

--- a/ui/src/components/alert/QasAlert.yml
+++ b/ui/src/components/alert/QasAlert.yml
@@ -8,7 +8,7 @@ props:
     desc: Props do componente QasBtn.
     default:
       variant: primary
-    type: Object
+    type: [Object, Array]
 
   model-value:
     desc: Model do componente, controla se o componente aparece ou não.
@@ -27,7 +27,7 @@ props:
   router-link-props:
     desc: Propriedades do componente RouterLink.
     default: {}
-    type: Object
+    type: [Object, Array]
 
   text:
     desc: Texto a ser exibido.


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
### Adicionado
- `QasAlert`: Adicionado possibilidade do componente ter vários `QasBtn` ou `RouterLink`.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
