### PR TITLE
Adicionado aviso na doc do QasTableGenerator para o uso da prop columns

### DIFF
--- a/docs/src/pages/components/table-generator.md
+++ b/docs/src/pages/components/table-generator.md
@@ -94,7 +94,12 @@ fieldsProps: {
 ```
 :::
 <doc-example file="QasTableGenerator/WithFieldsProps" title="Com componentes por props e ação na ultima coluna" />
+
+:::warning
+É necessário passar a prop "columns" no uso da prop skeleton, pois o componente replica as colunas que serão usadas pra simular os dados.
+:::
 <doc-example file="QasTableGenerator/Skeleton" title="Skeleton" />
+
 <doc-example file="QasTableGenerator/WithHeader" title="Com header" />
 <doc-example file="QasTableGenerator/HeaderSlot" title="Acessando slot do header" />
 <doc-example file="QasTableGenerator/NoBox" title="Sem box" />


### PR DESCRIPTION
Adicionado aviso na doc do QasTableGenerator para o uso da prop columns

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [ ] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [ ] Não

## Checklist

- [ ] Foi discutida anteriormente com os times de Frontend e Design;
- [ ] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [ ] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [ ] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [ ] Foi atualizada e testada a documentação;
- [ ] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [ ] Fiz meu próprio _code review_ antes de abrir este _pull request_.
