### PR TITLE
QasTableGenerator: Tabela com destaque

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não p
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
 ## Não publicado
+### Adicionado
+- `QasTableGenerator`:
+  - Adicionado prop `groups`, onde é podemos exibir as informações na tabela de forma agrupada.
+  - Adicionado prop `highlights`, onde é uma função de callback das linhas da tabela, podendo tratar quais linhas terão destaques.
+  - Adicionado prop `useStickyLastRow` para manter a última linha da tabela fixa.
+
 ### Corrigido
 - `QasSelect`: corrigido comportamento do texto do input do select sobrepor o item selecionado ao apertar a tecla tab.
 

--- a/docs/src/examples/QasTableGenerator/WithHightlight.vue
+++ b/docs/src/examples/QasTableGenerator/WithHightlight.vue
@@ -1,0 +1,40 @@
+<template>
+  <qas-container>
+    <qas-table-generator v-bind="tableGeneratorProps" />
+  </qas-container>
+</template>
+
+<script setup>
+import { fields, results } from 'src/mocks/users'
+
+defineOptions({ name: 'WithHightlight' })
+
+const tableGeneratorProps = {
+  results,
+  fields,
+  columns: ['name', 'isActive', 'company', 'document', 'email'],
+
+  maxHeight: '500px',
+  useVirtualScroll: true,
+
+  useGroups: true,
+  groups: {
+    first: {
+      label: 'Primeiro grupo',
+      fields: ['isActive', 'company']
+    },
+
+    second: {
+      label: 'Segundo grupo',
+      fields: ['document', 'email']
+    }
+  },
+
+  highlights: ({ index }) => {
+    // Adicionar destaque somente na quarta linha.
+    if (index === 3) return true
+  },
+
+  useStickLastRow: true
+}
+</script>

--- a/docs/src/examples/QasTableGenerator/WithHightlight.vue
+++ b/docs/src/examples/QasTableGenerator/WithHightlight.vue
@@ -35,6 +35,6 @@ const tableGeneratorProps = {
     if (index === 3) return true
   },
 
-  useStickLastRow: true
+  useStickyLastRow: true
 }
 </script>

--- a/docs/src/pages/components/table-generator.md
+++ b/docs/src/pages/components/table-generator.md
@@ -148,3 +148,5 @@ O virtual scroll renderiza dinamicamente as linhas a serem exibidas na tabela.
 Apenas utilize virtual scroll quando realmente houver comportamentos no qual não se pode ter paginação e tiver muitos dados na tabela.
 :::
 <doc-example file="QasTableGenerator/WithVirtualScroll" title="Com virtual scroll" />
+
+<doc-example file="QasTableGenerator/WithHightlight" title="Com linhas destacadas" />

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -483,7 +483,8 @@ export default {
         'qas-table-generator--mobile': this.$qas.screen.isSmall,
         'qas-table-generator--sticky-header': this.useStickyHeader,
         'qas-table-generator--has-actions': this.hasActionsMenu,
-        'qas-table-generator--multiline': this.useMultiline
+        'qas-table-generator--multiline': this.useMultiline,
+        'qas-table-generator--row-spacing': !!this.highlights || this.useStickyLastRow
       }
     },
 
@@ -893,16 +894,6 @@ export default {
     &--highlighted {
       background-color: $light-blue-1 !important;
       color: $grey-10;
-
-      &:first-child {
-        border-bottom-left-radius: var(--qas-generic-border-radius);
-        border-top-left-radius: var(--qas-generic-border-radius);
-      }
-
-      &:last-child {
-        border-bottom-right-radius: var(--qas-generic-border-radius);
-        border-top-right-radius: var(--qas-generic-border-radius);
-      }
     }
   }
 
@@ -955,6 +946,18 @@ export default {
     td {
       background-color: $light-blue-1 !important;
       color: $grey-10;
+    }
+  }
+
+  &--row-spacing {
+    .q-table {
+      th:first-child {
+        padding-left: var(--qas-spacing-md);
+      }
+
+      td:first-child {
+        padding-left: var(--qas-spacing-md);
+      }
     }
   }
 

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -88,7 +88,7 @@
       </template>
 
       <template
-        v-if="useStickLastRow"
+        v-if="useStickyLastRow"
         #bottom-row="context"
       >
         <slot :context="context" name="bottom-row">
@@ -257,7 +257,7 @@ export default {
       type: Boolean
     },
 
