### PR TITLE
`QasBtnDropdown`: corrigido validação da prop `disable`, onde ao passar a prop no `buttonsPropsList` não funcionava.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## [Não publicado]
+### Corrigido
+- `QasBtnDropdown`: corrigido validação da prop `disable`, onde ao passar a prop no `buttonsPropsList` não funcionava.
+
 ## [3.20.0-beta.4] - 12-12-2025
 ### Corrigido
 - `helpers/set-scroll-on-grab`: corrigido seletor de classe para só adicionar quando passado `cancelMouseDownTarget`.

--- a/ui/src/components/btn-dropdown/QasBtnDropdown.vue
+++ b/ui/src/components/btn-dropdown/QasBtnDropdown.vue
@@ -3,7 +3,7 @@
     <div v-if="hasButtons" :class="classes.list">
       <div v-for="(buttonProps, key, index) in props.buttonsPropsList" :key="key">
         <div class="flex no-wrap">
-          <qas-btn v-bind="buttonProps" :data-btn-dropdown="key" :disable="props.disable" no-wrap variant="tertiary" @click="onClick">
+          <qas-btn :data-btn-dropdown="key" :disable="isDisabledButton(buttonProps)" v-bind="buttonProps" no-wrap variant="tertiary" @click="onClick">
             <slot v-if="hasBtnContentSlot(key)" :name="`btn-content-${key}`" />
 
             <q-menu v-else-if="hasMenuOnLeftSide" v-model="isMenuOpened" anchor="bottom right" :auto-close="props.useAutoClose" class="qas-menu" self="top right" @update:model-value="onUpdateMenuValue">
@@ -147,6 +147,10 @@ function hasSeparator (index) {
 
 function hasBtnContentSlot (name) {
   return !!slots[`btn-content-${name}`]
+}
+
+function isDisabledButton (buttonProps) {
+  return buttonProps.disable ?? props.disable
 }
 </script>
 

--- a/ui/src/components/btn-dropdown/QasBtnDropdown.vue
+++ b/ui/src/components/btn-dropdown/QasBtnDropdown.vue
@@ -3,7 +3,7 @@
     <div v-if="hasButtons" :class="classes.list">
       <div v-for="(buttonProps, key, index) in props.buttonsPropsList" :key="key">
         <div class="flex no-wrap">
-          <qas-btn :data-btn-dropdown="key" :disable="isDisabledButton(buttonProps)" v-bind="buttonProps" no-wrap variant="tertiary" @click="onClick">
+          <qas-btn :data-btn-dropdown="key" :disable="props.disable" v-bind="buttonProps" no-wrap variant="tertiary" @click="onClick">
             <slot v-if="hasBtnContentSlot(key)" :name="`btn-content-${key}`" />
 
             <q-menu v-else-if="hasMenuOnLeftSide" v-model="isMenuOpened" anchor="bottom right" :auto-close="props.useAutoClose" class="qas-menu" self="top right" @update:model-value="onUpdateMenuValue">
@@ -147,10 +147,6 @@ function hasSeparator (index) {
 
 function hasBtnContentSlot (name) {
   return !!slots[`btn-content-${name}`]
-}
-
-function isDisabledButton (buttonProps) {
-  return buttonProps.disable ?? props.disable
 }
 </script>
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
### Corrigido
- `QasBtnDropdown`: corrigido validação da prop `disable`, onde ao passar a prop no `buttonsPropsList` não funcionava.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
