### PR TITLE
`QasTableGenerator`: corrigido validação da função `rowRouteFn` pra conseguirmos validar por linha da tabela qual terá click.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+### Corrigido
+- `QasTableGenerator`: corrigido validação da função `rowRouteFn` pra conseguirmos validar por linha da tabela qual terá click.
+
 ## [3.20.0-beta.8] - 26-01-2026
 ### Adicionado
 - `QasTableGenerator`: adicionado `inject`: `isTableGenerator`.

--- a/docs/src/examples/QasTableGenerator/TableLink.vue
+++ b/docs/src/examples/QasTableGenerator/TableLink.vue
@@ -24,7 +24,10 @@ export default {
   },
 
   methods: {
-    rowRouteFn (/* row */) {
+    rowRouteFn (row) {
+      // tratamento feito pra deixar somente as linhas que são ativas clicaveis.
+      if (!row.default.isActive) return
+
       /*
         Poderá ter acesso ao row, caso precise passar uma rota com id da linha por exemplo:
         { path: 'table-generator', params: { id: row.uuid } }

--- a/docs/src/pages/components/table-generator.md
+++ b/docs/src/pages/components/table-generator.md
@@ -124,6 +124,10 @@ rowExternalRouteFn () {
 ```
 :::
 
+:::info
+Ao utilizar o "rowRouteFn", é possível tratar linha a linha qual vai ser clicável, fazendo o tratamento no retorno da fn.
+:::
+
 <doc-example file="QasTableGenerator/TableLink" title="Tabela com links" />
 
 Funcionalidade que permite que o cabeçalho da tabela permaneça visível na parte superior enquanto o usuário faz rolagem do conteúdo da tabela. Para utilizar atribua a prop `use-sticky-header`.

--- a/docs/src/store/mocks/users.json
+++ b/docs/src/store/mocks/users.json
@@ -105,7 +105,7 @@
     },
     {
       "uuid": "82f18f90-d5f9-486f-8b7b-b95745fa123d57",
-      "isActive": false,
+      "isActive": true,
       "company": "Quia qui blanditiis est minus ut quia dolores expedita aut.",
       "name": "Deleniti est quaerat qui dolores blanditiis qui vel maxime.",
       "email": "Felipe94@yahoo.com",
@@ -149,7 +149,7 @@
     },
     {
       "uuid": "62fc0a79-ddea-45b5-8d21-be6f0502929645",
-      "isActive": false,
+      "isActive": true,
       "company": "Sed occaecati cupiditate.",
       "name": "Quaerat veritatis aut voluptatem enim.",
       "email": "Jillian_Wilkinson97@gmail.com",
@@ -160,7 +160,7 @@
     },
     {
       "uuid": "2f8856d0-8eca-4e41-8146-63ed2a4fff4c35",
-      "isActive": false,
+      "isActive": true,
       "company": "Dolores minus iusto quo et dolorem eveniet nesciunt.",
       "name": "Maiores animi non asperiores recusandae dolor exercitationem ut.",
       "email": "Rafael91@hotmail.com",
@@ -171,7 +171,7 @@
     },
     {
       "uuid": "5bda242f-5e99-43dd-af6a-093d68cee15f23",
-      "isActive": false,
+      "isActive": true,
       "company": "Excepturi ad nihil est.",
       "name": "Ullam eligendi dolor a placeat.",
       "email": "Katelyn_Bernhard76@gmail.com",
@@ -182,7 +182,7 @@
     },
     {
       "uuid": "620c8045-acc8-4c53-b083-fe7ed9913cf523",
-      "isActive": false,
+      "isActive": true,
       "company": "Quis ea voluptas recusandae omnis.",
       "name": "Debitis maiores itaque sit et recusandae et eveniet.",
       "email": "Syble42@yahoo.com",
@@ -193,7 +193,7 @@
     },
     {
       "uuid": "82f18f90-d5f9-486f-8b7b-b95745fa1d5723",
-      "isActive": false,
+      "isActive": true,
       "company": "Quia qui blanditiis est minus ut quia dolores expedita aut.",
       "name": "Deleniti est quaerat qui dolores blanditiis qui vel maxime.",
       "email": "Felipe94@yahoo.com",

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -570,6 +570,13 @@ export default {
       this.resizeObserver.unobserve(this.elementToObserve)
     },
 
+    /**
+     * Valida se o valor retornado para a row é um route.
+     *
+     * @param {Object} row - Objeto referente ao row da tabela.
+     *
+     * @returns {boolean}
+     */
     hasRowRoute (row) {
       const routePayload = this.rowRouteFn?.(row)
       const isRoutePayloadObject = typeof routePayload === 'object'

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -45,7 +45,7 @@
         <q-td :class="getTdClasses(context.row)">
           <qas-skeleton v-if="skeleton" v-bind="getTgSkeletonProps(fieldName, context.row)" />
 
-          <component :is="tdChildComponent" v-else class="qas-table-generator__td-item" v-bind="getTdChildComponentProps(context.row)">
+          <component :is="tdChildComponent(context.row)" v-else class="qas-table-generator__td-item" v-bind="getTdChildComponentProps(context.row)">
             <slot :name="`body-cell-${fieldName}`" v-bind="context || {}">
               <pv-table-generator-td v-if="getFieldsProps(context.row, context.rowIndex)[fieldName]" :component-data="getFieldsProps(context.row, context.rowIndex)[fieldName]" :label="normalizedFields[fieldName]?.label" :name="fieldName" :row="context.row" />
 
@@ -260,12 +260,6 @@ export default {
       }
 
       return this.results
-    },
-
-    tdChildComponent () {
-      if (this.useExternalLink) return 'a'
-
-      return this.rowRouteFn ? 'router-link' : 'span'
     },
 
     bodyCellNameSlots () {
@@ -576,18 +570,21 @@ export default {
       this.resizeObserver.unobserve(this.elementToObserve)
     },
 
-    getTdClasses (row) {
+    hasRowRoute (row) {
       const routePayload = this.rowRouteFn?.(row)
       const isRoutePayloadObject = typeof routePayload === 'object'
-      const hasRoutePayload = isRoutePayloadObject ? !!Object.keys(routePayload).length : !!routePayload
 
+      return isRoutePayloadObject ? !!Object.keys(routePayload).length : !!routePayload
+    },
+
+    getTdClasses (row) {
       return {
-        'qas-table-generator__td--has-action': this.hasRowClick || hasRoutePayload
+        'qas-table-generator__td--has-action': this.hasRowRoute(row)
       }
     },
 
     getTdChildComponentProps (row) {
-      if (!this.rowRouteFn || this.skeleton) return
+      if (!this.hasRowRoute(row) || this.skeleton) return
 
       return {
         class: [
@@ -608,6 +605,12 @@ export default {
       if (this.skeleton) return
 
       this.$attrs.onRowClick(...arguments)
+    },
+
+    tdChildComponent (row) {
+      if (this.useExternalLink) return 'a'
+
+      return this.hasRowRoute(row) ? 'router-link' : 'span'
     },
 
     getFieldsProps (row, index) {

--- a/ui/src/components/table-generator/QasTableGenerator.yml
+++ b/ui/src/components/table-generator/QasTableGenerator.yml
@@ -70,7 +70,7 @@ props:
   row-route-fn:
     desc: Usado quando há a necessidade de alteração de rota ao clicar em um item da tabela(a linha passa ser um <a> habilitando a opção de abrir em uma nova aba).
     type: Function
-    examples: ["(row) => ({ path: 'table-generator', params: { id: row.uuid } })"]
+    examples: ["row => ({ path: 'table-generator', params: { id: row.uuid } })", "row => undefined", "row => {}"]
 
   selected:
     desc: Usado como model das linhas selecionadas.


### PR DESCRIPTION
### Corrigido
- `QasTableGenerator`: corrigido validação da função `rowRouteFn` pra conseguirmos validar por linha da tabela qual terá click.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
