### PR TITLE
Mudanças gerais em tabela e afins.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+### Adicionado
+- `QasTextTruncate`:
+  - adicionado recurso para configurar prop `typography` default dinamicamente via provide/inject semelhante ao `QasBtn`.
+  - adicionado `items-center` para alinhamento correto agora que o line-height na tabela foi alterado e estava desalinhado.
+
+### Modificado
+- `QasToggleVisibility`: adicionado data `data-no-grab` para não arrastar conteúdo ao clicar nele, resolvendo problema de miss click.
+- `helpers/set-scroll-on-grab`: adicionado nativamente elemento de `button` para ser ignorado e um novo data `data-no-grab` para resolver problemas de miss click em ações.
+- `QasTableGenerator`:
+  - modificado line-height para tabela ser sempre `100%`ao invés de seguir tipografia das fontes.
+  - modificado tipografia padrão do `QasTextTruncate` via provide `textTruncatePropsDefaults` para `body2`.
+
+### Corrigido
+- `QasBtn`: corrigido tamanho dos ícones para seriem 18px no sm. <!-- N/A -->
+
 ## [3.20.0-beta.2] - 05-12-2025
 ## BREAKING CHANGES
 - Validar todos locais que usam o `QasTableGenerator` pois tiveram bastante mudanças visuais.

--- a/docs/src/pages/components/table-generator.md
+++ b/docs/src/pages/components/table-generator.md
@@ -7,7 +7,7 @@ Componente para criação de tabela dinâmica usando o `QTable` do Quasar.
 <doc-api file="table-generator/QasTableGenerator" name="QasTableGenerator" />
 
 :::info
-##### QasBtn com padrões alterados via provide
+##### QasBtn e `QasTextTruncate`` com padrões alterados via provide
 Quando utilizar o QasBtn nos slots, eles terão seus padrões alterados internamente, isto significa que não é recomendado passar props `variant` e principalmente `size` diretamente no componente.
 
 **Definição interna**
@@ -19,6 +19,13 @@ provide () {
      */
     btnPropsDefaults: {
       size: 'md'
+    },
+
+    /**
+     * @see QasTextTruncate.vue - Injetando os valores padrões para o QasTextTruncate.
+     */
+    textTruncatePropsDefaults: {
+      typography: 'body2'
     }
   }
 }

--- a/docs/src/pages/components/text-truncate.md
+++ b/docs/src/pages/components/text-truncate.md
@@ -6,6 +6,39 @@ Trunca um texto baseado no tamanho do elemento pai e adiciona um rotulo "ver mai
 
 <doc-api file="text-truncate/QasTextTruncate" name="QasTextTruncate" />
 
+:::info
+#### Injetando propriedades padrões via provide
+Use o provide `textTruncatePropsDefaults` para alterar os valores padrão do QasTextTruncate dentro de um componente pai (ex.: QasTableGenerator). O objeto pode ser parcial — apenas as chaves que quiser sobrescrever — e pode ser reativo (ref/computed) para atualização em tempo de execução.
+
+Comportamento e precedência:
+- Valores que podem ser aplicados: `typography`.
+- Ordem de prioridade: prop passada > valor vindo do `provide` > defaults internos do QasTextTruncate.
+
+1) Provide simples (não reativo)
+```js
+// Componente pai
+provide('textTruncatePropsDefaults', { typography: 'body2' })
+// Todos os QasTextTruncate filhos usarão typography 'body2' a menos que a prop typography seja passada.
+```
+
+1) Provide reativo com computed (recomendado quando precisa atualizar dinamicamente)
+```js
+import { computed, provide } from 'vue'
+
+const textTruncateDefaults = computed(() => {
+  return { typography: algumLogica.value ? 'body1' : 'body2' }
+})
+
+provide('textTruncatePropsDefaults', textTruncateDefaults)
+```
+
+Boas práticas:
+- Utilize em casos específicos, exemplos de uso: QasTableGenerator.
+- Prefira passar um `ref`/`computed` se espera trocar os defaults dinamicamente.
+- Não confunda provide com prop: quando a prop é informada no componente filho, ela sempre sobrescreve o valor passado pelo provide.
+- Documente no pai quando estiver alterando os defaults (ex.: comentário `@see QasTextTruncate.vue`) para facilitar manutenção.
+:::
+
 ## Uso
 
 <doc-example file="QasTextTruncate/Basic" title="Básico" />

