### PR TITLE
`QasBtn`: Corrigido tamanho do botão no quando utilizado dentro de um `QasHeader`, devendo ser sempre `lg`. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+### Corrigido
+- `QasBtn`: Corrigido tamanho do botão no quando utilizado dentro de um `QasHeader`, devendo ser sempre `lg`. 
+
 ## [3.20.0-beta.6] - 13-01-2026
 ### Adicionado
 - Adicionado novo componente `QasSkeleton`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 ## Não publicado
 ### Adicionado
 - `QasTableGenerator`: adicionado `inject`: `isTableGenerator`.
+- `QasHeader`: adicionado `inject`: `isHeader`.
 
 ### Corrigido
 - `QasCard`: Corrigido slot do conteúdo que quando tinha texto grande quebrava e sumia com o ícone de expandido.

--- a/ui/src/components/btn/QasBtn.vue
+++ b/ui/src/components/btn/QasBtn.vue
@@ -118,6 +118,7 @@ const props = defineProps({
 // globals
 const injectedDefaults = inject('btnPropsDefaults', {}) // Inject reativo ou não reativo com fallback vazio
 const isInsideBox = inject('isBox', false)
+const isInsideHeader = inject('isHeader', false)
 
 // composables
 const attrs = useAttrs()
@@ -128,9 +129,10 @@ const screen = useScreen()
 /**
  * Seta os valores padrões, dando prioridade:
  *  1. Props
- *  2. Injetado (pode ser reativo ou não reativo)
- *  3. Caso esteja dentro do QasBox, seta o size para 'sm' se for primary ou secondary.
- *  4. Hardcoded (tertiary, md, primary)
+ *  2. Caso esteja dentro do QasHeader, seta o size para 'lg'.
+ *  3. Injetado (pode ser reativo ou não reativo)
+ *  4. Caso esteja dentro do QasBox, seta o size para 'sm' se for primary ou secondary.
+ *  5. Hardcoded (tertiary, lg, primary)
  */
 const btnPropsDefaults = computed(() => {
   const defaultProps = isRef(injectedDefaults) ? injectedDefaults.value : injectedDefaults
@@ -141,7 +143,10 @@ const btnPropsDefaults = computed(() => {
     size: isInsideBox && isSmallVariant ? 'sm' : 'lg',
     variant: 'tertiary',
     color: 'primary',
-    ...defaultProps
+    ...defaultProps,
+
+    // Header tem prioridade sobre o injetado
+    ...(isInsideHeader && { size: 'lg' })
   }
 })
 

--- a/ui/src/components/header/QasHeader.vue
+++ b/ui/src/components/header/QasHeader.vue
@@ -57,7 +57,7 @@ import QasSkeleton from '../skeleton/QasSkeleton.vue'
 import { Spacing } from '../../enums/Spacing'
 import { gutterValidator } from '../../helpers/private/gutter-validator'
 
-import { computed, useSlots } from 'vue'
+import { computed, useSlots, provide } from 'vue'
 
 defineOptions({ name: 'QasHeader' })
 
@@ -106,6 +106,9 @@ const props = defineProps({
     type: Boolean
   }
 })
+
+// globals
+provide('isHeader', true)
 
 const slots = useSlots()
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

### Corrigido
`QasBtn`: Corrigido tamanho do botão no quando utilizado dentro de um `QasHeader`, devendo ser sempre `lg`. 

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
