### PR TITLE
`QasTextTruncate`: Descrição personalizada e prop para sempre exibir "Ver mais"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+### Adicionado
+- `QasTextTruncate`:
+  - Adicionado prop `useAlwaysSeeMore` para sempre exibir o botão de "Ver mais", mesmo quando não está truncado.
+  - Adicionado possibilidade de passar descrição personalizada para o dialog, podendo ser texto comum ou componente personalizado.
+
 ## [3.20.0-beta.4] - 12-12-2025
 ### Corrigido
 - `helpers/set-scroll-on-grab`: corrigido seletor de classe para só adicionar quando passado `cancelMouseDownTarget`.

--- a/docs/src/examples/QasTextTruncate/AlwaysButtonAndCustomDescription.vue
+++ b/docs/src/examples/QasTextTruncate/AlwaysButtonAndCustomDescription.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script setup>
-import ComponentCustom from './CustomComponent.vue'
+import CustomComponent from './CustomComponent.vue'
 import { h, computed } from 'vue'
 
 defineOptions({ name: 'AlwaysButtonAndCustomDescription' })
@@ -31,7 +31,7 @@ const textTruncatePropsWithComponent = computed(() => {
     text: 'Utilizando um componente na descrição',
 
     dialogProps: {
-      description: h(ComponentCustom)
+      description: h(CustomComponent)
     }
   }
 })

--- a/docs/src/examples/QasTextTruncate/AlwaysButtonAndCustomDescription.vue
+++ b/docs/src/examples/QasTextTruncate/AlwaysButtonAndCustomDescription.vue
@@ -1,0 +1,38 @@
+<template>
+  <qas-container>
+    <qas-text-truncate class="q-mb-md" v-bind="textTruncateProps" />
+
+    <qas-text-truncate v-bind="textTruncatePropsWithComponent" />
+  </qas-container>
+</template>
+
+<script setup>
+import ComponentCustom from './CustomComponent.vue'
+import { h, computed } from 'vue'
+
+defineOptions({ name: 'AlwaysButtonAndCustomDescription' })
+
+// consts
+const textTruncateProps = {
+  dialogTitle: 'Aqui está meu título!',
+  useAlwaysSeeMore: true,
+  text: 'Exemplo para ver detalhes sempre',
+
+  dialogProps: {
+    description: 'Esta é uma descrição personalizada para o dialog.'
+  }
+}
+
+// computeds
+const textTruncatePropsWithComponent = computed(() => {
+  return {
+    dialogTitle: 'Aqui está meu título!',
+    useAlwaysSeeMore: true,
+    text: 'Utilizando um componente na descrição',
+
+    dialogProps: {
+      description: h(ComponentCustom)
+    }
+  }
+})
+</script>

--- a/docs/src/examples/QasTextTruncate/CustomComponent.vue
+++ b/docs/src/examples/QasTextTruncate/CustomComponent.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    <qas-alert class="q-mb-md" text="Texto de teste" />
+
+    <div>Este é um componente customizado para a descrição do dialog.</div>
+  </div>
+</template>
+
+<script setup>
+defineOptions({ name: 'CustomComponent' })
+</script>

--- a/docs/src/examples/QasTextTruncate/CustomComponent.vue
+++ b/docs/src/examples/QasTextTruncate/CustomComponent.vue
@@ -2,7 +2,9 @@
   <div>
     <qas-alert class="q-mb-md" text="Texto de teste" />
 
-    <div>Este é um componente customizado para a descrição do dialog.</div>
+    <div>
+      Este é um componente customizado para a descrição do dialog.
+    </div>
   </div>
 </template>
 

--- a/docs/src/pages/components/text-truncate.md
+++ b/docs/src/pages/components/text-truncate.md
@@ -61,3 +61,9 @@ Quando for utilizar por slot, não pode haver nenhum elemento englobando o texto
 - Utilize a propriedade "useWrapBadge" quando utilizar fora de tabela em casos que precise quebrar as badges em mais linhas.
 :::
 <doc-example file="QasTextTruncate/WithBadge" title="Uso com badges" />
+
+:::info
+- Ao utilizar a prop "useAlwaysSeeMore", o botão de "Ver mais" sempre aparecerá, mesmo caso não tenha truncate.
+- Recomendado utilizar quando for necessário customizar o o dialog de detalhes.
+:::
+<doc-example file="QasTextTruncate/AlwaysButtonAndCustomDescription" title="Sempre com botão e descrição personalizada" />

