### PR TITLE
Correções de navegação em overlay.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+### Corrigido
+- `Navegação em overlay`: corrigido problema com background route que quando a rota de background era nested (tinha layout) ela não renderizava corretamente.
+- `QasSingleView`: corrigido parâmero da url id que pegava via route do vue-router e agora pega route do overlay.
+
 ## [3.20.0-beta.10] - 10-02-2026
 ### Adicionado
 - `helpers/set-scroll-gradient`:

--- a/app-extension/src/boot/overlay-navigation.js
+++ b/app-extension/src/boot/overlay-navigation.js
@@ -53,14 +53,27 @@ async function onBeforeEach (to, from, next, router) {
     const backgroundResult = await getBackgroundComponent()
 
     if (backgroundResult) {
-      const { component: backgroundComponent, resolvedRoute } = backgroundResult
+      const { resolvedRoute } = backgroundResult
 
       const { name, params = {}, fullPath, path, query = {} } = resolvedRoute || {}
 
       to.meta.backgroundRoute = { name, params, fullPath, path, query }
 
+      /**
+       * Resolve todos os componentes lazy da rota de background e armazena a rota
+       * resolvida em `to.meta.overlayBackgroundResolvedRoute`.
+       *
+       * O QasLayout usa essa rota via `<router-view :route="..." />` para renderizar
+       * o background com sua hierarquia completa (parent layout + children),
+       * enquanto o overlay continua usando a rota atual normalmente.
+       */
+      await resolveRouteComponents(resolvedRoute)
+
+      to.meta.overlayBackgroundResolvedRoute = resolvedRoute
+
+      // Apenas adicionar o overlay, sem alterar o default
       to.matched[matchedIndex].components = {
-        default: backgroundComponent,
+        ...to.matched[matchedIndex].components,
         overlay: overlayComponent
       }
     }
@@ -73,6 +86,21 @@ async function onBeforeEach (to, from, next, router) {
   next()
 
   // functions
+
+  /**
+   * Resolve todos os componentes lazy (ex: () => import(...)) de uma rota.
+   * Necessário porque router.resolve() não resolve lazy components automaticamente.
+   *
+   * @param {import('vue-router').RouteLocationNormalized} route
+   */
+  async function resolveRouteComponents (route) {
+    for (const matched of route.matched) {
+      for (const [viewName, comp] of Object.entries(matched.components || {})) {
+        matched.components[viewName] = await getResolvedComponent(comp)
+      }
+    }
+  }
+
   function getComponentByRoute (route) {
     const lastIndex = route.matched.length - 1
     const matched = route.matched[lastIndex]

--- a/ui/src/components/layout/QasLayout.vue
+++ b/ui/src/components/layout/QasLayout.vue
@@ -11,7 +11,7 @@
     <slot>
       <q-page-container>
         <q-page>
-          <router-view />
+          <router-view :route="overlayBackgroundRoute" />
         </q-page>
       </q-page-container>
     </slot>
@@ -34,6 +34,7 @@ import useScreen from '../../composables/use-screen'
 import useNotifications from '../../composables/use-notifications'
 
 import { computed, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
 
 defineOptions({ name: 'QasLayout' })
 
@@ -68,10 +69,24 @@ const screen = useScreen()
 
 const { isNotificationsEnabled, setUnreadNotificationsCount } = useNotifications()
 
+const route = useRoute()
+
 const menuDrawer = ref(false)
 const notificationsDrawer = ref(false)
 
 // computed
+
+/**
+ * Sempre fornece uma rota para o <router-view>. Quando o overlay está ativo,
+ * usa a rota resolvida do background; sem overlay, usa a rota atual.
+ * Isso evita alternância entre `undefined` e objeto de rota, reduzindo remounts.
+ */
+const overlayBackgroundRoute = computed(() => {
+  return route.query?.overlay === 'true'
+    ? route.meta.overlayBackgroundResolvedRoute
+    : route
+})
+
 const defaultAppMenuProps = computed(() => {
   return {
     ...props.appBarProps,

--- a/ui/src/components/single-view/QasSingleView.vue
+++ b/ui/src/components/single-view/QasSingleView.vue
@@ -108,7 +108,6 @@ const hasResult = computed(() => !!resultModel.value)
 
 // watch
 watch(() => route, (to, from) => {
-  console.log('🚀 ~ isBackgroundOverlay.value:', isBackgroundOverlay.value)
   if (isBackgroundOverlay.value) return
 
   if (to.name === from.name) {

--- a/ui/src/components/single-view/QasSingleView.vue
+++ b/ui/src/components/single-view/QasSingleView.vue
@@ -71,7 +71,7 @@ const qas = inject('qas')
 // composables
 const route = useRoute()
 
-const { isBackgroundOverlay } = useOverlayNavigation()
+const { isBackgroundOverlay, route: overlayRoute } = useOverlayNavigation()
 
 const {
   // state
@@ -96,7 +96,7 @@ const {
 defineExpose({ fetchSingle, fetchHandler })
 
 // computed
-const id = computed(() => props.customId || route.params.id)
+const id = computed(() => props.customId || overlayRoute.value.params.id)
 
 const resultModel = computed(() => {
   if (props.useStore) return qas.getGetter({ entity: props.entity, key: 'byId' })(id.value) || {}
@@ -108,6 +108,7 @@ const hasResult = computed(() => !!resultModel.value)
 
 // watch
 watch(() => route, (to, from) => {
+  console.log('🚀 ~ isBackgroundOverlay.value:', isBackgroundOverlay.value)
   if (isBackgroundOverlay.value) return
 
   if (to.name === from.name) {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
### Corrigido
- `Navegação em overlay`: corrigido problema com background route que quando a rota de background era nested (tinha layout) ela não renderizava corretamente.
- `QasSingleView`: corrigido parâmero da url id que pegava via route do vue-router e agora pega route do overlay.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
