### PR TITLE
Update changelog and enhance QasCard, QasActionsMenu, and QasTableGen…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 - `QasCard`: Corrigido slot do conteúdo que quando tinha texto grande quebrava e sumia com o ícone de expandido.
 
 ### Modificado
-- `QasCard`
+- `QasCard`:
+  - Modificado tipografia do label do expansivo para `text-h6`.
+  - Modificado tamanho do ícone do expansivo.
+- `QasActionsMenu`: alterado default da prop `useLabelOnSmallScreen` para sempre mostrar label quando estiver dentro do `QasTableGenerator`.
 
 ## [3.20.0-beta.7] - 16-01-2026
 ### Adicionado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+### Adicionado
+- `QasTableGenerator`: adicionado `inject`: `isTableGenerator`.
+
+### Corrigido
+- `QasCard`: Corrigido slot do conteúdo que quando tinha texto grande quebrava e sumia com o ícone de expandido.
+
+### Modificado
+- `QasCard`
+
 ## [3.20.0-beta.7] - 16-01-2026
 ### Adicionado
 - `QasLazyLoadingComponent`: adicionado componente responsável por carregar elementos somente quando ficam visíveis na viewport, otimizando performance da página. ([#1339](https://github.com/bildvitta/asteroid/issues/1339))

--- a/docs/src/pages/components/actions-menu.md
+++ b/docs/src/pages/components/actions-menu.md
@@ -22,6 +22,8 @@ Componente wrapper do `QasBtnDropdown` que implementa regras de negocio.
 - Propriedade `buttonProps` é usada para quando o botão esta no modo "Opções" (não existe a prop `splitName`) ou o botão está no mobile.
 
 - A prop `deleteProps` ativa o plugin `Delete.js`, quando é passada o `QasActionsMenu` adiciona a opção de deletar o item como padrão, caso não seja passado, o plugin `Delete.js` não é adicionado por padrão.
+
+- O padrão da prop `useLabelOnSmallScreen` é `false` exceto quando o componente esta dentro do componente `QasTableGenerator`, neste caso o label é exibido sempre.
 :::
 
 :::info

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -49,8 +49,6 @@ const SPLIT_SIZE = 2
 
 defineOptions({ name: 'QasActionsMenu' })
 
-const qas = inject('qas')
-
 const props = defineProps({
   buttonProps: {
     default: () => ({}),
@@ -104,6 +102,10 @@ const props = defineProps({
   }
 })
 
+// globals
+const qas = inject('qas')
+const isInsideTableGenerator = inject('isTableGenerator', false)
+
 // refs
 const menuModel = ref(false)
 
@@ -156,7 +158,8 @@ const primaryKey = computed(() => {
 const defaultButtonPropsList = computed(() => {
   const defaultButtonPropsList = {
     useHoverOnWhiteColor: true,
-    useLabelOnSmallScreen: false
+    // se estiver dentro do QasTableGenerator, sempre mostra o label.
+    useLabelOnSmallScreen: isInsideTableGenerator
   }
 
   const normalizedButtonPropsList = {}

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -158,6 +158,7 @@ const primaryKey = computed(() => {
 const defaultButtonPropsList = computed(() => {
   const defaultButtonPropsList = {
     useHoverOnWhiteColor: true,
+
     // se estiver dentro do QasTableGenerator, sempre mostra o label.
     useLabelOnSmallScreen: isInsideTableGenerator
   }

--- a/ui/src/components/card/QasCard.vue
+++ b/ui/src/components/card/QasCard.vue
@@ -38,10 +38,10 @@
           <slot name="default" />
         </div>
 
-        <div class="q-mt-auto">
-          <q-separator v-if="hasFooter" class="q-mb-sm" />
+        <div class="full-width q-mt-auto">
+          <q-separator v-if="hasFooter" />
 
-          <div v-if="hasExpansion" class="div">
+          <div v-if="hasExpansion">
             <div v-if="props.skeleton" class="flex justify-between">
               <qas-skeleton type="text" use-contrast width="150px" />
 
@@ -49,10 +49,14 @@
             </div>
 
             <slot v-else name="footer">
-              <q-expansion-item v-if="hasExpansion" class="full-width" dense expand-icon-class="text-primary" header-class="q-pa-none text-primary" :label="props.expansionProps.label">
-                <slot name="expansion-content">
-                  {{ props.expansionProps.content }}
-                </slot>
+              <q-expansion-item v-if="hasExpansion" class="full-width text-h1" dense expand-icon-class="text-grey-10" header-class="qas-card__expansion-header q-mt-sm q-pa-none text-primary" :label="props.expansionProps.label">
+                <div class="q-mt-xs">
+                  <q-separator vertical />
+
+                  <slot name="expansion-content">
+                    {{ props.expansionProps.content }}
+                  </slot>
+                </div>
               </q-expansion-item>
             </slot>
           </div>
@@ -215,6 +219,8 @@ const formattedActionsMenuProps = computed(() => {
 
 <style lang="scss">
 .qas-card {
+  // $
+
   &__content {
     max-width: 100%;
   }
@@ -226,6 +232,30 @@ const formattedActionsMenuProps = computed(() => {
   &__router {
     &:hover {
       color: $primary;
+    }
+  }
+
+  &__expansion-header {
+    transition: color var(--qas-generic-transition);
+
+    // pega apenas o primeiro .q-item__label
+    &.q-item {
+      min-height: auto !important;
+    }
+    .q-item__label:first-of-type {
+      @include set-typography($h6);
+    }
+
+    .q-expansion-item__toggle-icon {
+      font-size: 20px;
+    }
+
+    &:hover {
+      color: $primary;
+
+      .q-expansion-item__toggle-icon {
+        color: $primary;
+      }
     }
   }
 }

--- a/ui/src/components/card/QasCard.vue
+++ b/ui/src/components/card/QasCard.vue
@@ -42,14 +42,14 @@
           <q-separator v-if="hasFooter" />
 
           <div v-if="hasExpansion">
-            <div v-if="props.skeleton" class="flex justify-between">
+            <div v-if="props.skeleton" class="flex justify-between q-mt-sm">
               <qas-skeleton type="text" use-contrast width="150px" />
 
               <qas-skeleton size="24px" type="QasBtn" />
             </div>
 
             <slot v-else name="footer">
-              <q-expansion-item v-if="hasExpansion" class="full-width text-h1" dense expand-icon-class="text-grey-10" header-class="qas-card__expansion-header q-mt-sm q-pa-none text-primary" :label="props.expansionProps.label">
+              <q-expansion-item v-if="hasExpansion" class="full-width" dense expand-icon-class="text-grey-10" header-class="qas-card__expansion-header q-mt-sm q-pa-none" :label="props.expansionProps.label">
                 <div class="q-mt-xs">
                   <q-separator vertical />
 
@@ -238,10 +238,11 @@ const formattedActionsMenuProps = computed(() => {
   &__expansion-header {
     transition: color var(--qas-generic-transition);
 
-    // pega apenas o primeiro .q-item__label
     &.q-item {
       min-height: auto !important;
     }
+
+    // pega apenas o primeiro .q-item__label
     .q-item__label:first-of-type {
       @include set-typography($h6);
     }

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -90,6 +90,8 @@ export default {
 
   provide () {
     return {
+      isTableGenerator: true,
+
       /**
        * @see QasBtn.vue - Injetando os valores padrões para o QasBtn.
        */


### PR DESCRIPTION
## Não publicado
### Adicionado
- `QasTableGenerator`: adicionado `inject`: `isTableGenerator`.

### Corrigido
- `QasCard`: Corrigido slot do conteúdo que quando tinha texto grande quebrava e sumia com o ícone de expandido.

### Modificado
- `QasCard`:
  - Modificado tipografia do label do expansivo para `text-h6`.
  - Modificado tamanho do ícone do expansivo.
- `QasActionsMenu`: alterado default da prop `useLabelOnSmallScreen` para sempre mostrar label quando estiver dentro do `QasTableGenerator`.


<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