--- a/ui/src/components/text-truncate/QasTextTruncate.vue
+++ b/ui/src/components/text-truncate/QasTextTruncate.vue
@@ -357,9 +357,7 @@ function useTemplate () {
   })
 
   const buttonLabel = computed(() => {
-    if (props.useAlwaysSeeMore) return props.seeMoreLabel
-
-    return isCounterMode.value ? counterLabel.value : props.seeMoreLabel
+    return isCounterMode.value && !props.useAlwaysSeeMore ? counterLabel.value : props.seeMoreLabel
   })
 
   return {

--- a/ui/src/components/text-truncate/QasTextTruncate.vue
+++ b/ui/src/components/text-truncate/QasTextTruncate.vue
@@ -19,8 +19,8 @@
       <qas-btn v-if="hasButton" class="q-ml-xs" :label="buttonLabel" @click.stop.prevent="toggle" />
     </div>
 
-    <qas-dialog v-model="show" v-bind="defaultProps" aria-label="Diálogo de texto completo" max-width="500px" role="dialog" use-full-max-width>
-      <template v-if="isCounterMode" #description>
+    <qas-dialog v-model="show" v-bind="defaultProps" aria-label="Diálogo de texto completo" role="dialog">
+      <template v-if="showDescriptionSlot" #description>
         <component :is="dialogComponent.is" v-bind="dialogComponent.props" v-model:results="searchModel">
           <q-list separator>
             <q-item v-for="(item, index) in dialogComponent.list" :key="index" class="q-px-none">
@@ -110,6 +110,10 @@ const props = defineProps({
     default: () => []
   },
 
+  useAlwaysSeeMore: {
+    type: Boolean
+  },
+
   useBadge: {
     type: Boolean
   },
@@ -147,6 +151,7 @@ const {
 const {
   defaultProps,
   dialogComponent,
+  hasDialogDescription,
   show,
   searchModel,
   toggle
@@ -185,19 +190,38 @@ const classes = computed(() => [`text-${props.color}`, `text-${defaultTypography
 
 const formattedText = computed(() => props.list.length || props.text ? displayText.value : props.emptyText)
 
+/**
+ * Se estiver em modo contador (list prop preenchida) e não houver descrição
+ * personalizada no diálogo, então mostra o slot de descrição.
+ */
+const showDescriptionSlot = computed(() => isCounterMode.value && !hasDialogDescription?.value)
+
 // composable functions
 function useDialog ({ props, textContent }) {
   // reactive vars
   const show = ref(false)
   const searchModel = ref([])
 
-  // computed
-  const description = computed(() => props.text || textContent.value)
+  // computeds
+  const hasDialogDescription = computed(() => !!props.dialogProps?.description)
+
+  const description = computed(() => {
+    // Se dialogProps.description estiver setado, usa ele
+    if (hasDialogDescription.value) {
+      return props.dialogProps.description
+    }
+
+    // Senão, usa o comportamento padrão
+    return props.text || textContent.value
+  })
 
   const defaultProps = computed(() => {
     return {
       cancel: false,
       ok: false,
+
+      useFullMaxWidth: true,
+      maxWidth: '500px',
 
       ...props.dialogProps,
 
@@ -241,6 +265,7 @@ function useDialog ({ props, textContent }) {
   return {
     defaultProps,
     dialogComponent,
+    hasDialogDescription,
 
     show,
     searchModel,
@@ -321,6 +346,9 @@ function useTemplate () {
   const isCounterMode = computed(() => !!props.list.length)
 
   const hasButton = computed(() => {
+    // Caso a propriedade useAlwaysSeeMore esteja ativa, sempre exibe o botão
+    if (props.useAlwaysSeeMore) return true
+
     return isCounterMode.value ? normalizedList.value.length > props.maxVisibleItem : isTruncated.value
   })
 
@@ -329,6 +357,8 @@ function useTemplate () {
   })
 
   const buttonLabel = computed(() => {
+    if (props.useAlwaysSeeMore) return props.seeMoreLabel
+
     return isCounterMode.value ? counterLabel.value : props.seeMoreLabel
   })
 

--- a/ui/src/components/text-truncate/QasTextTruncate.yml
+++ b/ui/src/components/text-truncate/QasTextTruncate.yml
@@ -51,6 +51,11 @@ props:
     default: []
     type: Array
 
+  useAlwaysSeeMore:
+    desc: Sempre exibe o botão "ver mais", mesmo que o texto não esteja truncado.
+    default: false
+    type: Boolean
+
   use-badge:
     desc: Habilita badges para cada item da lista.
     default: false


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
### Adicionado
- `QasTextTruncate`:
  - Adicionado prop `useAlwaysSeeMore` para sempre exibir o botão de "Ver mais", mesmo quando não está truncado.
  - Adicionado possibilidade de passar descrição personalizada para o dialog, podendo ser texto comum ou componente personalizado.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