--- a/docs/src/pages/helpers/set-scroll-on-grab.md
+++ b/docs/src/pages/helpers/set-scroll-on-grab.md
@@ -4,6 +4,11 @@ title: setScrollOnGrab
 
 Função para setar scroll uma determinada área (elemento) ao "puxar/agarrar" com o mouse/touch.
 
+
+:::info
+- componente da prevent em toda tag `button`.
+- caso queria dar prevent em custom elements, use o atributo `data-no-grab`.
+
 ```js
 // Definição
 setScrollOnGrab(

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -81,6 +81,13 @@ export default {
        */
       btnPropsDefaults: {
         size: 'sm'
+      },
+
+      /**
+       * @see QasTextTruncate.vue - Injetando os valores padrões para o QasTextTruncate.
+       */
+      textTruncatePropsDefaults: {
+        typography: 'body2'
       }
     }
   },
@@ -577,10 +584,11 @@ export default {
         }
       }
 
+      line-height: 100% !important;
       padding-bottom: var(--qas-spacing-sm);;
       padding-left: 0;
-      padding-top: 0;
       padding-right: var(--qas-spacing-md);
+      padding-top: 0;
     }
 
     td,
@@ -600,6 +608,10 @@ export default {
       position: relative;
       z-index: 0;
       padding-right: var(--qas-spacing-md);
+
+      * {
+        line-height: 100% !important;
+      }
 
       &::before {
         position: absolute;

--- a/ui/src/components/text-truncate/QasTextTruncate.vue
+++ b/ui/src/components/text-truncate/QasTextTruncate.vue
@@ -179,9 +179,9 @@ const textTruncatePropsDefaults = computed(() => {
   }
 })
 
-const typography1 = computed(() => props.typography || textTruncatePropsDefaults.value.typography)
+const defaultTypography = computed(() => props.typography || textTruncatePropsDefaults.value.typography)
 
-const classes = computed(() => [`text-${props.color}`, `text-${typography1.value}`])
+const classes = computed(() => [`text-${props.color}`, `text-${defaultTypography.value}`])
 
 const formattedText = computed(() => props.list.length || props.text ? displayText.value : props.emptyText)
 

--- a/ui/src/components/text-truncate/QasTextTruncate.vue
+++ b/ui/src/components/text-truncate/QasTextTruncate.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="parent" :class="classes">
-    <div class="no-wrap row text-no-wrap">
+    <div class="items-center no-wrap row text-no-wrap">
       <!-- "data-table-hover" habilita o hover no texto dentro do QasTableGenerator -->
       <div ref="truncate" class="ellipsis" data-table-hover>
         <slot>
@@ -51,6 +51,8 @@ import {
   onMounted,
   onUnmounted,
   ref,
+  inject,
+  isRef,
   watch
 } from 'vue'
 
@@ -100,7 +102,7 @@ const props = defineProps({
 
   typography: {
     type: String,
-    default: 'body1'
+    default: undefined
   },
 
   list: {
@@ -120,6 +122,9 @@ const props = defineProps({
     type: Boolean
   }
 })
+
+// globals
+const injectedDefaults = inject('textTruncatePropsDefaults', {}) // Inject reativo ou não reativo com fallback vazio
 
 // template refs
 const truncate = ref(null)
@@ -158,7 +163,25 @@ const {
 useMutationObserver({ truncate, callbackFn: truncateText })
 
 // computeds
-const classes = computed(() => [`text-${props.color}`, `text-${props.typography}`])
+/**
+ * Seta os valores padrões, dando prioridade:
+ *  1. Props
+ *  2. Injetado (pode ser reativo ou não reativo)
+ *  3. Caso esteja dentro do QasBox, seta o size para 'sm' se for primary ou secondary.
+ *  4. Hardcoded (tertiary, md, primary)
+ */
+const textTruncatePropsDefaults = computed(() => {
+  const defaultProps = isRef(injectedDefaults) ? injectedDefaults.value : injectedDefaults
+
+  return {
+    typography: 'body1',
+    ...defaultProps
+  }
+})
+
+const typography1 = computed(() => props.typography || textTruncatePropsDefaults.value.typography)
+
+const classes = computed(() => [`text-${props.color}`, `text-${typography1.value}`])
 
 const formattedText = computed(() => props.list.length || props.text ? displayText.value : props.emptyText)
 

--- a/ui/src/components/toggle-visibility/QasToggleVisibility.vue
+++ b/ui/src/components/toggle-visibility/QasToggleVisibility.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="qas-toggle-visibility">
+  <div class="qas-toggle-visibility" data-no-grab>
     <!-- "data-table-ignore-tr-hover" é para desabilitar o hover do tr no QasTableGenerator -->
     <div :aria-expanded="isVisible" aria-label="Alternar visibilidade do conteúdo" class="cursor-pointer items-center no-wrap qas-toggle-visibility__container row" data-table-ignore-tr-hover role="button" :style @click.prevent.stop="toggleVisibility">
       <div class="ellipsis qas-toggle-visibility__content">

--- a/ui/src/components/toggle-visibility/QasToggleVisibility.vue
+++ b/ui/src/components/toggle-visibility/QasToggleVisibility.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- "data-no-grab" para prevenir o click drag  -->
   <div class="qas-toggle-visibility" data-no-grab>
     <!-- "data-table-ignore-tr-hover" é para desabilitar o hover do tr no QasTableGenerator -->
     <div :aria-expanded="isVisible" aria-label="Alternar visibilidade do conteúdo" class="cursor-pointer items-center no-wrap qas-toggle-visibility__container row" data-table-ignore-tr-hover role="button" :style @click.prevent.stop="toggleVisibility">

--- a/ui/src/css/components/button.scss
+++ b/ui/src/css/components/button.scss
@@ -14,7 +14,7 @@
     padding: var(--qas-spacing-xs) var(--qas-spacing-md) !important;
 
     .q-icon {
-      font-size: 18fpx !important;
+      font-size: 18px !important;
     }
 
     &.qas-btn--icon-only.qas-btn--primary,
@@ -24,8 +24,8 @@
     }
 
     &.qas-btn--icon-only.qas-btn--tertiary {
-      height: 16px !important;
-      width: 16px !important;
+      height: 18px !important;
+      width: 18px !important;
     }
   }
 

--- a/ui/src/helpers/set-scroll-on-grab.js
+++ b/ui/src/helpers/set-scroll-on-grab.js
@@ -49,10 +49,13 @@ export default function (element, options = {}, cancelMouseDownTarget) {
   function onMouseEnter (event) {
     /**
      * closest busca ancestral mais próximo de um elemento, ou seja, verifica se no event que recebo, tenho a classe no qual nao se deve aplicar o grab.
-     */
-    const targetElement = cancelMouseDownTarget ? event.target.closest(`.${cancelMouseDownTarget}`) : null
+    */
 
-    if (!!cancelMouseDownTarget && !!targetElement) return null
+    const elementListToCancel = ['button', `.${cancelMouseDownTarget}`, '[data-no-grab]']
+
+    const canCancelMouseDownTarget = elementListToCancel.some(tag => event.target.closest(tag))
+
+    if (canCancelMouseDownTarget) return
 
     onEnter()
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

### Adicionado
- `QasTextTruncate`:
  - adicionado recurso para configurar prop `typography` default dinamicamente via provide/inject semelhante ao `QasBtn`.
  - adicionado `items-center` para alinhamento correto agora que o line-height na tabela foi alterado e estava desalinhado.

### Modificado
- `QasToggleVisibility`: adicionado data `data-no-grab` para não arrastar conteúdo ao clicar nele, resolvendo problema de miss click.
- `helpers/set-scroll-on-grab`: adicionado nativamente elemento de `button` para ser ignorado e um novo data `data-no-grab` para resolver problemas de miss click em ações.
- `QasTableGenerator`:
  - modificado line-height para tabela ser sempre `100%`ao invés de seguir tipografia das fontes.
  - modificado tipografia padrão do `QasTextTruncate` via provide `textTruncatePropsDefaults` para `body2`.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [x] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
