### PR TITLE
Resolvendo as issues:  #1453, #1411

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,12 @@ Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não p
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
 ## Não publicado
+### Adicionado
+- `QasDateTimeInput`: adicionado comportamento de setar hora automaticamente após digitar a data. ([#1411](https://github.com/bildvitta/asteroid/issues/1411))
+
 ### Modificado
-- `QasTableGenerator`: modicado fields do tipo `hidden`, não serão exibidos na tabela. 
+- `QasTableGenerator`: modificado fields do tipo `hidden`, não serão exibidos na tabela.([#1387](https://github.com/bildvitta/asteroid/issues/1387))
+- `search-filter.js`: modificado lógica dos campos dependentes, quando o campo estiver desabilitado, só o campo só será limpo, não batera a API. ([#1453](https://github.com/bildvitta/asteroid/issues/1453))
 
 ## [3.20.0-beta.13] - 19-02-2026
 ### Adicionado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 ### Modificado
 - `QasTableGenerator`: modificado fields do tipo `hidden`, não serão exibidos na tabela.([#1387](https://github.com/bildvitta/asteroid/issues/1387))
 - `search-filter.js`: modificado lógica dos campos dependentes, quando o campo estiver desabilitado, só o campo só será limpo, não batera a API. ([#1453](https://github.com/bildvitta/asteroid/issues/1453))
+- `QasDateTimeInput`: modificado comportamento do model, ao sair do campo e a data for inválida ou incompleta, vamos limpar o model, mas iremos continuar exibindo o valor incorreto no campo com o aviso de erro.
 
 ## [3.20.0-beta.13] - 19-02-2026
 ### Adicionado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+### Modificado
+- `QasTableGenerator`: modicado fields do tipo `hidden`, não serão exibidos na tabela. 
+
 ## [3.20.0-beta.13] - 19-02-2026
 ### Adicionado
 - Adicionado skills:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 - `QasDateTimeInput`: adicionado comportamento de setar hora automaticamente após digitar a data. ([#1411](https://github.com/bildvitta/asteroid/issues/1411))
 
 ### Modificado
-- `QasTableGenerator`: modificado fields do tipo `hidden`, não serão exibidos na tabela.([#1387](https://github.com/bildvitta/asteroid/issues/1387))
 - `search-filter.js`: modificado lógica dos campos dependentes, quando o campo estiver desabilitado, só o campo só será limpo, não batera a API. ([#1453](https://github.com/bildvitta/asteroid/issues/1453))
 - `QasDateTimeInput`: modificado comportamento do model, ao sair do campo e a data for inválida ou incompleta, vamos limpar o model, mas iremos continuar exibindo o valor incorreto no campo com o aviso de erro.
 

--- a/ui/src/components/date-time-input/QasDateTimeInput.vue
+++ b/ui/src/components/date-time-input/QasDateTimeInput.vue
@@ -221,12 +221,12 @@ function getDefaultTimeByMask () {
 function normalizeDateTimeValue (value = '') {
   if (props.useDateOnly || props.useTimeOnly || !value) return value
 
-  const [typedDate, typedTime] = value.split(' ')
-  const hasFullDate = typedDate?.length === props.dateMask.length
+  const [currentDate, currentTime] = value.split(' ')
+  const hasFullDate = currentDate?.length === props.dateMask.length
 
-  if (!hasFullDate || typedTime) return value
+  if (!hasFullDate || currentTime) return value
 
-  return `${typedDate} ${getDefaultTimeByMask()}`
+  return `${currentDate} ${getDefaultTimeByMask()}`
 }
 
 function updateModelValue (value) {

--- a/ui/src/components/date-time-input/QasDateTimeInput.vue
+++ b/ui/src/components/date-time-input/QasDateTimeInput.vue
@@ -216,7 +216,7 @@ function getDefaultTimeByMask () {
  * Faz o tratamento de setar o horário default ao preencher a data via input,
  * quando a configuração for para data e hora.
  *
- * @param value - Valor a ser normalizado, que pode ser uma data, hora ou data e hora dependendo da configuração.
+ * @param {string} value - Valor a ser normalizado, que pode ser data, hora ou data e hora dependendo da configuração.
  */
 function normalizeDateTimeValue (value = '') {
   if (props.useDateOnly || props.useTimeOnly || !value) return value

--- a/ui/src/components/date-time-input/QasDateTimeInput.vue
+++ b/ui/src/components/date-time-input/QasDateTimeInput.vue
@@ -166,7 +166,7 @@ const hasTimePicker = computed(() => !props.useDateOnly && !props.readonly)
 
 watch(() => props.modelValue, (current, original) => {
   /**
-   * No caso de for adicionado uma data incompleta ou inválida, vamos limpar o model,
+   * No caso de ser adicionado uma data incompleta ou inválida, vamos limpar o model,
    * mas não vamos limpar o "currentValue", para não limpar o campo, somente o model.
    */
   if (!current && original && error.value) return

--- a/ui/src/components/date-time-input/QasDateTimeInput.vue
+++ b/ui/src/components/date-time-input/QasDateTimeInput.vue
@@ -165,6 +165,11 @@ const hasDatePicker = computed(() => !props.useTimeOnly && !props.readonly)
 const hasTimePicker = computed(() => !props.useDateOnly && !props.readonly)
 
 watch(() => props.modelValue, (current, original) => {
+  console.log(current, '<-- current')
+  console.log(original, '<-- original')
+
+  if (!current && original && error.value) return
+
   if (!current || props.useTimeOnly) {
     currentValue.value = current
     return
@@ -207,47 +212,26 @@ function toMask (value) {
   )
 }
 
-// Pega o valor default do horário baseado na mascara, substituindo os caracteres por 0.
-function getDefaultTimeByMask () {
-  return props.timeMask.replace(/[A-Za-z]/g, '0')
-}
-
-/**
- * Faz o tratamento de setar o horário default ao preencher a data via input,
- * quando a configuração for para data e hora.
- *
- * @param {string} value - Valor a ser normalizado, que pode ser data, hora ou data e hora dependendo da configuração.
- */
-function normalizeDateTimeValue (value = '') {
-  if (props.useDateOnly || props.useTimeOnly || !value) return value
-
-  const [currentDate, currentTime] = value.split(' ')
-  const hasFullDate = currentDate?.length === props.dateMask.length
-
-  if (!hasFullDate || currentTime) return value
-
-  return `${currentDate} ${getDefaultTimeByMask()}`
-}
-
 function updateModelValue (value) {
-  const normalizedValue = normalizeDateTimeValue(value)
+  currentValue.value = value
 
-  currentValue.value = normalizedValue
+  const valueLength = value?.replace?.(/_/g, '')?.length
 
-  const valueLength = normalizedValue?.replace?.(/_/g, '')?.length
-
-  error.value = validateDateAndTime(normalizedValue)
+  error.value = validateDateAndTime(value)
 
   if (error.value) {
     hasInvalidDate.value = true
     errorMessage.value = 'Data inválida.'
+
+    emit('update:modelValue', '')
+
     return
   }
 
   hasInvalidDate.value = false
 
-  if (normalizedValue === '' || valueLength === mask.value.length) {
-    lastValue.value = props.useTimeOnly ? normalizedValue : toISOString(normalizedValue)
+  if (value === '' || valueLength === mask.value.length) {
+    lastValue.value = props.useTimeOnly ? value : toISOString(value)
     emit('update:modelValue', lastValue.value)
   }
 
@@ -286,18 +270,33 @@ function validateDateAndTime (value) {
 function validateDateTimeOnBlur () {
   const valueLength = currentValue.value?.replace?.(/_/g, '')?.length
 
+  // Caso for datetime
+  if (!props.useDateOnly && !props.useTimeOnly) {
+    const [date, time] = (currentValue.value || '').split(' ') || []
+    const isValidDate = date?.replace?.(/_/g, '')?.length === props.dateMask.length
+
+    /**
+     * Caso tenha preenchido a data, a data seja válida e não tenha preenchido o horário,
+     * preenche o horário com 00:00, ou de acordo com a mask.
+     */
+    if (isValidDate && !validateDateOnly(date) && !time?.length) {
+      // Horario setado deve seguir a mascara.
+      const defaultTimeByMask = props.timeMask.replace(/[HhMmSs]/g, '0')
+      const newValue = `${date} ${defaultTimeByMask}`
+
+      currentValue.value = newValue
+      updateModelValue(newValue)
+
+      return
+    }
+  }
+
   // valida se o tamanho digitado é o tamanho que a mascara espera receber
   error.value = !!((valueLength < mask.value.length || error.value) && valueLength)
 
   if (error.value && !hasInvalidDate.value) {
     errorMessage.value = 'Data incompleta.'
-  }
 
-  if (hasInvalidDate.value) {
-    currentValue.value = ''
-  }
-
-  if (error.value || hasInvalidDate.value) {
     emit('update:modelValue', '')
   }
 }

--- a/ui/src/components/date-time-input/QasDateTimeInput.vue
+++ b/ui/src/components/date-time-input/QasDateTimeInput.vue
@@ -165,9 +165,10 @@ const hasDatePicker = computed(() => !props.useTimeOnly && !props.readonly)
 const hasTimePicker = computed(() => !props.useDateOnly && !props.readonly)
 
 watch(() => props.modelValue, (current, original) => {
-  console.log(current, '<-- current')
-  console.log(original, '<-- original')
-
+  /**
+   * No caso de for adicionado uma data incompleta ou inválida, vamos limpar o model,
+   * mas não vamos limpar o "currentValue", para não limpar o campo, somente o model.
+   */
   if (!current && original && error.value) return
 
   if (!current || props.useTimeOnly) {

--- a/ui/src/components/date-time-input/QasDateTimeInput.vue
+++ b/ui/src/components/date-time-input/QasDateTimeInput.vue
@@ -207,10 +207,17 @@ function toMask (value) {
   )
 }
 
+// Pega o valor default do horário baseado na mascara, substituindo os caracteres por 0.
 function getDefaultTimeByMask () {
   return props.timeMask.replace(/[A-Za-z]/g, '0')
 }
 
+/**
+ * Faz o tratamento de setar o horário default ao preencher a data via input,
+ * quando a configuração for para data e hora.
+ *
+ * @param value - Valor a ser normalizado, que pode ser uma data, hora ou data e hora dependendo da configuração.
+ */
 function normalizeDateTimeValue (value = '') {
   if (props.useDateOnly || props.useTimeOnly || !value) return value
 

--- a/ui/src/components/date-time-input/QasDateTimeInput.vue
+++ b/ui/src/components/date-time-input/QasDateTimeInput.vue
@@ -207,12 +207,29 @@ function toMask (value) {
   )
 }
 
+function getDefaultTimeByMask () {
+  return props.timeMask.replace(/[A-Za-z]/g, '0')
+}
+
+function normalizeDateTimeValue (value = '') {
+  if (props.useDateOnly || props.useTimeOnly || !value) return value
+
+  const [typedDate, typedTime] = value.split(' ')
+  const hasFullDate = typedDate?.length === props.dateMask.length
+
+  if (!hasFullDate || typedTime) return value
+
+  return `${typedDate} ${getDefaultTimeByMask()}`
+}
+
 function updateModelValue (value) {
-  currentValue.value = value
+  const normalizedValue = normalizeDateTimeValue(value)
 
-  const valueLength = value?.replace?.(/_/g, '')?.length
+  currentValue.value = normalizedValue
 
-  error.value = validateDateAndTime(value)
+  const valueLength = normalizedValue?.replace?.(/_/g, '')?.length
+
+  error.value = validateDateAndTime(normalizedValue)
 
   if (error.value) {
     hasInvalidDate.value = true
@@ -222,8 +239,8 @@ function updateModelValue (value) {
 
   hasInvalidDate.value = false
 
-  if (value === '' || valueLength === mask.value.length) {
-    lastValue.value = props.useTimeOnly ? value : toISOString(value)
+  if (normalizedValue === '' || valueLength === mask.value.length) {
+    lastValue.value = props.useTimeOnly ? normalizedValue : toISOString(normalizedValue)
     emit('update:modelValue', lastValue.value)
   }
 

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -234,18 +234,7 @@ export default {
         return fields
       }
 
-      const fields = {}
-
-      // Remover os campos do tipo "hidden".
-      Object.keys(this.fields).forEach(key => {
-        const field = this.fields[key]
-
-        if (field.type === 'hidden') return
-
-        fields[key] = field
-      })
-
-      return fields
+      return this.fields
     },
 
     /**

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -234,7 +234,18 @@ export default {
         return fields
       }
 
-      return this.fields
+      const fields = {}
+
+      // Remover os campos do tipo "hidden".
+      Object.keys(this.fields).forEach(key => {
+        const field = this.fields[key]
+
+        if (field.type === 'hidden') return
+
+        fields[key] = field
+      })
+
+      return fields
     },
 
     /**

--- a/ui/src/mixins/search-filter.js
+++ b/ui/src/mixins/search-filter.js
@@ -98,7 +98,7 @@ export default {
 
         this.mx_cachedOptions = []
 
-        this.mx_filterOptionsByStore('')
+        if (!this.disable) this.mx_filterOptionsByStore('')
 
         setTimeout(() => this.$emit('update:modelValue', undefined))
       }


### PR DESCRIPTION
### Adicionado
- `QasDateTimeInput`: adicionado comportamento de setar hora automaticamente após digitar a data. ([#1411](https://github.com/bildvitta/asteroid/issues/1411))

### Modificado
- `search-filter.js`: modificado lógica dos campos dependentes, quando o campo estiver desabilitado, só o campo só será limpo, não batera a API. ([#1453](https://github.com/bildvitta/asteroid/issues/1453))
- `QasDateTimeInput`: modificado comportamento do model, ao sair do campo e a data for inválida ou incompleta, vamos limpar o model, mas iremos continuar exibindo o valor incorreto no campo com o aviso de erro.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
