### PR TITLE
`QasSelect`: corrigido comportamento do texto do input do select sobrepor o item selecionado ao apertar a tecla tab.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+### Corrigido
+- `QasSelect`: corrigido comportamento do texto do input do select sobrepor o item selecionado ao apertar a tecla tab.
+
 ## [3.20.0-beta.13] - 19-02-2026
 ### Adicionado
 - Adicionado skills:

--- a/ui/src/components/select/QasSelect.vue
+++ b/ui/src/components/select/QasSelect.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-select v-model="model" v-bind="attributes" class="qas-select" :class="componentClasses" no-error-icon>
+  <q-select ref="select" v-model="model" v-bind="attributes" class="qas-select" :class="componentClasses" no-error-icon>
     <template v-if="hasIcon" #prepend>
       <q-icon :name="defaultIcon" />
     </template>
@@ -409,6 +409,12 @@ export default {
 
     onPopupHide () {
       this.isPopupContentOpen = false
+
+      /**
+       * necessário limpar o campo de input ao fechar o popup, para evitar que o valor da busca permaneça no campo
+       * quando abrir novamente e também o texto não sobreponha os itens selecionados ao apertar a tecla tab.
+       */
+      this.$refs.select.updateInputValue('', true)
       this.$emit('popup-hide')
     },
 

--- a/ui/src/components/select/QasSelect.vue
+++ b/ui/src/components/select/QasSelect.vue
@@ -411,10 +411,11 @@ export default {
       this.isPopupContentOpen = false
 
       /**
-       * necessário limpar o campo de input ao fechar o popup, para evitar que o valor da busca permaneça no campo
-       * quando abrir novamente e também o texto não sobreponha os itens selecionados ao apertar a tecla tab.
+       * necessário limpar o campo de input de pesquisa ao fechar o popup, para evitar que o valor da busca permaneça
+       * no campo quando abrir novamente e também o texto não sobreponha os itens selecionados ao apertar a tecla tab.
        */
-      this.$refs.select.updateInputValue('', true)
+      if (this.isSearchable) this.$refs.select.updateInputValue('', true)
+
       this.$emit('popup-hide')
     },
 


### PR DESCRIPTION
### Corrigido
`QasSelect`: corrigido comportamento do texto do input do select sobrepor o item selecionado ao apertar a tecla tab.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