-    useStickLastRow: {
+    useStickyLastRow: {
       type: Boolean
     },
 
@@ -321,7 +321,7 @@ export default {
         })
       }
 
-      if (this.useStickLastRow) {
+      if (this.useStickyLastRow) {
         return this.results.slice(0, this.results.length - 1)
       }
 

--- a/ui/src/components/table-generator/QasTableGenerator.vue
+++ b/ui/src/components/table-generator/QasTableGenerator.vue
@@ -5,6 +5,36 @@
     </slot>
 
     <q-table v-show="hasResults" ref="table" v-bind="attributes" v-model:selected="selectedModel" class="bg-white text-grey-8">
+      <template v-if="hasGroups" #header="context">
+        <slot :context="context" name="header">
+          <q-tr>
+            <!-- Precisa de um TH vazio para ficar com espaço na primeira coluna -->
+            <th class="qas-table-generator__group-th" />
+
+            <th
+              v-for="(group, key) in groups"
+              :key="key"
+              class="qas-table-generator__group-th text-left"
+              :colspan="group.fields?.length"
+            >
+              <div class="bg-light-blue-1 text-grey-10">
+                {{ group.label }}
+              </div>
+            </th>
+          </q-tr>
+
+          <q-tr>
+            <th
+              v-for="(field, key) in columnsByFields"
+              :key="key"
+              class="qas-table-generator__field-th text-left"
+            >
+              {{ field.label }}
+            </th>
+          </q-tr>
+        </slot>
+      </template>
+
       <template v-if="skeleton" #header-cell="props">
         <q-th :props="props">
           <qas-skeleton v-bind="getThSkeletonProps()" />
@@ -42,7 +72,7 @@
       </template>
 
       <template v-for="(fieldName, index) in bodyCellNameSlots" :key="index" #[`body-cell-${fieldName}`]="context">
-        <q-td :class="getTdClasses(context.row)">
+        <q-td :class="getTdClasses(context)">
           <qas-skeleton v-if="skeleton" v-bind="getTgSkeletonProps(fieldName, context.row)" />
 
           <component :is="tdChildComponent(context.row)" v-else class="qas-table-generator__td-item" v-bind="getTdChildComponentProps(context.row)">
@@ -55,6 +85,24 @@
             </slot>
           </component>
         </q-td>
+      </template>
+
+      <template
+        v-if="useStickLastRow"
+        #bottom-row="context"
+      >
+        <slot :context="context" name="bottom-row">
+          <q-tr class="qas-table-generator__sticky-total">
+            <td
+              v-for="(col, index) in context.cols"
+              :key="index"
+            >
+              <span>
+                {{ getTotalInfo(col) }}
+              </span>
+            </td>
+          </q-tr>
+        </slot>
       </template>
     </q-table>
 
@@ -134,9 +182,19 @@ export default {
       type: [Object, Function]
     },
 
+    groups: {
+      type: Object,
+      default: () => ({})
+    },
+
     headerProps: {
       default: () => ({}),
       type: Object
+    },
+
+    highlights: {
+      type: Function,
+      default: undefined
     },
 
     maxHeight: {
@@ -199,6 +257,10 @@ export default {
       type: Boolean
     },
 
+    useStickLastRow: {
+      type: Boolean
+    },
+
     useVirtualScroll: {
       type: Boolean
     }
@@ -257,6 +319,10 @@ export default {
 
           return result
         })
+      }
+
+      if (this.useStickLastRow) {
+        return this.results.slice(0, this.results.length - 1)
       }
 
       return this.results
@@ -482,6 +548,10 @@ export default {
       set (rows) {
         this.$emit('update:selected', this.useObjectSelectedModel ? rows : rows.map(row => row[this.rowKey]))
       }
+    },
+
+    hasGroups () {
+      return !!Object.keys(this.groups).length
     }
   },
 
@@ -584,9 +654,14 @@ export default {
       return isRoutePayloadObject ? !!Object.keys(routePayload).length : !!routePayload
     },
 
-    getTdClasses (row) {
+    getTdClasses (context) {
+      const { row, rowIndex: index } = context
+
+      const hasHighlightsFn = !!this.highlights
+
       return {
-        'qas-table-generator__td--has-action': this.hasRowRoute(row)
+        'qas-table-generator__td--has-action': this.hasRowRoute(row),
+        'qas-table-generator__td--highlighted': hasHighlightsFn && this.highlights?.({ row, index })
       }
     },
 
@@ -693,6 +768,13 @@ export default {
         useContrast: true,
         width: `${width}px`
       }
+    },
+
+    getTotalInfo ({ name }) {
+      // O último resultado é sempre o total geral.
+      const lastResult = this.results.at(-1)
+
+      return humanize(this.fields[name], lastResult[name])
     }
   }
 }
