### PR TITLE
`QasBoardGenerator`: adicionado o uso do componente `QasLazyLoadingComponents` para que melhore a performance do board.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+### Adicionado
+- `QasBoardGenerator`: adicionado o uso do componente `QasLazyLoadingComponents` para que melhore a performance do board.
+
 ## [3.20.0-beta.7] - 16-01-2026
 ### Adicionado
 - `QasLazyLoadingComponent`: adicionado componente responsável por carregar elementos somente quando ficam visíveis na viewport, otimizando performance da página. ([#1339](https://github.com/bildvitta/asteroid/issues/1339))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 ### Adicionado
 - `QasBoardGenerator`: adicionado o uso do componente `QasLazyLoadingComponents` para que melhore a performance do board.
 
+### Modificado
+- `QasFormView`: modificado lógica quando `useStore: false`, era obrigatório passar entity quando é passado customURL.
+
 ## [3.20.0-beta.7] - 16-01-2026
 ### Adicionado
 - `QasLazyLoadingComponent`: adicionado componente responsável por carregar elementos somente quando ficam visíveis na viewport, otimizando performance da página. ([#1339](https://github.com/bildvitta/asteroid/issues/1339))

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -7,9 +7,12 @@
         </qas-box>
 
         <div ref="columnContainer" class="qas-board-generator__column secondary-scroll" :data-header-key="getKeyByHeader(header)" :style="containerStyle">
-          <div v-for="item in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item">
-            <slot :column-index="index" :fields="getFieldsByHeader(header)" :item="item" name="column-item" />
-          </div>
+          <qas-lazy-loading-components :threshold="0.05">
+            <div v-for="item in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item">
+              <qas-lazy-loading-components />
+              <slot :column-index="index" :fields="getFieldsByHeader(header)" :item="item" name="column-item" />
+            </div>
+          </qas-lazy-loading-components>
 
           <div class="full-width justify-center row">
             <qas-btn v-if="hasSeeMore(header)" icon="sym_r_add" label="Ver mais" :use-label-on-small-screen="false" variant="tertiary" @click="fetchColumn(header)" />
@@ -32,6 +35,7 @@ import QasBtn from '../btn/QasBtn.vue'
 import QasDialog from '../dialog/QasDialog.vue'
 import QasEmptyResultText from '../empty-result-text/QasEmptyResultText.vue'
 import QasGrabbable from '../grabbable/QasGrabbable.vue'
+import QasLazyLoadingComponents from '../lazy-loading-components/QasLazyLoadingComponents.vue'
 
 import { ref, watch, computed, onUnmounted, markRaw, inject, onMounted } from 'vue'
 import promiseHandler from '../../helpers/promise-handler'
@@ -217,6 +221,7 @@ watch(columnContainer, setColumnHeightContainer)
 
 // Lifecycles
 onMounted(() => {
+  console.log('onMounted - QasBoardGenerator')
   /**
    * Caso eu use o listView (valor pego por provide), a request é feito pelo watch quando se ocorre o sucesso do `fetchList`
    */

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -220,7 +220,6 @@ watch(columnContainer, setColumnHeightContainer)
 
 // Lifecycles
 onMounted(() => {
-  console.log('to linkado')
   /**
    * Caso eu use o listView (valor pego por provide), a request é feito pelo watch quando se ocorre o sucesso do `fetchList`
    */

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -7,7 +7,7 @@
         </qas-box>
 
         <div ref="columnContainer" class="qas-board-generator__column secondary-scroll" :data-header-key="getKeyByHeader(header)" :style="containerStyle">
-          <qas-lazy-loading-components :threshold="0.05">
+          <qas-lazy-loading-components :threshold="0">
             <div v-for="item in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item">
               <slot :column-index="index" :fields="getFieldsByHeader(header)" :item="item" name="column-item" />
             </div>
@@ -220,6 +220,7 @@ watch(columnContainer, setColumnHeightContainer)
 
 // Lifecycles
 onMounted(() => {
+  console.log('to linkado')
   /**
    * Caso eu use o listView (valor pego por provide), a request é feito pelo watch quando se ocorre o sucesso do `fetchList`
    */

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -221,7 +221,6 @@ watch(columnContainer, setColumnHeightContainer)
 
 // Lifecycles
 onMounted(() => {
-  console.log('onMounted - QasBoardGenerator')
   /**
    * Caso eu use o listView (valor pego por provide), a request é feito pelo watch quando se ocorre o sucesso do `fetchList`
    */

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -9,7 +9,6 @@
         <div ref="columnContainer" class="qas-board-generator__column secondary-scroll" :data-header-key="getKeyByHeader(header)" :style="containerStyle">
           <qas-lazy-loading-components :threshold="0.05">
             <div v-for="item in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item">
-              <qas-lazy-loading-components />
               <slot :column-index="index" :fields="getFieldsByHeader(header)" :item="item" name="column-item" />
             </div>
           </qas-lazy-loading-components>

--- a/ui/src/components/form-view/QasFormView.vue
+++ b/ui/src/components/form-view/QasFormView.vue
@@ -163,6 +163,11 @@ export default {
     useStore: {
       type: Boolean,
       default: true
+    },
+
+    entity: {
+      type: String,
+      default: ''
     }
   },
 
@@ -503,6 +508,9 @@ export default {
 
     getFormattedURL ({ payload, isSubmit = false } = {}) {
       const { url: customURL } = payload
+
+      if (customURL) return customURL
+
       const decamelizedEntity = decamelize(this.entity, { separator: '-' })
 
       // Utiliza a URL passada via prop, ou monta a URL baseada na entity e id.
@@ -512,9 +520,7 @@ export default {
        * Utiliza a customURL que pode vir via payload, no caso de um beforeSubmit por exemplo
        * Caso for uma ação de submit, retorna a customURL ou a baseURL (sem o mode new ou edit).
        */
-      if (isSubmit) {
-        return customURL || baseURL
-      }
+      if (isSubmit) return baseURL
 
       const mode = this.isCreateMode ? 'new' : 'edit'
 
@@ -522,7 +528,7 @@ export default {
        * Utiliza a customURL que pode vir via payload, no caso de um beforeFetch por exemplo,
        * ou então concatena a baseURL com o mode (new ou edit).
        */
-      return customURL || `${baseURL}/${mode}`
+      return `${baseURL}/${mode}`
     },
 
     handleFetchAction (payload) {

--- a/ui/src/components/form-view/QasFormView.vue
+++ b/ui/src/components/form-view/QasFormView.vue
@@ -163,11 +163,6 @@ export default {
     useStore: {
       type: Boolean,
       default: true
-    },
-
-    entity: {
-      type: String,
-      default: ''
     }
   },
 


### PR DESCRIPTION
### Adicionado
`QasBoardGenerator`: adicionado o uso do componente `QasLazyLoadingComponents` para que melhore a performance do board.

### Modificado
- `QasFormView`: modificado lógica quando `useStore: false`, era obrigatório passar entity quando é passado customURL.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
