### PR TITLE
QasHeader com tip | Novo slot no QasSelectListDialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 ## Não publicado
 ### Adicionado
 - `QasTableGenerator`: adicionado `inject`: `isTableGenerator`.
-- `QasHeader`: adicionado `inject`: `isHeader`.
+- `QasHeader`: 
+  - Adicionado `inject`: `isHeader`;
+  - Adicionado tip ao lado do título (label), controlado pela prop `tipProps`. 
+- `QasSelectListDialog`: Adicionado novo slot `container-header` para personalizar o header do componente.
 
 ### Corrigido
 - `QasCard`: Corrigido slot do conteúdo que quando tinha texto grande quebrava e sumia com o ícone de expandido.

--- a/docs/src/examples/QasHeader/HeaderWithTip.vue
+++ b/docs/src/examples/QasHeader/HeaderWithTip.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="container spaced">
+    <qas-header class="q-mb-md" v-bind="headerProps" />
+  </div>
+</template>
+
+<script setup>
+defineOptions({ name: 'HeaderWithTip' })
+
+const headerProps = {
+  labelProps: { label: 'Título do header' },
+  description: 'Algum texto de exemplo para ficar ao lado do botão de adicionar.',
+  tipProps: { text: 'Dica adicional sobre o header.' }
+}
+</script>

--- a/docs/src/pages/components/header.md
+++ b/docs/src/pages/components/header.md
@@ -13,5 +13,6 @@ Componente para cabeçalho composto por label (título), badges, descrição e a
 <doc-example file="QasHeader/HeaderWithoutActions" title="Sem ações" />
 <doc-example file="QasHeader/HeaderWithFilters" title="Com filtro" />
 <doc-example file="QasHeader/HeaderWithBadges" title="Com badges" />
+<doc-example file="QasHeader/HeaderWithTip" title="Com tip" />
 <doc-example file="QasHeader/HeaderWithActionsMenu" title="Com QasActionsMenu e somente descrição" />
 <doc-example file="QasHeader/HeaderWithSlots" title="Com slot" />

--- a/ui/src/components/header/QasHeader.vue
+++ b/ui/src/components/header/QasHeader.vue
@@ -7,7 +7,7 @@
         </div>
 
         <slot v-else name="label">
-          <div class="items-center q-gutter-x-sm row">
+          <div v-if="hasLabel" class="items-center q-gutter-x-sm row">
             <qas-label v-if="hasLabel" v-bind="defaultLabelProps" />
 
             <qas-tip v-if="hasTip" v-bind="defaultTipProps" />

--- a/ui/src/components/header/QasHeader.vue
+++ b/ui/src/components/header/QasHeader.vue
@@ -7,7 +7,11 @@
         </div>
 
         <slot v-else name="label">
-          <qas-label v-if="hasLabel" v-bind="defaultLabelProps" />
+          <div class="items-center q-gutter-x-sm row">
+            <qas-label v-if="hasLabel" v-bind="defaultLabelProps" />
+
+            <qas-tip v-if="hasTip" v-bind="defaultTipProps" />
+          </div>
         </slot>
 
         <div v-if="hasBadges" class="col-auto items-center q-col-gutter-sm row">
@@ -53,6 +57,7 @@ import QasBtn from '../btn/QasBtn.vue'
 import QasActionsMenu from '../actions-menu/QasActionsMenu.vue'
 import QasFilters from '../filters/QasFilters.vue'
 import QasSkeleton from '../skeleton/QasSkeleton.vue'
+import QasTip from '../tip/QasTip.vue'
 
 import { Spacing } from '../../enums/Spacing'
 import { gutterValidator } from '../../helpers/private/gutter-validator'
@@ -102,6 +107,11 @@ const props = defineProps({
     validator: gutterValidator
   },
 
+  tipProps: {
+    type: Object,
+    default: () => ({})
+  },
+
   useEllipsis: {
     type: Boolean
   }
@@ -147,6 +157,15 @@ const defaultLabelProps = computed(() => {
 
     margin: 'none',
     ...props.labelProps
+  }
+})
+
+const hasTip = computed(() => !!Object.keys(props.tipProps).length)
+
+const defaultTipProps = computed(() => {
+  return {
+    size: '20px',
+    ...props.tipProps
   }
 })
 

--- a/ui/src/components/header/QasHeader.yml
+++ b/ui/src/components/header/QasHeader.yml
@@ -44,6 +44,11 @@ props:
     type: String
     examples: [none, xs, sm, md, lg, xl, '2xl', '3xl', '4xl', '5xl']
 
+  tip-props:
+    desc: Propriedades repassadas para o componente do QasTip ficando ao lado do título (label).
+    type: Object
+    default: {}
+
   use-ellipsis:
     desc: Adiciona ellipsis ao título (label).
     type: Boolean

--- a/ui/src/components/select-list-dialog/QasSelectListDialog.vue
+++ b/ui/src/components/select-list-dialog/QasSelectListDialog.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="app-select-list-dialog full-width">
-    <qas-header v-bind="headerProps" />
+    <slot name="container-header" :toggle-dialog>
+      <qas-header v-bind="headerProps" />
+    </slot>
 
     <component
       :is="containerListComponent"

--- a/ui/src/components/select-list-dialog/QasSelectListDialog.yml
+++ b/ui/src/components/select-list-dialog/QasSelectListDialog.yml
@@ -82,6 +82,13 @@ slots:
   dialog-header:
     desc: Slot para substituir cabeçalho do dialog.
 
+  container-header:
+    desc: Slot para personalizar o header do componente dentro do box.
+    scope:
+      toggle-dialog:
+        desc: Função para abertura/fechamento do dialog do select list.
+        type: Function
+
   selected-content:
     desc: Slot para personalizar o conteúdo dos itens adicionados.
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

### Adicionado
- `QasHeader`: 
  - Adicionado tip ao lado do título (label), controlado pela prop `tipProps`. 
- `QasSelectListDialog`: Adicionado novo slot `container-header` para personalizar o header do componente.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