@@ -807,6 +889,23 @@ export default {
     }
   }
 
+  &__td {
+    &--highlighted {
+      background-color: $light-blue-1 !important;
+      color: $grey-10;
+
+      &:first-child {
+        border-bottom-left-radius: var(--qas-generic-border-radius);
+        border-top-left-radius: var(--qas-generic-border-radius);
+      }
+
+      &:last-child {
+        border-bottom-right-radius: var(--qas-generic-border-radius);
+        border-top-right-radius: var(--qas-generic-border-radius);
+      }
+    }
+  }
+
   &--multiline {
     @media (min-width: $breakpoint-sm) {
       .q-table td {
@@ -844,6 +943,40 @@ export default {
           top: 0;
         }
       }
+    }
+  }
+
+  &__sticky-total {
+    background-color: $light-blue-1 !important;
+    bottom: 0;
+    position: sticky;
+    transition: box-shadow var(--qas-generic-transition);
+
+    td {
+      background-color: $light-blue-1 !important;
+      color: $grey-10;
+    }
+  }
+
+  &__group-th {
+    padding: 0 !important;
+    border: none !important;
+
+    div {
+      margin-bottom: var(--qas-spacing-sm);
+      align-items: center;
+      border-radius: var(--qas-generic-border-radius);
+      display: flex;
+      height: 40px; // mesmo tamanho da linha
+      margin-right: var(--qas-spacing-sm);
+      padding-left: calc(var(--qas-spacing-lg) / 2);
+      padding-right: calc(var(--qas-spacing-lg) / 2);
+    }
+  }
+
+  &:has(#{$root}__group-th) {
+    #{$root}__field-th {
+      padding-top: var(--qas-spacing-sm);
     }
   }
 }

--- a/ui/src/components/table-generator/QasTableGenerator.yml
+++ b/ui/src/components/table-generator/QasTableGenerator.yml
@@ -142,7 +142,7 @@ props:
     default: false
     type: Boolean
 
-  use-stick-last-row:
+  use-sticky-last-row:
     desc: Usado para manter a última linha da tabela fixa.
     default: false
     type: Boolean

--- a/ui/src/components/table-generator/QasTableGenerator.yml
+++ b/ui/src/components/table-generator/QasTableGenerator.yml
@@ -45,11 +45,29 @@ props:
         desc: Índice da linha da tabela.
         type: Number
 
+    groups:
+      desc: Usado para criar um destaque no header, com intenção de agrupar as informações das colunas.
+      default: {}
+      type: Object
+      examples: ["{ first: { label: 'Primeiro grupo', fields: ['email', 'phone'] } }"]
+
   header-props:
     desc: Propriedades repassadas para o componente `QasHeader`.
     default: {}
     type: Object
     examples: ["{ description: 'Descrição', labelProps: { label: 'Titulo do header'} }"]
+
+  highlights:
+    desc: Função para destacar células da tabela com base em uma condição.
+    default: undefined
+    type: Function
+    params:
+      row:
+        desc: Payload da linha da tabela.
+        type: Object
+      index:
+        desc: Índice da linha da tabela.
+        type: Number
 
   max-height:
     desc: Usado para definir a altura máxima da tabela e exibir o scroll vertical. Somente funciona quando a propriedade "use-sticky-header" ou "use-virtual-scroll" é utilizada.
@@ -121,6 +139,11 @@ props:
 
   use-virtual-scroll:
     desc: Usado para ativar o scroll virtual da tabela.
+    default: false
+    type: Boolean
+
+  use-stick-last-row:
+    desc: Usado para manter a última linha da tabela fixa.
     default: false
     type: Boolean
 


### PR DESCRIPTION
### Adicionado
- `QasTableGenerator`:
  - Adicionado prop `groups`, onde é podemos exibir as informações na tabela de forma agrupada.
  - Adicionado prop `highlights`, onde é uma função de callback das linhas da tabela, podendo tratar quais linhas terão destaques.
  - Adicionado prop `useStickyLastRow` para manter a última linha da tabela fixa.


## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
