### PR TITLE
Ajustes de documentação | Provide | Screen | QasStepper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+### Adicionado
+- `Screen (Plugin) | use-screen`: Adicionado novos tokens de tamanhos para validaçào de telas maiores.
+
+### Corrigido
+- `QasStepper`:
+  - Corrigido cor da linha quando da step anterior quando uma outra step é finalizada. ([#1105](https://github.com/bildvitta/asteroid/issues/1105))
+  - Corrigido tamanho das linhas centrais setando proporções na primeira e última linha. ([#1105](https://github.com/bildvitta/asteroid/issues/1105))
+
 ## [3.20.0-beta.10] - 10-02-2026
 ### Adicionado
 - `helpers/set-scroll-gradient`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 
 ## Não publicado
 ### Adicionado
-- `Screen (Plugin) | use-screen`: Adicionado novos tokens de tamanhos para validaçào de telas maiores.
+- `Screen (Plugin) | use-screen`: Adicionado novos tokens de tamanhos para validaçào de telas maiores. ([#1351](https://github.com/bildvitta/asteroid/issues/1351))
 
 ### Corrigido
 - `QasStepper`:

--- a/docs/src/pages/composables/use-screen.md
+++ b/docs/src/pages/composables/use-screen.md
@@ -12,9 +12,13 @@ const screen = useScreen()
 
 screen.isSmall // até 599px
 screen.isMedium // de 600 até 1023px
-screen.isLarge // de 600 até 1023px
+screen.isLarge // Maior que 1023px
+screen.isXLarge // Maior que 1439px
+screen.is2XLarge // Maior que 1919px
 screen.untilMedium // de 0 até 599px
-screen.untilLarge // de 0 ate 1023px
+screen.untilLarge // de 0 até 1023px
+screen.untilXLarge // de 0 até 1439px
+screen.until2XLarge // de 0 até 1919px
 screen.isMobile // Plataforma
 
 // ou
@@ -23,8 +27,12 @@ const {
   isSmall,
   isMedium,
   isLarge,
+  isXLarge,
+  is2XLarge,
   untilMedium,
   untilLarge,
+  untilXLarge,
+  until2XLarge,
   isMobile
 } = toRefs(useScreen())
 ```

--- a/ui/src/components/box/QasBox.yml
+++ b/ui/src/components/box/QasBox.yml
@@ -32,3 +32,8 @@ props:
   use-spacing:
     desc: Controla espaçamento do componente.
     type: Boolean
+
+provide:
+  is-box:
+    desc: Identificador booleano que indica quando um componente está dentro do contexto de um QasBox.
+    type: Boolean

--- a/ui/src/components/dialog/QasDialog.yml
+++ b/ui/src/components/dialog/QasDialog.yml
@@ -69,6 +69,11 @@ slots:
   header:
     desc: Slot para o título.
 
+provide:
+  is-dialog:
+    desc: Identificador booleano que indica quando um componente está dentro do contexto de um QasDialog.
+    type: Boolean
+
 events:
   '@update:model-value -> function (value)':
     desc: Dispara toda vez que o model é atualizado, também utilizado para v-model.

--- a/ui/src/components/expansion-item/QasExpansionItem.yml
+++ b/ui/src/components/expansion-item/QasExpansionItem.yml
@@ -62,6 +62,11 @@ slots:
   content:
     desc: Slot para substituir o conteúdo principal do card.
 
+provide:
+  is-expansion-item:
+    desc: Identificador booleano que indica quando um componente está dentro do contexto de um QasExpansionItem.
+    type: Boolean
+
 events:
   '@update:model-value -> function(value)':
     desc: Dispara quando o model-value altera, também usado para v-model.

--- a/ui/src/components/form-generator/QasFormGenerator.yml
+++ b/ui/src/components/form-generator/QasFormGenerator.yml
@@ -120,6 +120,11 @@ slots:
   'legend-bottom[nome-da-chave-do-fieldset]-[nome-da-chave-do-subset]':
     desc: Acessa o slot da seção abaixo do conteúdo do form de um subset específico.
 
+provide:
+  is-form-generator:
+    desc: Identificador booleano que indica quando um componente está dentro do contexto de um QasFormGenerator.
+    type: Boolean
+
 events:
   '@update:model-value -> function(value)':
     desc: Dispara quando o model-value altera, também usado para v-model.

--- a/ui/src/components/header/QasHeader.yml
+++ b/ui/src/components/header/QasHeader.yml
@@ -54,6 +54,11 @@ props:
     type: Boolean
     default: false
 
+provide:
+  is-header:
+    desc: Identificador booleano que indica quando um componente está dentro do contexto de um QasHeader.
+    type: Boolean
+
 slots:
   actions:
     desc: slot para acessar seção da direita (ações).

--- a/ui/src/components/stepper/QasStepper.vue
+++ b/ui/src/components/stepper/QasStepper.vue
@@ -206,6 +206,27 @@ function previous () {
         border-radius: var(--qas-generic-border-radius);
       }
 
+      .q-stepper__tab {
+        /*
+         * Por padrão o quasar sempre deixa as demais linhas com o mesmo tamanho, exceto a primeira e a última, que são
+         * maiores devido terem alinhamento inicial e final respectivamente, enquanto as demais possuem alinhamento
+         * central. Para equalizar visualmente os tamanhos, é necessário setar uma proporção de flex diferente para a
+         * primeira/última tab e para as tabs do meio.
+         *
+         * Proporção 2:3 para equalizar visualmente os tamanhos:
+         * - Primeira/última tab: flex 2 (possuem apenas meia linha)
+         * - Tabs do meio: flex 3 (possuem linha completa dos dois lados)
+         */
+        &:first-child,
+        &:last-child {
+          flex: 2;
+        }
+
+        &:not(:first-child):not(:last-child) {
+          flex: 3;
+        }
+      }
+
       .q-stepper {
         &__tab {
           &--done {
@@ -223,9 +244,10 @@ function previous () {
               }
             }
 
-            // Seta a cor do after da linha quando a step está finalizada, é a primeira step ou a próxima é ativa.
+            // Seta a cor do after da linha quando a step está finalizada, é a primeira step ou a próxima é ativa ou finalizada.
             &:first-child,
-            &:has(+ .q-stepper__tab.q-stepper__tab--active) {
+            &:has(+ .q-stepper__tab.q-stepper__tab--active),
+            &:has(+ .q-stepper__tab.q-stepper__tab--done) {
               .q-stepper__line::after {
                  background-color: var(--q-primary);
               }

--- a/ui/src/composables/use-screen.js
+++ b/ui/src/composables/use-screen.js
@@ -7,8 +7,12 @@ import { computed, reactive } from 'vue'
  *  isSmall: boolean,
  *  isMedium: boolean,
  *  isLarge: boolean,
+ *  isXLarge: boolean,
+ *  is2XLarge: boolean,
  *  untilMedium: boolean,
  *  untilLarge: boolean,
+ *  untilXLarge: boolean,
+ *  until2XLarge: boolean,
  *  isMobile: boolean
  * }}
  *
@@ -25,14 +29,26 @@ export default function () {
     // de 600 até 1023px
     isMedium: computed(() => Screen.sm),
 
-    // de 600 até 1023px
+    // Maior que 1023px
     isLarge: computed(() => Screen.gt.sm),
+
+    // Maior que 1439px
+    isXLarge: computed(() => Screen.gt.md),
+
+    // Maior que 1919px
+    is2XLarge: computed(() => Screen.gt.lg),
 
     // de 0 até 599px
     untilMedium: computed(() => Screen.lt.sm),
 
     // de 0 ate 1023px
     untilLarge: computed(() => Screen.lt.md),
+
+    // de 0 até 1439px
+    untilXLarge: computed(() => Screen.lt.lg),
+
+    // de 0 até 1919px
+    until2XLarge: computed(() => Screen.lt.xl),
 
     // Plataforma
     isMobile: computed(() => Platform.is.mobile || false)

--- a/ui/src/plugins/delete/Delete.yml
+++ b/ui/src/plugins/delete/Delete.yml
@@ -3,7 +3,7 @@ type: component
 meta:
   desc: Plugin que implementa a action `destroy` do `StoreModule` adicionando comportamento de confirmação antes de excluir, este mesmo plugin é utilizado no componente `QasDelete`.
 
-inject:
+provide:
   'this.$qas.delete(config)':
     params:
       config:

--- a/ui/src/plugins/dialog/Dialog.yml
+++ b/ui/src/plugins/dialog/Dialog.yml
@@ -3,7 +3,7 @@ type: component
 meta:
   desc: Plugin que implementa o `QasDialog`.
 
-inject:
+provide:
   'this.$qas.dialog(config)':
     params:
       config:

--- a/ui/src/plugins/notify-error/NotifyError.yml
+++ b/ui/src/plugins/notify-error/NotifyError.yml
@@ -3,7 +3,7 @@ type: component
 meta:
   desc: Plugin que implementa o "QNotify" do quasar.
 
-inject:
+provide:
   'this.$qas.error(msg)':
     params:
       msg:

--- a/ui/src/plugins/notify-success/NotifySuccess.yml
+++ b/ui/src/plugins/notify-success/NotifySuccess.yml
@@ -3,7 +3,7 @@ type: component
 meta:
   desc: Plugin que implementa o "QNotify" do quasar para notificações de sucesso.
 
-inject:
+provide:
   'this.$qas.success(msg)':
     params:
       msg:

--- a/ui/src/plugins/screen/Screen.js
+++ b/ui/src/plugins/screen/Screen.js
@@ -4,14 +4,30 @@ export default () => {
   const screensModel = {
     // até 599px
     isSmall: () => Screen.xs,
+
     // de 600 até 1023px
     isMedium: () => Screen.sm,
-    // de 600 até 1023px
+
+    // Maior que 1023px
     isLarge: () => Screen.gt.sm,
+
+    // Maior que 1439px
+    isXLarge: () => Screen.gt.md,
+
+    // Maior que 1919px
+    is2XLarge: () => Screen.gt.lg,
+
     // de 0 até 599px
     untilMedium: () => Screen.lt.sm,
+
     // de 0 ate 1023px
     untilLarge: () => Screen.lt.md,
+
+    // de 0 até 1439px
+    untilXLarge: () => Screen.lt.lg,
+
+    // de 0 até 1919px
+    until2XLarge: () => Screen.lt.xl,
 
     // Plataforma
     isMobile: () => Platform.is.mobile || false

--- a/ui/src/plugins/screen/Screen.yml
+++ b/ui/src/plugins/screen/Screen.yml
@@ -3,7 +3,7 @@ type: component
 meta:
   desc: Plugin que implementa o "Screen" do quasar.
 
-inject:
+provide:
   'this.$qas.screen':
     type: Object
     debugger: true

--- a/ui/src/plugins/screen/Screen.yml
+++ b/ui/src/plugins/screen/Screen.yml
@@ -11,6 +11,10 @@ provide:
       isSmall: false
       isMedium: false
       isLarge: false
+      isXLarge: false
+      is2XLarge: false
       untilMedium: false
       untilLarge: false
+      untilXLarge: false
+      until2XLarge: false
       isMobile: false


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
closes #1105
closes #1351

### Adicionado
- `Screen (Plugin) | use-screen`: Adicionado novos tokens de tamanhos para validaçào de telas maiores.

### Corrigido
- `QasStepper`:
  - Corrigido cor da linha quando da step anterior quando uma outra step é finalizada. ([#1105](https://github.com/bildvitta/asteroid/issues/1105))
  - Corrigido tamanho das linhas centrais setando proporções na primeira e última linha. ([#1105](https://github.com/bildvitta/asteroid/issues/1105))

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [ ] Componentes
- [x] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [x] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
