### PR TITLE
Mudanças em tabela, actions-menu etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,30 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+## BREAKING CHANGES
+- Validar todos locais que usam o `QasTableGenerator` pois tiveram bastante mudanças visuais.
+
+### Adicionado
+- `QasTableGenerator`:
+  - adicionado nova propriedade `useMultiline`.
+  - adicionado `QasTip`usado via prop `columns`.
+  - adicionado label "Ações" na coluna de ação.
+- `QasActionsMenu`: adicionado nova propriedade `useDropdownAlways`.
+- `QasTooltip`: adicionado o componente `QasBreakline`para ser usado na prop `text, agora é possível quebrar textos usando `\n`.
+- `QasToggleVisibility`: adicionado propriedade `visibleTooltip` e `hiddenTooltip`.
+
+### Modificado
+- `QasTooltip`: modificado tamanho máximo para `300px`.
+- `QasBtn`: modificado tamanho do botão para `18px` quando o `size` ser `sm`.
+- `helpers/filters/formatDocument`: adicionado validação para parâmetro vazio.
+- `QasTableGenerator`:
+  - adicionado bordam abaixo do titulo das colunas.
+  - modificado tipografia de `body1` para `body2`.
+  - modificado tamanho padrão do `QasBtn` de `md` para `sm`.
+  - modificado validação do `mappedResults`, quando usado type `object` ele não passa pelo `humanize` e não adicionado na chave `default` visando performance.
+  - coluna de ação agora tem o conteúdo alinhado á esquerda igual aos demais. 
+
 ## [3.20.0-beta.1] - 25-11-2025
 ### Adicionado
 - `QasBtnDropdown`: adicionado novo slot dinâmico `btn-content-[buttons-props-list-key]`.

--- a/docs/src/examples/QasActionsMenu/ExUseDropdownAlways.vue
+++ b/docs/src/examples/QasActionsMenu/ExUseDropdownAlways.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="container q-py-lg">
+    <qas-actions-menu v-bind="props" />
+  </div>
+</template>
+
+<script setup>
+const list = {
+  visibility: {
+    icon: 'sym_r_visibility',
+    label: 'Visualizar',
+    handler: () => alert('handler ativado')
+  }
+}
+
+const props = {
+  list,
+  useDropdownAlways: true
+}
+</script>

--- a/docs/src/examples/QasTableGenerator/Basic.vue
+++ b/docs/src/examples/QasTableGenerator/Basic.vue
@@ -8,7 +8,7 @@ import { fields, results } from 'src/mocks/users'
 defineOptions({ name: 'Basic' })
 
 const columns = [
-  { sortable: false, name: 'isActive' },
+  { tooltip: 'Tooltip de exemplo', name: 'isActive' },
   'name',
   'createdAt',
   'date'

--- a/docs/src/pages/components/actions-menu.md
+++ b/docs/src/pages/components/actions-menu.md
@@ -12,6 +12,7 @@ Componente wrapper do `QasBtnDropdown` que implementa regras de negocio.
   - com 2 itens na lista mostra um botão ao lado do outro.
   - com 3+ itens na lista mostra o botão primário e todo o restante dentro do dropdown.
 - Sem `splitName`: Sempre mostra o botão "Opções".
+- Com `useDropdownAlways`: Sempre mostra o botão "Opções", mesmo com apenas 1 item.
 - No mobile toda a lista é sempre dentro do dropdown.
 - Use a prop `useLabel: false` para remover todas labels dos botões **fora** do dropdown.
 -  Use a prop `useTooltip: true` para mostrar tooltip das labels dos botões **fora** do dropdown quando a prop `useLabel` for `false`.
@@ -62,3 +63,4 @@ Componente wrapper do `QasBtnDropdown` que implementa regras de negocio.
 <doc-example file="QasActionsMenu/ExNoLabel" title="Sem label" />
 <doc-example file="QasActionsMenu/ExTooltip" title="Sem label com tooltip" />
 <doc-example file="QasActionsMenu/ExWithLoading" title="Com loading" />
+<doc-example file="QasActionsMenu/ExUseDropdownAlways" title="Sempre dropdown" />

--- a/docs/src/pages/components/table-generator.md
+++ b/docs/src/pages/components/table-generator.md
@@ -50,8 +50,8 @@ Exemplo:
 
 ## Uso
 
-<!-- <doc-example file="QasTableGenerator/Basic" title="Básico" />
-<doc-example file="QasTableGenerator/Selection" title="Selecionável" /> -->
+<doc-example file="QasTableGenerator/Basic" title="Básico" />
+<doc-example file="QasTableGenerator/Selection" title="Selecionável" />
 
 :::info
 A propriedade "actionsMenuProps" adiciona automaticamente uma coluna "actions" na tabela e renderiza o `QasActionsMenu` por callback, é a maneira **correta** de se usar ação na ultima coluna.
@@ -87,17 +87,17 @@ fieldsProps: {
 ```
 :::
 <doc-example file="QasTableGenerator/WithFieldsProps" title="Com componentes por props e ação na ultima coluna" />
