### PR TITLE
`QasGridGenerator`: Corrigido container dos fields nao respeitando o pai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+### Corrigido
+- `QasGridGenerator`: Corrigido container de fields no qual não respeitava o tamanho do container pai.
+
 ## [3.19.0-beta.8] - 07-10-2025
 ### Adicionado
 - `QasAlert`: Adicionado possibilidade do componente ter vários `QasBtn` ou `RouterLink`.

--- a/ui/src/components/grid-generator/QasGridGenerator.vue
+++ b/ui/src/components/grid-generator/QasGridGenerator.vue
@@ -1,7 +1,7 @@
 <template>
   <component :is="component.is" v-bind="component.props">
     <div class="column q-col-gutter-y-lg">
-      <div v-for="(fieldsetItem, fieldsetItemKey) in normalizedFields" :key="fieldsetItemKey">
+      <div v-for="(fieldsetItem, fieldsetItemKey) in normalizedFields" :key="fieldsetItemKey" class="full-width">
         <q-separator v-if="hasSeparator({ item: fieldsetItem })" class="q-mb-lg" />
 
         <qas-header v-if="fieldsetItem.__hasHeader" v-bind="getHeaderProps({ values: fieldsetItem })" />


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

### Corrigido
- `QasGridGenerator`: Corrigido container de fields no qual não respeitava o tamanho do container pai.

Antes:
<img width="798" height="411" alt="image" src="https://github.com/user-attachments/assets/c13eddc6-a514-4ddf-b180-ce7f74f949cd" />

Depois: 
<img width="793" height="419" alt="image" src="https://github.com/user-attachments/assets/0ac72aaf-6b5a-430a-9b79-e3f73691064b" />


<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
