### PR TITLE
QasAlert: Ter opção de destacar (strong) parte do texto 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+### Adicionado
+- `QasAlert`: Adicionado possiblidade de dar destaque nos textos (bold) passando eles dentro de `**asteriscos**`.
+
 ## [3.20.0-beta.1] - 25-11-2025
 ### Adicionado
 - `QasBtnDropdown`: adicionado novo slot dinâmico `btn-content-[buttons-props-list-key]`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 
 ## Não publicado
 ### Adicionado
-- `QasAlert`: Adicionado possiblidade de dar destaque nos textos (bold) passando eles dentro de `**asteriscos**`.
+- `QasAlert`: Adicionado possiblidade de dar destaque nos textos (bold) passando eles dentro de `**asteriscos**`. [[#1410](https://github.com/bildvitta/asteroid/issues/1410)]
 
 ## [3.20.0-beta.1] - 25-11-2025
 ### Adicionado

--- a/docs/src/examples/QasAlert/WithBoldText.vue
+++ b/docs/src/examples/QasAlert/WithBoldText.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="container q-py-lg">
+    <qas-alert v-bind="withBoldTextAndButton" />
+  </div>
+</template>
+
+<script setup>
+defineOptions({ name: 'WithBoldText' })
+
+const withBoldTextAndButton = {
+  useRegex: true,
+  text: 'Exemplo com [botão 1], e destaque de **texto** para negrito.',
+  buttonProps: {
+    onClick: () => alert('Button clicked')
+  }
+}
+</script>

--- a/docs/src/pages/components/alert.md
+++ b/docs/src/pages/components/alert.md
@@ -11,6 +11,7 @@ Componente para informações.
   - RouterLink (se existir a propriedade `routerLinkProps`).
   - QasBtn (se existir a propriedade `buttonProps`).
 - Quando a propriedade "useRegex" for "true", todo texto da propriedade "text" que estiver dentro de `** **` será adicionado dentro de uma tag strong.
+  - Exemplo: `Exemplo de texto destacando **essa parte**`.
 - slot "default" só existe se "useRegex" for "false".
 :::
 

--- a/docs/src/pages/components/alert.md
+++ b/docs/src/pages/components/alert.md
@@ -10,6 +10,7 @@ Componente para informações.
 - Quando a propriedade "useRegex" for "true", todo texto da propriedade "text" que estiver dentro de `[]` será substituído pelos componentes:
   - RouterLink (se existir a propriedade `routerLinkProps`).
   - QasBtn (se existir a propriedade `buttonProps`).
+- Quando a propriedade "useRegex" for "true", todo texto da propriedade "text" que estiver dentro de `** **` será adicionado dentro de uma tag strong.
 - slot "default" só existe se "useRegex" for "false".
 :::
 
@@ -25,4 +26,5 @@ Componente para informações.
 <doc-example file="QasAlert/InsideDialog" title="Dentro de dialog" />
 <doc-example file="QasAlert/Button" title="Com botão" />
 <doc-example file="QasAlert/MultipleButtons" title="Com múltiplos botões / links" />
+<doc-example file="QasAlert/WithBoldText" title="Com destaque nos textos" />
 <doc-example file="QasAlert/ExternalLink" title="Link externo" />

--- a/ui/src/components/alert/QasAlert.vue
+++ b/ui/src/components/alert/QasAlert.vue
@@ -133,41 +133,82 @@ const component = computed(() => {
 })
 
 const textComponent = computed(() => {
-  // Regex para encontrar caracteres que estiverem dentro de [] para links/botões
-  const linkRegex = /\[.*?\]/g
-  // Regex para encontrar caracteres que estiverem dentro de ** para bold
-  const boldRegex = /\*\*(.*?)\*\*/g
+  // Configuração dos tokens suportados
+  const tokens = [
+    {
+      type: 'LINK',
+      regex: /\[(.*?)\]/g,
+      extractContent: match => match.replace(/\[(.*?)\]/, '$1'),
+      render: (content, index) => {
+        const isButtonPropsArray = Array.isArray(props.buttonProps)
+        const isRouterPropsArray = Array.isArray(props.routerLinkProps)
 
-  const linkMatches = props.text.match(linkRegex) || []
-  const boldMatches = props.text.match(boldRegex) || []
+        const buttonPropsForIndex = isButtonPropsArray
+          ? props.buttonProps[index]
+          : props.buttonProps
 
-  // Se não há matches de links/botões e nem bold, retorna texto simples
-  if (!linkMatches.length && !boldMatches.length) {
+        const routerLinkPropsForIndex = isRouterPropsArray
+          ? props.routerLinkProps[index]
+          : props.routerLinkProps
+
+        const hasButtonProps = buttonPropsForIndex && !!Object.keys(buttonPropsForIndex).length
+
+        if (hasButtonProps) {
+          return h(QasBtn, {
+            variant: 'tertiary',
+            label: content,
+            ...buttonPropsForIndex
+          })
+        }
+
+        return h(RouterLink, {
+          ...routerLinkPropsForIndex,
+          class: 'text-primary text-subtitle1 qas-alert__link'
+        }, {
+          default: () => content
+        })
+      }
+    },
+    {
+      type: 'BOLD',
+      regex: /\*\*(.*?)\*\*/g,
+      extractContent: match => match.replace(/\*\*(.*?)\*\*/, '$1'),
+      render: content => h('strong', { class: 'text-weight-bold' }, content)
+    }
+  ]
+
+  // Encontra todos os matches de todos os tipos de token
+  const allMatches = []
+
+  tokens.forEach(token => {
+    const matches = props.text.match(token.regex) || []
+
+    matches.forEach(match => {
+      allMatches.push({
+        type: token.type,
+        match,
+        content: token.extractContent(match),
+        render: token.render
+      })
+    })
+  })
+
+  // Se não há matches, retorna texto simples
+  if (!allMatches.length) {
     return h('span', props.text)
   }
 
   let processedText = props.text
 
-  /**
-   * Substitui cada match de link por um placeholder único na ordem correta
-   * Exemplo: "Clique [aqui] para [ver mais]" vira "Clique $LINK_0 para $LINK_1"
-   */
-  linkMatches.forEach((match, index) => {
-    processedText = processedText.replace(match, `$LINK_${index}`)
+  // Substitui cada match por um placeholder único
+  allMatches.forEach((matchData, index) => {
+    processedText = processedText.replace(matchData.match, `$${matchData.type}_${index}`)
   })
 
-  /**
-   * Substitui cada match de bold por um placeholder único na ordem correta
-   * Exemplo: "Texto **importante** aqui" vira "Texto $BOLD_0 aqui"
-   */
-  boldMatches.forEach((match, index) => {
-    processedText = processedText.replace(match, `$BOLD_${index}`)
-  })
-
-  // Separa o texto em partes usando regex mais específica
-  const parts = processedText.split(/(\$(?:LINK|BOLD)_\d+)/)
-
+  // Separa o texto em partes
+  const parts = processedText.split(/(\$\w+_\d+)/)
   const result = []
+
   parts.forEach(part => {
     // Se a parte é texto normal, adiciona como string
     if (!part.startsWith('$')) {
@@ -175,72 +216,25 @@ const textComponent = computed(() => {
       return
     }
 
-    // Se é um placeholder, processa baseado no tipo
-    const placeholderMatch = part.match(/\$(LINK|BOLD)_(\d+)/)
-
+    // Se é um placeholder, encontra o match correspondente
+    const placeholderMatch = part.match(/\$(\w+)_(\d+)/)
     if (!placeholderMatch) return
 
     const [, type, indexStr] = placeholderMatch
-    const placeholderIndex = parseInt(indexStr)
+    const index = parseInt(indexStr)
 
-    if (type === 'LINK') {
-      // Pega o texto original do match de link. Ex: '[Clique aqui]'
-      const linkMatch = linkMatches[placeholderIndex]
+    // Encontra o match data correspondente
+    const matchData = allMatches[index]
+    if (!matchData || matchData.type !== type) return
 
-      // Remove os colchetes do match. Ex: [Clique aqui] para Clique aqui
-      const routerLabel = linkMatch.replaceAll(/[[\]]/g, '')
+    // Conta quantos matches do mesmo tipo vieram antes (para o índice das props)
+    const typeIndex = allMatches
+      .slice(0, index)
+      .filter(m => m.type === type)
+      .length
 
-      // Determina as props do botão/link baseado no índice
-      const isButtonPropsArray = Array.isArray(props.buttonProps)
-      const isRouterPropsArray = Array.isArray(props.routerLinkProps)
-
-      const buttonPropsForIndex = isButtonPropsArray
-        ? props.buttonProps[placeholderIndex]
-        : props.buttonProps
-
-      const routerLinkPropsForIndex = isRouterPropsArray
-        ? props.routerLinkProps[placeholderIndex]
-        : props.routerLinkProps
-
-      const hasButtonProps = buttonPropsForIndex && !!Object.keys(buttonPropsForIndex).length
-
-      const getRouterLinkRender = () => {
-        return h(
-          RouterLink,
-          {
-            ...routerLinkPropsForIndex,
-            class: 'text-primary text-subtitle1 qas-alert__link'
-          },
-          {
-            default: () => routerLabel
-          }
-        )
-      }
-
-      const getQasBtnRender = () => {
-        return h(
-          QasBtn,
-          {
-            variant: 'tertiary',
-            label: routerLabel,
-            ...buttonPropsForIndex
-          }
-        )
-      }
-
-      result.push(hasButtonProps ? getQasBtnRender() : getRouterLinkRender())
-    } else if (type === 'BOLD') {
-      // Pega o texto original do match de bold. Ex: '**texto importante**'
-      const boldMatch = boldMatches[placeholderIndex]
-
-      // Remove os asteriscos do match. Ex: **texto importante** para texto importante
-      const boldText = boldMatch.replace(/\*\*(.*?)\*\*/, '$1')
-
-      // Cria elemento bold
-      result.push(
-        h('strong', boldText)
-      )
-    }
+    // Renderiza o componente
+    result.push(matchData.render(matchData.content, typeIndex))
   })
 
   return h('span', result)

--- a/ui/src/components/alert/QasAlert.vue
+++ b/ui/src/components/alert/QasAlert.vue
@@ -133,42 +133,62 @@ const component = computed(() => {
 })
 
 const textComponent = computed(() => {
-  // Regex para encontrar caracteres que estiverem dentro de [].
-  const regex = /\[.*?\]/g
+  // Regex para encontrar caracteres que estiverem dentro de [] para links/botões
+  const linkRegex = /\[.*?\]/g
+  // Regex para encontrar caracteres que estiverem dentro de ** para bold
+  const boldRegex = /\*\*(.*?)\*\*/g
 
-  const matches = props.text.match(regex) || []
+  const linkMatches = props.text.match(linkRegex) || []
+  const boldMatches = props.text.match(boldRegex) || []
 
-  if (!matches.length) return h('span', props.text)
+  // Se não há matches de links/botões e nem bold, retorna texto simples
+  if (!linkMatches.length && !boldMatches.length) {
+    return h('span', props.text)
+  }
 
   let processedText = props.text
 
   /**
-   * Substitui cada match por um placeholder único na ordem correta
-   * Exemplo: "Clique [aqui] para [ver mais]" vira "Clique $0 para $1"
+   * Substitui cada match de link por um placeholder único na ordem correta
+   * Exemplo: "Clique [aqui] para [ver mais]" vira "Clique $LINK_0 para $LINK_1"
    */
-  matches.forEach((match, index) => {
-    processedText = processedText.replace(match, `$${index}`)
+  linkMatches.forEach((match, index) => {
+    processedText = processedText.replace(match, `$LINK_${index}`)
   })
 
-  // Divide o texto pelos placeholders
-  const parts = processedText.split(/\$\d+/)
+  /**
+   * Substitui cada match de bold por um placeholder único na ordem correta
+   * Exemplo: "Texto **importante** aqui" vira "Texto $BOLD_0 aqui"
+   */
+  boldMatches.forEach((match, index) => {
+    processedText = processedText.replace(match, `$BOLD_${index}`)
+  })
 
-  const placeholders = processedText.match(/\$\d+/g) || []
+  // Separa o texto em partes usando regex mais específica
+  const parts = processedText.split(/(\$(?:LINK|BOLD)_\d+)/)
 
   const result = []
+  parts.forEach(part => {
+    // Se a parte é texto normal, adiciona como string
+    if (!part.startsWith('$')) {
+      if (part) result.push(part)
+      return
+    }
 
-  parts.forEach((part, index) => {
-    if (part) result.push(part)
+    // Se é um placeholder, processa baseado no tipo
+    const placeholderMatch = part.match(/\$(LINK|BOLD)_(\d+)/)
 
-    if (index < placeholders.length) {
-      // Pega o índice do placeholder para encontrar o match correto
-      const placeholderIndex = parseInt(placeholders[index].replace('$', ''))
+    if (!placeholderMatch) return
 
-      // Pega o texto original do match. Ex: '[Clique aqui]'
-      const match = matches[placeholderIndex]
+    const [, type, indexStr] = placeholderMatch
+    const placeholderIndex = parseInt(indexStr)
+
+    if (type === 'LINK') {
+      // Pega o texto original do match de link. Ex: '[Clique aqui]'
+      const linkMatch = linkMatches[placeholderIndex]
 
       // Remove os colchetes do match. Ex: [Clique aqui] para Clique aqui
-      const routerLabel = match.replaceAll(/[[\]]/g, '')
+      const routerLabel = linkMatch.replaceAll(/[[\]]/g, '')
 
       // Determina as props do botão/link baseado no índice
       const isButtonPropsArray = Array.isArray(props.buttonProps)
@@ -209,6 +229,17 @@ const textComponent = computed(() => {
       }
 
       result.push(hasButtonProps ? getQasBtnRender() : getRouterLinkRender())
+    } else if (type === 'BOLD') {
+      // Pega o texto original do match de bold. Ex: '**texto importante**'
+      const boldMatch = boldMatches[placeholderIndex]
+
+      // Remove os asteriscos do match. Ex: **texto importante** para texto importante
+      const boldText = boldMatch.replace(/\*\*(.*?)\*\*/, '$1')
+
+      // Cria elemento bold
+      result.push(
+        h('strong', boldText)
+      )
     }
   })
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
closes #1410

### Adicionado
- `QasAlert`: Adicionado possiblidade de dar destaque nos textos (bold) passando eles dentro de `**asteriscos**`.
<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