-<!-- <doc-example file="QasTableGenerator/WithHeader" title="Com header" />
+<doc-example file="QasTableGenerator/WithHeader" title="Com header" />
 <doc-example file="QasTableGenerator/HeaderSlot" title="Acessando slot do header" />
-<doc-example file="QasTableGenerator/NoBox" title="Sem box" /> -->
+<doc-example file="QasTableGenerator/NoBox" title="Sem box" />
 
 Este componente renderiza componentes dinamicamente através da prop `fields`, cada field dentro de fields tem um `name`, através dele, você consegue acessar os slots dinâmicos.
 
-<!-- <doc-example file="QasTableGenerator/CustomSlot" title="Slots personalizados" /> -->
+<doc-example file="QasTableGenerator/CustomSlot" title="Slots personalizados" />
 
 Também é possível configurar o componente para executar uma ação ao clicar em uma linha, para isso, basta escutar o evento `row-click`.
 
-<!-- <doc-example file="QasTableGenerator/ClickableRow" title="Linha clicável" /> -->
+<doc-example file="QasTableGenerator/ClickableRow" title="Linha clicável" />
 
 Caso queira que ao clicar em uma linha vá para outra rota, é possível utilizar a prop `row-route-fn` na qual o retorno deve ser com a estrutura aceita pelo vue-router.(a linha passa ser um `<a>` internamente, habilitando a opção de abrir em uma nova aba)
 
