### PR TITLE
feat(`QasDateTimeInput`): adiciona função para preencher automaticame…

### DIFF
--- a/ui/src/components/date-time-input/QasDateTimeInput.vue
+++ b/ui/src/components/date-time-input/QasDateTimeInput.vue
@@ -243,6 +243,8 @@ function validateDateAndTime (value) {
 }
 
 function validateDateTimeOnBlur () {
+  autoFillMissingTime()
+
   const valueLength = currentValue.value?.replace?.(/_/g, '')?.length
 
   // valida se o tamanho digitado é o tamanho que a mascara espera receber
@@ -265,5 +267,27 @@ function resetError () {
   if (!currentValue.value) {
     error.value = false
   }
+}
+
+function autoFillMissingTime () {
+  if (props.useDateOnly || props.useTimeOnly) return
+
+  const value = currentValue.value
+
+  if (!value) return
+
+  const [rawDate = '', rawTime = ''] = value.split(' ')
+
+  const hasCompleteDate = !!rawDate && !rawDate.includes('_')
+  const hasTimeDigits = rawTime.replace(/[^0-9]/g, '').length > 0
+
+  if (!hasCompleteDate || hasTimeDigits) return
+
+  const defaultTime = props.timeMask.replace(/[a-zA-Z]/g, '0')
+  const nextValue = `${rawDate} ${defaultTime}`.trim()
+
+  if (nextValue === value) return
+
+  updateModelValue(nextValue)
 }
 </script>


### PR DESCRIPTION
Closes #1411.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [ ] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [ ] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [ ] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [ ] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [ ] Foi atualizada e testada a documentação;
- [ ] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
