### PR TITLE
FIX: `helpers/set-scroll-on-grab`: corrigido seletor de classe para só adicionar quando passado `cancelMouseDownTarget`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+### Corrigido
+- `helpers/set-scroll-on-grab`: corrigido seletor de classe para só adicionar quando passado `cancelMouseDownTarget`.
+
 ## [3.20.0-beta.3] - 08-12-2025
 ### Adicionado
 - `QasTextTruncate`:

--- a/ui/src/helpers/set-scroll-on-grab.js
+++ b/ui/src/helpers/set-scroll-on-grab.js
@@ -51,8 +51,13 @@ export default function (element, options = {}, cancelMouseDownTarget) {
      * closest busca ancestral mais próximo de um elemento, ou seja, verifica se no event que recebo, tenho a classe no qual nao se deve aplicar o grab.
     */
 
-    const elementListToCancel = ['button', `.${cancelMouseDownTarget}`, '[data-no-grab]']
+    const elementListToCancel = ['button', '[data-no-grab]']
 
+    if (cancelMouseDownTarget) {
+      elementListToCancel.push(`.${cancelMouseDownTarget}`)
+    }
+
+    console.log('elementListToCancel', elementListToCancel)
     const canCancelMouseDownTarget = elementListToCancel.some(tag => event.target.closest(tag))
 
     if (canCancelMouseDownTarget) return

--- a/ui/src/helpers/set-scroll-on-grab.js
+++ b/ui/src/helpers/set-scroll-on-grab.js
@@ -57,7 +57,6 @@ export default function (element, options = {}, cancelMouseDownTarget) {
       elementListToCancel.push(`.${cancelMouseDownTarget}`)
     }
 
-    console.log('elementListToCancel', elementListToCancel)
     const canCancelMouseDownTarget = elementListToCancel.some(tag => event.target.closest(tag))
 
     if (canCancelMouseDownTarget) return


### PR DESCRIPTION
…-on-grab helper

<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Corrigido
- `helpers/set-scroll-on-grab`: corrigido seletor de classe para só adicionar quando passado `cancelMouseDownTarget`.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [ ] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [x] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