@@ -116,7 +116,7 @@ rowExternalRouteFn () {
 ```
 :::
 
-<!-- <doc-example file="QasTableGenerator/TableLink" title="Tabela com links" /> -->
+<doc-example file="QasTableGenerator/TableLink" title="Tabela com links" />
 
 Funcionalidade que permite que o cabeçalho da tabela permaneça visível na parte superior enquanto o usuário faz rolagem do conteúdo da tabela. Para utilizar atribua a prop `use-sticky-header`.
 
@@ -124,10 +124,10 @@ Funcionalidade que permite que o cabeçalho da tabela permaneça visível na par
 É possível alterar a altura máxima da tabela utilizando a prop `max-height`.
 :::
 
-<!-- <doc-example file="QasTableGenerator/StickyHeader" title="Header fixo" /> -->
+<doc-example file="QasTableGenerator/StickyHeader" title="Header fixo" />
 
 :::warning
 O virtual scroll renderiza dinamicamente as linhas a serem exibidas na tabela.
 Apenas utilize virtual scroll quando realmente houver comportamentos no qual não se pode ter paginação e tiver muitos dados na tabela.
 :::
-<!-- <doc-example file="QasTableGenerator/WithVirtualScroll" title="Com virtual scroll" /> -->
+<doc-example file="QasTableGenerator/WithVirtualScroll" title="Com virtual scroll" />

--- a/docs/src/pages/components/table-generator.md
+++ b/docs/src/pages/components/table-generator.md
@@ -50,8 +50,8 @@ Exemplo:
 
 ## Uso
 
-<doc-example file="QasTableGenerator/Basic" title="Básico" />
-<doc-example file="QasTableGenerator/Selection" title="Selecionável" />
+<!-- <doc-example file="QasTableGenerator/Basic" title="Básico" />
+<doc-example file="QasTableGenerator/Selection" title="Selecionável" /> -->
 
 :::info
 A propriedade "actionsMenuProps" adiciona automaticamente uma coluna "actions" na tabela e renderiza o `QasActionsMenu` por callback, é a maneira **correta** de se usar ação na ultima coluna.
@@ -87,17 +87,17 @@ fieldsProps: {
 ```
 :::
 <doc-example file="QasTableGenerator/WithFieldsProps" title="Com componentes por props e ação na ultima coluna" />
-<doc-example file="QasTableGenerator/WithHeader" title="Com header" />
+<!-- <doc-example file="QasTableGenerator/WithHeader" title="Com header" />
 <doc-example file="QasTableGenerator/HeaderSlot" title="Acessando slot do header" />
-<doc-example file="QasTableGenerator/NoBox" title="Sem box" />
+<doc-example file="QasTableGenerator/NoBox" title="Sem box" /> -->
 
 Este componente renderiza componentes dinamicamente através da prop `fields`, cada field dentro de fields tem um `name`, através dele, você consegue acessar os slots dinâmicos.
 
-<doc-example file="QasTableGenerator/CustomSlot" title="Slots personalizados" />
+<!-- <doc-example file="QasTableGenerator/CustomSlot" title="Slots personalizados" /> -->
 
 Também é possível configurar o componente para executar uma ação ao clicar em uma linha, para isso, basta escutar o evento `row-click`.
 
-<doc-example file="QasTableGenerator/ClickableRow" title="Linha clicável" />
+<!-- <doc-example file="QasTableGenerator/ClickableRow" title="Linha clicável" /> -->
 
 Caso queira que ao clicar em uma linha vá para outra rota, é possível utilizar a prop `row-route-fn` na qual o retorno deve ser com a estrutura aceita pelo vue-router.(a linha passa ser um `<a>` internamente, habilitando a opção de abrir em uma nova aba)
 
@@ -116,7 +116,7 @@ rowExternalRouteFn () {
 ```
 :::
 
-<doc-example file="QasTableGenerator/TableLink" title="Tabela com links" />
+<!-- <doc-example file="QasTableGenerator/TableLink" title="Tabela com links" /> -->
 
 Funcionalidade que permite que o cabeçalho da tabela permaneça visível na parte superior enquanto o usuário faz rolagem do conteúdo da tabela. Para utilizar atribua a prop `use-sticky-header`.
 
@@ -124,10 +124,10 @@ Funcionalidade que permite que o cabeçalho da tabela permaneça visível na par
 É possível alterar a altura máxima da tabela utilizando a prop `max-height`.
 :::
 
-<doc-example file="QasTableGenerator/StickyHeader" title="Header fixo" />
+<!-- <doc-example file="QasTableGenerator/StickyHeader" title="Header fixo" /> -->
 
 :::warning
 O virtual scroll renderiza dinamicamente as linhas a serem exibidas na tabela.
 Apenas utilize virtual scroll quando realmente houver comportamentos no qual não se pode ter paginação e tiver muitos dados na tabela.
 :::
-<doc-example file="QasTableGenerator/WithVirtualScroll" title="Com virtual scroll" />
+<!-- <doc-example file="QasTableGenerator/WithVirtualScroll" title="Com virtual scroll" /> -->

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -86,6 +86,10 @@ const props = defineProps({
     type: String
   },
 
+  useDropdownAlways: {
+    type: Boolean
+  },
+
   useLabel: {
     default: true,
     type: Boolean
@@ -209,7 +213,7 @@ const formattedList = computed(() => {
    */
   const payload = { dropdownList: {}, buttonsList: {} }
 
-  if ((!hasSplitName.value || screen.isSmall) && !isSingle.value) {
+  if (props.useDropdownAlways || ((!hasSplitName.value || screen.isSmall) && !isSingle.value)) {
     const { buttonsList } = useOptionsActions({ color: DEFAULT_COLOR, props })
 
     payload.buttonsList = buttonsList.value

--- a/ui/src/components/actions-menu/QasActionsMenu.yml
+++ b/ui/src/components/actions-menu/QasActionsMenu.yml
@@ -49,6 +49,11 @@ props:
     type: String
     examples: [visibility]
 
+  use-dropdown-always:
+    desc: Força o uso do dropdown mesmo caso tenha apenas 1 item na lista de ações.
+    default: false
+    type: Boolean
+
   use-tooltip:
     desc: Controla se vai ter o tooltip caso passe nas regras de exibição de tooltip
 

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -26,18 +26,13 @@
       <template v-for="(fieldName, index) in bodyCellNameSlots" :key="index" #[`body-cell-${fieldName}`]="context">
         <q-td :class="getTdClasses(context.row)">
           <component :is="tdChildComponent" class="qas-table-generator__td-item" v-bind="getTdChildComponentProps(context.row)">
-            <!-- <div style="max-width: 240px" >
-              <div class="ellipsis"> -->
+            <slot :name="`body-cell-${fieldName}`" v-bind="context || {}">
+              <pv-table-generator-td v-if="getFieldsProps(context.row, context.rowIndex)[fieldName]" :component-data="getFieldsProps(context.row, context.rowIndex)[fieldName]" :label="fields[fieldName]?.label" :name="fieldName" :row="context.row" />
 
-                <slot :name="`body-cell-${fieldName}`" v-bind="context || {}">
-                  <pv-table-generator-td v-if="getFieldsProps(context.row, context.rowIndex)[fieldName]" :component-data="getFieldsProps(context.row, context.rowIndex)[fieldName]" :label="fields[fieldName]?.label" :name="fieldName" :row="context.row" />
-
-                  <template v-else>
-                    {{ context.row?.[fieldName] }}
-                  </template>
-                </slot>
-              <!-- </div>
-            </div> -->
+              <template v-else>
+                {{ context.row?.[fieldName] }}
+              </template>
+            </slot>
           </component>
         </q-td>
       </template>
@@ -58,9 +53,9 @@
 <script>
 import PvTableGeneratorTd from './private/PvTableGeneratorTd.vue'
 import QasBox from '../box/QasBox.vue'
+import QasCheckbox from '../checkbox/QasCheckbox.vue'
 import QasEmptyResultText from '../empty-result-text/QasEmptyResultText.vue'
 import QasHeader from '../header/QasHeader.vue'
-import QasCheckbox from '../checkbox/QasCheckbox.vue'
 import QasTip from '../tip/QasTip.vue'
 
 import { isEmpty, humanize, setScrollOnGrab, setScrollGradient } from '../../helpers'
@@ -159,6 +154,10 @@ export default {
     useScrollOnGrab: {
       type: Boolean,
       default: true
+    },
+
+    useMultiline: {
+      type: Boolean
     },
 
     useObjectSelectedModel: {
@@ -345,7 +344,8 @@ export default {
       return {
         'qas-table-generator--mobile': this.$qas.screen.isSmall,
         'qas-table-generator--sticky-header': this.useStickyHeader,
-        'qas-table-generator--has-actions': this.hasActionsMenu
+        'qas-table-generator--has-actions': this.hasActionsMenu,
+        'qas-table-generator--multiline': this.useMultiline
       }
     },
 
@@ -561,35 +561,6 @@ export default {
       height: 24px;
     }
 
-    // thead tr:last-child th:last-child,
-    // td:last-child {
-    //   background-color: white;
-    // }
-
-    // th:last-child,
-    // td:last-child {
-    //   box-shadow: -4px 0 6px -2px rgba(0, 0, 0, 0.1);
-    //   min-width: 80px;
-    //   position: sticky;
-    //   right: 0;
-    //   z-index: 1;
-    // }
-
-  // max-width: 600px
-
-  // thead tr:last-child th:last-child
-  //   /* bg color is important for th; just specify one */
-  //   background-color: #00b4ff
-
-  // td:last-child
-  //   background-color: #00b4ff
-
-  // th:last-child,
-  // td:last-child
-  //   position: sticky
-  //   right: 0
-  //   z-index: 1
-
     th {
       @include set-typography($subtitle2);
 
@@ -606,19 +577,10 @@ export default {
         }
       }
 
-      // border: 0 !important;
       padding-bottom: var(--qas-spacing-sm);;
       padding-left: 0;
       padding-top: 0;
       padding-right: var(--qas-spacing-md);
-
-      // &:not(:last-child) {
-      //   padding-right: var(--qas-spacing-md);
-      // }
-
-      // &:last-child {
-      //   padding-right: 0;
-      // }
     }
 
     td,
@@ -638,14 +600,6 @@ export default {
       position: relative;
       z-index: 0;
       padding-right: var(--qas-spacing-md);
-
-      // &:not(:last-child) {
-      //   padding-right: var(--qas-spacing-md);
-      // }
-
-      // &:last-child {
-      //   padding-right: 0;
-      // }
 
       &::before {
         position: absolute;
@@ -702,16 +656,20 @@ export default {
     }
   }
 
+  &--multiline {
+    @media (min-width: $breakpoint-sm) {
+      .q-table td {
+        *:not(.qas-btn, .qas-btn *, .q-badge, .q-badge *){
+          white-space: normal;
+          overflow-wrap: anywhere;
+        }
+      }
+    }
+  }
+
   .q-table__container {
     margin-left: calc(var(--qas-spacing-md) * -1);
     margin-right: calc(var(--qas-spacing-md) * -1);
-  }
-
-  &--has-actions {
-    // td:last-child #{$root}__td-item {
-    //   display: flex;
-    //   justify-content: flex-end;
-    // }
   }
 
   &--mobile {

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -26,15 +26,28 @@
       <template v-for="(fieldName, index) in bodyCellNameSlots" :key="index" #[`body-cell-${fieldName}`]="context">
         <q-td :class="getTdClasses(context.row)">
           <component :is="tdChildComponent" class="qas-table-generator__td-item" v-bind="getTdChildComponentProps(context.row)">
-            <slot :name="`body-cell-${fieldName}`" v-bind="context || {}">
-              <pv-table-generator-td v-if="getFieldsProps(context.row, context.rowIndex)[fieldName]" :component-data="getFieldsProps(context.row, context.rowIndex)[fieldName]" :label="fields[fieldName]?.label" :name="fieldName" :row="context.row" />
+            <!-- <div style="max-width: 240px" >
+              <div class="ellipsis"> -->
 
-              <template v-else>
-                {{ context.row?.[fieldName] }}
-              </template>
-            </slot>
+                <slot :name="`body-cell-${fieldName}`" v-bind="context || {}">
+                  <pv-table-generator-td v-if="getFieldsProps(context.row, context.rowIndex)[fieldName]" :component-data="getFieldsProps(context.row, context.rowIndex)[fieldName]" :label="fields[fieldName]?.label" :name="fieldName" :row="context.row" />
+
+                  <template v-else>
+                    {{ context.row?.[fieldName] }}
+                  </template>
+                </slot>
+              <!-- </div>
+            </div> -->
           </component>
         </q-td>
+      </template>
+
+      <template v-for="(column, index) in columnsWithTooltip" :key="index" #[`header-cell-${column.name}`]="context">
+        <q-th :props="context">
+          {{ context.col.label }}
+
+          <qas-tip class="q-pl-xs" :text="column.tooltip" />
+        </q-th>
       </template>
     </q-table>
 
@@ -48,6 +61,7 @@ import QasBox from '../box/QasBox.vue'
 import QasEmptyResultText from '../empty-result-text/QasEmptyResultText.vue'
 import QasHeader from '../header/QasHeader.vue'
 import QasCheckbox from '../checkbox/QasCheckbox.vue'
+import QasTip from '../tip/QasTip.vue'
 
 import { isEmpty, humanize, setScrollOnGrab, setScrollGradient } from '../../helpers'
 
@@ -61,7 +75,8 @@ export default {
     QasBox,
     QasEmptyResultText,
     QasHeader,
-    QasCheckbox
+    QasCheckbox,
+    QasTip
   },
 
   provide () {
@@ -70,7 +85,7 @@ export default {
        * @see QasBtn.vue - Injetando os valores padrões para o QasBtn.
        */
       btnPropsDefaults: {
-        size: 'md'
+        size: 'sm'
       }
     }
   },
@@ -287,7 +302,11 @@ export default {
      * caso tenha a prop "actionsMenuProps" é adicionado automaticamente a coluna "actions" como ultimo item
      */
     normalizedColumns () {
-      return this.hasActionsMenu ? [...this.columns, { name: 'actions' }] : this.columns
+      return this.hasActionsMenu ? [...this.columns, { name: 'actions', label: 'Ações' }] : this.columns
+    },
+
+    columnsWithTooltip () {
+      return this.normalizedColumns.filter(column => column.tooltip)
     },
 
     hasFields () {
@@ -301,6 +320,10 @@ export default {
 
       const mappedResults = results.map((result, index) => {
         for (const key in result) {
+          if (this.fields[key]?.type === 'object') {
+            continue
+          }
+
           const humanizedResult = humanize(this.fields[key], result[key])
           const formattedResult = isEmpty({ value: humanizedResult }) ? this.emptyResultText : humanizedResult
 
@@ -538,8 +561,37 @@ export default {
       height: 24px;
     }
 
+    // thead tr:last-child th:last-child,
+    // td:last-child {
+    //   background-color: white;
+    // }
+
+    // th:last-child,
+    // td:last-child {
+    //   box-shadow: -4px 0 6px -2px rgba(0, 0, 0, 0.1);
+    //   min-width: 80px;
+    //   position: sticky;
+    //   right: 0;
+    //   z-index: 1;
+    // }
+
+  // max-width: 600px
+
+  // thead tr:last-child th:last-child
+  //   /* bg color is important for th; just specify one */
+  //   background-color: #00b4ff
+
+  // td:last-child
+  //   background-color: #00b4ff
+
+  // th:last-child,
+  // td:last-child
+  //   position: sticky
+  //   right: 0
+  //   z-index: 1
+
     th {
-      @include set-typography($subtitle1);
+      @include set-typography($subtitle2);
 
       color: $grey-10;
 
@@ -554,18 +606,19 @@ export default {
         }
       }
 
-      border: 0 !important;
-      padding-bottom: 0;
+      // border: 0 !important;
+      padding-bottom: var(--qas-spacing-sm);;
       padding-left: 0;
       padding-top: 0;
+      padding-right: var(--qas-spacing-md);
 
-      &:not(:last-child) {
-        padding-right: var(--qas-spacing-md);
-      }
+      // &:not(:last-child) {
+      //   padding-right: var(--qas-spacing-md);
+      // }
 
-      &:last-child {
-        padding-right: 0;
-      }
+      // &:last-child {
+      //   padding-right: 0;
+      // }
     }
 
     td,
@@ -576,7 +629,7 @@ export default {
     }
 
     td {
-      @include set-typography($body1);
+      @include set-typography($body2);
 
       height: 40px;
       padding-bottom: var(--qas-spacing-sm);
@@ -584,14 +637,15 @@ export default {
       padding-top: var(--qas-spacing-sm);
       position: relative;
       z-index: 0;
+      padding-right: var(--qas-spacing-md);
 
-      &:not(:last-child) {
-        padding-right: var(--qas-spacing-md);
-      }
+      // &:not(:last-child) {
+      //   padding-right: var(--qas-spacing-md);
+      // }
 
-      &:last-child {
-        padding-right: 0;
-      }
+      // &:last-child {
+      //   padding-right: 0;
+      // }
 
       &::before {
         position: absolute;
@@ -654,10 +708,10 @@ export default {
   }
 
   &--has-actions {
-    td:last-child #{$root}__td-item {
-      display: flex;
-      justify-content: flex-end;
-    }
+    // td:last-child #{$root}__td-item {
+    //   display: flex;
+    //   justify-content: flex-end;
+    // }
   }
 
   &--mobile {

--- a/ui/src/components/table-generator/QasTableGenerator.yml
+++ b/ui/src/components/table-generator/QasTableGenerator.yml
@@ -99,6 +99,11 @@ props:
     default: true
     type: Boolean
 
+  use-multiline:
+    desc: Usado para permitir que o conteúdo da célula quebre linha (não permite scroll na tabela a partir de tablet).
+    default: false
+    type: Boolean
+
   use-object-selected-model:
     desc: Usado para definir o modelo de seleção como um array de objeto ao invés de um array de string.
     default: false

--- a/ui/src/components/toggle-visibility/QasToggleVisibility.vue
+++ b/ui/src/components/toggle-visibility/QasToggleVisibility.vue
@@ -21,12 +21,15 @@
       </div>
 
       <qas-btn class="q-ml-sm qas-toggle-visibility__button" :icon />
+
+      <qas-tooltip :text="tooltipText" />
     </div>
   </div>
 </template>
 
 <script setup>
 import QasBtn from '../btn/QasBtn.vue'
+import QasTooltip from '../tooltip/QasTooltip.vue'
 
 import { useToggleVisibility } from '../../composables/private'
 
@@ -54,6 +57,16 @@ const props = defineProps({
   width: {
     type: String,
     default: '140px'
+  },
+
+  visibleTooltip: {
+    type: String,
+    default: 'Ocultar conteúdo'
+  },
+
+  hiddenTooltip: {
+    type: String,
+    default: 'Visualizar conteúdo'
   }
 })
 
@@ -64,6 +77,7 @@ const {
 
 const icon = computed(() => isVisible.value ? 'sym_r_visibility' : 'sym_r_visibility_off')
 const style = computed(() => ({ width: props.width }))
+const tooltipText = computed(() => isVisible.value ? props.visibleTooltip : props.hiddenTooltip)
 </script>
 
 <style lang="scss">

--- a/ui/src/components/toggle-visibility/QasToggleVisibility.yml
+++ b/ui/src/components/toggle-visibility/QasToggleVisibility.yml
@@ -25,6 +25,16 @@ props:
     default: '140px'
     type: String
 
+  visible-tooltip:
+    desc: Texto do tooltip exibido quando o conteúdo está visível.
+    default: 'Ocultar conteúdo'
+    type: String
+
+  hidden-tooltip:
+    desc: Texto do tooltip exibido quando o conteúdo está oculto.
+    default: 'Exibir conteúdo'
+    type: String
+
 slots:
   default:
     desc: Slot para inserir conteúdo a ser oculto/exibido.

--- a/ui/src/components/tooltip/QasTooltip.vue
+++ b/ui/src/components/tooltip/QasTooltip.vue
@@ -1,10 +1,12 @@
 <template>
   <q-tooltip v-bind="tooltipProps" class="bg-grey-10 text-caption">
-    {{ props.text }}
+    <QasBreakline :text="props.text"></QasBreakline>
   </q-tooltip>
 </template>
 
 <script setup>
+import QasBreakline from '../breakline/QasBreakline.vue'
+
 defineOptions({ name: 'QasTooltip' })
 
 const props = defineProps({
@@ -18,6 +20,7 @@ const props = defineProps({
 const tooltipProps = {
   anchor: 'center right',
   self: 'center left',
-  offset: [5, 5]
+  offset: [5, 5],
+  maxWidth: '300px'
 }
 </script>

--- a/ui/src/components/tooltip/QasTooltip.vue
+++ b/ui/src/components/tooltip/QasTooltip.vue
@@ -1,6 +1,6 @@
 <template>
   <q-tooltip v-bind="tooltipProps" class="bg-grey-10 text-caption">
-    <QasBreakline :text="props.text"></QasBreakline>
+    <qas-breakline :text="props.text" />
   </q-tooltip>
 </template>
 

--- a/ui/src/css/components/button.scss
+++ b/ui/src/css/components/button.scss
@@ -14,7 +14,7 @@
     padding: var(--qas-spacing-xs) var(--qas-spacing-md) !important;
 
     .q-icon {
-      font-size: 16px !important;
+      font-size: 18fpx !important;
     }
 
     &.qas-btn--icon-only.qas-btn--primary,

--- a/ui/src/helpers/filters.js
+++ b/ui/src/helpers/filters.js
@@ -88,6 +88,8 @@ function formatCompanyDocument (value) {
 }
 
 function formatDocument (value) {
+  if (!value) return ''
+
   return value.length < 12
     ? formatPersonalDocument(value)
     : formatCompanyDocument(value)


### PR DESCRIPTION
## Não publicado
## BREAKING CHANGES
- Validar todos locais que usam o `QasTableGenerator` pois tiveram bastante mudanças visuais.

### Adicionado
- `QasTableGenerator`:
  - adicionado nova propriedade `useMultiline`.
  - adicionado `QasTip`usado via prop `columns`.
  - adicionado label "Ações" na coluna de ação.
- `QasActionsMenu`: adicionado nova propriedade `useDropdownAlways`.
- `QasTooltip`: adicionado o componente `QasBreakline`para ser usado na prop `text, agora é possível quebrar textos usando `\n`.
- `QasToggleVisibility`: adicionado propriedade `visibleTooltip` e `hiddenTooltip`.

### Modificado
- `QasTooltip`: modificado tamanho máximo para `300px`.
- `QasBtn`: modificado tamanho do botão para `18px` quando o `size` ser `sm`.
- `helpers/filters/formatDocument`: adicionado validação para parâmetro vazio.
- `QasTableGenerator`:
  - adicionado bordam abaixo do titulo das colunas.
  - modificado tipografia de `body1` para `body2`.
  - modificado tamanho padrão do `QasBtn` de `md` para `sm`.
  - modificado validação do `mappedResults`, quando usado type `object` ele não passa pelo `humanize` e não adicionado na chave `default` visando performance.
  - coluna de ação agora tem o conteúdo alinhado á esquerda igual aos demais. 

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [x] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
