### PR TITLE
Feature/changes in board generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não p
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
 ## Não publicado
+### Adicionado
+- `QasBtn`: adicionada prop `useMagicAiColor` que aplica gradiente de inteligência artificial (magic AI) ao botão. O comportamento varia por variante: `primary` altera o fundo, `secondary` altera texto e borda, `tertiary` altera apenas o texto. Hover usa `$secondary-contrast`.
+- `QasActionsMenu`: suporte à propriedade `useMagicAiColor` nos itens da prop `list`, que aplica o gradiente de magic AI no ícone e no texto do item no dropdown. Quando o item é renderizado como botão externo (via `splitName`), as cores são aplicadas automaticamente.
+- CSS: adicionadas classes utilitárias `text-magic-ai`, `bg-magic-ai` e `border-magic-ai` para aplicação do gradiente de magic AI em textos, fundos e bordas respectivamente.
+
 ### Corrigido
 - `QasSelect`: corrigido comportamento do texto do input do select sobrepor o item selecionado ao apertar a tecla tab.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 
 ## Não publicado
 ## BREAKING CHANGES
-- `QasBoardGenerator`: Varias mudanças de comportamento e visuais no componente, revisar se nada quebra.
+- `QasBoardGenerator`:
+  - Varias mudanças de comportamento e visuais no componente, revisar se nada quebra.
+  - removido prop `headerBoxProps` porque agora não existe um `QasBox` englobando o header.
 
 ### Adicionado
 - `QasBoardGenerator`:
@@ -47,7 +49,9 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 - `helpers/set-scroll-gradient`: Corrigido pequena diferença de posicionamento do gradiente.
 
 ### Removido
-- `QasBoardGenerator`: removido prop `useMarkRaw`, agora o componente faz o controle sozinho de quando vai ser ou não reativo os dados.
+- `QasBoardGenerator`: 
+  - removido prop `useMarkRaw`, agora o componente faz o controle sozinho de quando vai ser ou não reativo os dados.
+  - removido prop `headerBoxProps` porque agora não existe um `QasBox` englobando o header.
 
 ## [3.20.0-beta.13] - 19-02-2026
 ### Adicionado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,19 +15,39 @@ Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não p
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
 ## Não publicado
+## BREAKING CHANGES
+- `QasBoardGenerator`: Varias mudanças de comportamento e visuais no componente, revisar se nada quebra.
+
 ### Adicionado
+- `QasBoardGenerator`:
+  - adicionada prop `skeleton` (default `false`) para exibir cards fictícios de carregamento enquanto as colunas são buscadas.
+  - adicionado suporte a lazy loading das colunas via `QasLazyLoadingComponents`, priorizando o carregamento das colunas visíveis.
+  - adicionado scroll horizontal suave durante drag-and-drop, com velocidade vertical independente e melhoras no estilo da classe ghost.
+  - adicionados novos métodos expostos: `refreshColumn`, `removeItemFromList`, `updateItemInList`, `refetchColumns` e `transferItemToColumn`.
+  - adicionado parâmetro `isUpdatingPosition` no slot `column-item` para indicar quando o item está sendo processado pelo drag-and-drop.
+  - adicionado parâmetros `header` e `columnIndex` no slot `column-item`.
+- `QasLazyLoadingComponents`:
+  - adicionada prop `direction` (`vertical` | `horizontal`) para suporte a listas de rolagem horizontal.
+  - adicionada prop `placeholder-width` para definir a largura dos placeholders no modo horizontal.
+  - adicionado `v-model:visible-items` que expõe os índices dos itens atualmente visíveis na viewport.
+- `QasDialog`: adicionado slot `title` para inserir conteúdo adicional ao lado do título do card do dialog.
 - `QasBtn`: adicionada prop `useMagicAiColor` que aplica gradiente de inteligência artificial (magic AI) ao botão. O comportamento varia por variante: `primary` altera o fundo, `secondary` altera texto e borda, `tertiary` altera apenas o texto. Hover usa `$secondary-contrast`.
 - `QasActionsMenu`: suporte à propriedade `useMagicAiColor` nos itens da prop `list`, que aplica o gradiente de magic AI no ícone e no texto do item no dropdown. Quando o item é renderizado como botão externo (via `splitName`), as cores são aplicadas automaticamente.
 - CSS: adicionadas classes utilitárias `text-magic-ai`, `bg-magic-ai` e `border-magic-ai` para aplicação do gradiente de magic AI em textos, fundos e bordas respectivamente.
 - `QasDateTimeInput`: adicionado comportamento de setar hora automaticamente após digitar a data. ([#1411](https://github.com/bildvitta/asteroid/issues/1411))
 
 ### Modificado
+- `QasListView`: removida lógica que acionava delete automático quando `useStore: false` e `entity` estava definido; o comportamento agora é controlado exclusivamente pelas props `useAutoHandleOnDelete` e `useAutoRefetchOnDelete`.
 - `search-filter.js`: modificado lógica dos campos dependentes, quando o campo estiver desabilitado, só o campo só será limpo, não batera a API. ([#1453](https://github.com/bildvitta/asteroid/issues/1453))
 - `QasDateTimeInput`: modificado comportamento do model, ao sair do campo e a data for inválida ou incompleta, vamos limpar o model, mas iremos continuar exibindo o valor incorreto no campo com o aviso de erro.
 - `filters.js`: modificado label da função booleanLabel para começarem com letras maiúsculas.
 
 ### Corrigido
 - `QasSelect`: corrigido comportamento do texto do input do select sobrepor o item selecionado ao apertar a tecla tab.
+- `helpers/set-scroll-gradient`: Corrigido pequena diferença de posicionamento do gradiente.
+
+### Removido
+- `QasBoardGenerator`: removido prop `useMarkRaw`, agora o componente faz o controle sozinho de quando vai ser ou não reativo os dados.
 
 ## [3.20.0-beta.13] - 19-02-2026
 ### Adicionado

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
-  "version": "3.20.0-beta.14-alpha.2",
+  "version": "3.20.0-beta.14-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-app-extension-asteroid",
-      "version": "3.20.0-beta.14-alpha.2",
+      "version": "3.20.0-beta.14-alpha.3",
       "license": "MIT",
       "dependencies": {
-        "@bildvitta/quasar-ui-asteroid": "3.20.0-beta.14-alpha.2",
+        "@bildvitta/quasar-ui-asteroid": "3.20.0-beta.14-alpha.3",
         "@bildvitta/store-adapter": "^1.0.0",
         "execa": "^7.1.1",
         "fontfaceobserver": "^2.3.0",
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@bildvitta/quasar-ui-asteroid": {
-      "version": "3.20.0-beta.14-alpha.2",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.20.0-beta.14-alpha.2.tgz",
-      "integrity": "sha512-UCdALIujHV8IzveJCdW3B5w86JjvbEhjgR0EWscm91D+0Xt7oNqMIsgqNzI1/ejz68AzsPwnPQ7Xp4JhO6rdjA==",
+      "version": "3.20.0-beta.14-alpha.3",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.20.0-beta.14-alpha.3.tgz",
+      "integrity": "sha512-NR07AAbY15i+VjzTfZkRpFIFgNs3CpxP49sTtCY3sA2Gry/x3Fjjemt5oWEBcfRLt4VjLABYYjUII1hb0MZX7A==",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",
@@ -138,446 +138,38 @@
         "vite-plugin-dts": "^1.4.1"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
-      "cpu": [
-        "ppc64"
-      ],
+    "node_modules/@emnapi/core": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
+      "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
       "license": "MIT",
       "optional": true,
-      "os": [
-        "aix"
-      ],
       "peer": true,
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
+      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
       "peer": true,
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
       "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@fawmi/vue-google-maps": {
@@ -591,28 +183,28 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
-      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
-      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.4",
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
     "node_modules/@googlemaps/markerclusterer": {
@@ -625,27 +217,6 @@
         "@types/supercluster": "^7.1.3",
         "fast-equals": "^5.2.2",
         "supercluster": "^8.0.1"
-      }
-    },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
-      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -722,21 +293,21 @@
       }
     },
     "node_modules/@microsoft/api-extractor": {
-      "version": "7.57.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.57.0.tgz",
-      "integrity": "sha512-ZWflRQNLRBgG4DPRDUB6DQR2AL2Z+gYU/1PIwFKna8c8c9IGF4h0FHtb73MbV0LfufqfzDVnpaLPXmOtDAeUaA==",
+      "version": "7.57.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.57.7.tgz",
+      "integrity": "sha512-kmnmVs32MFWbV5X6BInC1/TfCs7y1ugwxv1xHsAIj/DyUfoe7vtO0alRUgbQa57+yRGHBBjlNcEk33SCAt5/dA==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/api-extractor-model": "7.33.0",
+        "@microsoft/api-extractor-model": "7.33.4",
         "@microsoft/tsdoc": "~0.16.0",
-        "@microsoft/tsdoc-config": "~0.18.0",
-        "@rushstack/node-core-library": "5.20.0",
-        "@rushstack/rig-package": "0.7.0",
-        "@rushstack/terminal": "0.22.0",
-        "@rushstack/ts-command-line": "5.3.0",
+        "@microsoft/tsdoc-config": "~0.18.1",
+        "@rushstack/node-core-library": "5.20.3",
+        "@rushstack/rig-package": "0.7.2",
+        "@rushstack/terminal": "0.22.3",
+        "@rushstack/ts-command-line": "5.3.3",
         "diff": "~8.0.2",
         "lodash": "~4.17.23",
-        "minimatch": "10.1.2",
+        "minimatch": "10.2.3",
         "resolve": "~1.22.1",
         "semver": "~7.5.4",
         "source-map": "~0.6.1",
@@ -747,23 +318,23 @@
       }
     },
     "node_modules/@microsoft/api-extractor-model": {
-      "version": "7.33.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.0.tgz",
-      "integrity": "sha512-cMrvErE9yJz8aImpRztUfbO085WRSI4nsvMQ+VNGgHxiQO7s5LAXrt+B35RUghIsn0JdNdqIzusXXtKgSnXh7Q==",
+      "version": "7.33.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.4.tgz",
+      "integrity": "sha512-u1LTaNTikZAQ9uK6KG1Ms7nvNedsnODnspq/gH2dcyETWvH4hVNGNDvRAEutH66kAmxA4/necElqGNs1FggC8w==",
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "~0.16.0",
-        "@microsoft/tsdoc-config": "~0.18.0",
-        "@rushstack/node-core-library": "5.20.0"
+        "@microsoft/tsdoc-config": "~0.18.1",
+        "@rushstack/node-core-library": "5.20.3"
       }
     },
     "node_modules/@microsoft/api-extractor-model/node_modules/@rushstack/node-core-library": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.20.0.tgz",
-      "integrity": "sha512-yix/WFzuMPvbECgQjdzjDqynv7YQnrcGUfy56WU7QWAVcoN4uB1wCwpt3heo/ghHp2nINrRecPtVS7sQmqY+OA==",
+      "version": "5.20.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.20.3.tgz",
+      "integrity": "sha512-95JgEPq2k7tHxhF9/OJnnyHDXfC9cLhhta0An/6MlkDsX2A6dTzDrTUG18vx4vjc280V0fi0xDH9iQczpSuWsw==",
       "license": "MIT",
       "dependencies": {
-        "ajv": "~8.13.0",
+        "ajv": "~8.18.0",
         "ajv-draft-04": "~1.0.0",
         "ajv-formats": "~3.0.1",
         "fs-extra": "~11.3.0",
@@ -781,26 +352,10 @@
         }
       }
     },
-    "node_modules/@microsoft/api-extractor-model/node_modules/ajv": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
-      "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.4.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/@microsoft/api-extractor-model/node_modules/fs-extra": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -827,12 +382,12 @@
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/@rushstack/node-core-library": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.20.0.tgz",
-      "integrity": "sha512-yix/WFzuMPvbECgQjdzjDqynv7YQnrcGUfy56WU7QWAVcoN4uB1wCwpt3heo/ghHp2nINrRecPtVS7sQmqY+OA==",
+      "version": "5.20.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.20.3.tgz",
+      "integrity": "sha512-95JgEPq2k7tHxhF9/OJnnyHDXfC9cLhhta0An/6MlkDsX2A6dTzDrTUG18vx4vjc280V0fi0xDH9iQczpSuWsw==",
       "license": "MIT",
       "dependencies": {
-        "ajv": "~8.13.0",
+        "ajv": "~8.18.0",
         "ajv-draft-04": "~1.0.0",
         "ajv-formats": "~3.0.1",
         "fs-extra": "~11.3.0",
@@ -850,26 +405,31 @@
         }
       }
     },
-    "node_modules/@microsoft/api-extractor/node_modules/ajv": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
-      "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
+    "node_modules/@microsoft/api-extractor/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.4.1"
+        "balanced-match": "^4.0.2"
       },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/fs-extra": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -881,15 +441,15 @@
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/minimatch": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
-      "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
+      "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -917,15 +477,32 @@
       "license": "MIT"
     },
     "node_modules/@microsoft/tsdoc-config": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.18.0.tgz",
-      "integrity": "sha512-8N/vClYyfOH+l4fLkkr9+myAoR6M7akc8ntBJ4DJdWH2b09uVfr71+LTMpNyG19fNqWDg8KEDZhx5wxuqHyGjw==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.18.1.tgz",
+      "integrity": "sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==",
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "0.16.0",
-        "ajv": "~8.12.0",
+        "ajv": "~8.18.0",
         "jju": "~1.4.0",
         "resolve": "~1.22.2"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -963,6 +540,26 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@oxc-project/runtime": {
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.115.0.tgz",
+      "integrity": "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.115.0.tgz",
+      "integrity": "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@quasar/extras": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/@quasar/extras/-/extras-1.17.0.tgz",
@@ -973,6 +570,268 @@
         "type": "github",
         "url": "https://donate.quasar.dev"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.9.tgz",
+      "integrity": "sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.9.tgz",
+      "integrity": "sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.9.tgz",
+      "integrity": "sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.9.tgz",
+      "integrity": "sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.9.tgz",
+      "integrity": "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
@@ -1007,356 +866,6 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
-    },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
-      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
-      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
-      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
-      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
-      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
-      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
-      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
-      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
-      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
-      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
-      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
-      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
-      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
-      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
-      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
-      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
-      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
-      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
-      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
-      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
-      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
-      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
     },
     "node_modules/@rrweb/record": {
       "version": "2.0.0-alpha.20",
@@ -1452,9 +961,9 @@
       }
     },
     "node_modules/@rushstack/problem-matcher": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/problem-matcher/-/problem-matcher-0.2.0.tgz",
-      "integrity": "sha512-IHV2qdypwqEatMg8Ka9e/q26pu2tOyhG3fuJZtrrPA3O++ctW8y1p6oCeeeIV8v1/kJ3xJPtg1xdZshyNZb8sg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/problem-matcher/-/problem-matcher-0.2.1.tgz",
+      "integrity": "sha512-gulfhBs6n+I5b7DvjKRfhMGyUejtSgOHTclF/eONr8hcgF1APEDjhxIsfdUYYMzC3rvLwGluqLjbwCFZ8nxrog==",
       "license": "MIT",
       "peerDependencies": {
         "@types/node": "*"
@@ -1466,9 +975,9 @@
       }
     },
     "node_modules/@rushstack/rig-package": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.7.0.tgz",
-      "integrity": "sha512-iPHSnI/DtLPv2lydP9WWZczhD9knVCJWwLle1H01IYnvYNkhZX8rbnuUH+HEwcANd3YlLjCpXydWN3LMoLOxPw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.7.2.tgz",
+      "integrity": "sha512-9XbFWuqMYcHUso4mnETfhGVUSaADBRj6HUAAEYk50nMPn8WRICmBuCphycQGNB3duIR6EEZX3Xj3SYc2XiP+9A==",
       "license": "MIT",
       "dependencies": {
         "resolve": "~1.22.1",
@@ -1476,13 +985,13 @@
       }
     },
     "node_modules/@rushstack/terminal": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.22.0.tgz",
-      "integrity": "sha512-z5O2g5dws5iFNe3hAutAKLPmQARJs/VEWMxdpyew+xm0ohw1qh1G6+wY0nUzFPrLiKQjU+8KNA11VAEMb46ETg==",
+      "version": "0.22.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.22.3.tgz",
+      "integrity": "sha512-gHC9pIMrUPzAbBiI4VZMU7Q+rsCzb8hJl36lFIulIzoceKotyKL3Rd76AZ2CryCTKEg+0bnTj406HE5YY5OQvw==",
       "license": "MIT",
       "dependencies": {
-        "@rushstack/node-core-library": "5.20.0",
-        "@rushstack/problem-matcher": "0.2.0",
+        "@rushstack/node-core-library": "5.20.3",
+        "@rushstack/problem-matcher": "0.2.1",
         "supports-color": "~8.1.1"
       },
       "peerDependencies": {
@@ -1495,12 +1004,12 @@
       }
     },
     "node_modules/@rushstack/terminal/node_modules/@rushstack/node-core-library": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.20.0.tgz",
-      "integrity": "sha512-yix/WFzuMPvbECgQjdzjDqynv7YQnrcGUfy56WU7QWAVcoN4uB1wCwpt3heo/ghHp2nINrRecPtVS7sQmqY+OA==",
+      "version": "5.20.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.20.3.tgz",
+      "integrity": "sha512-95JgEPq2k7tHxhF9/OJnnyHDXfC9cLhhta0An/6MlkDsX2A6dTzDrTUG18vx4vjc280V0fi0xDH9iQczpSuWsw==",
       "license": "MIT",
       "dependencies": {
-        "ajv": "~8.13.0",
+        "ajv": "~8.18.0",
         "ajv-draft-04": "~1.0.0",
         "ajv-formats": "~3.0.1",
         "fs-extra": "~11.3.0",
@@ -1518,26 +1027,10 @@
         }
       }
     },
-    "node_modules/@rushstack/terminal/node_modules/ajv": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
-      "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.4.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/@rushstack/terminal/node_modules/fs-extra": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -1564,12 +1057,12 @@
       }
     },
     "node_modules/@rushstack/ts-command-line": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.0.tgz",
-      "integrity": "sha512-4hneaVxA5zPC8cwUGZtdvCUzGbW8A+b+qrBK3hYs/xO7TyWkgAMKxq/6FJY91fPG8awgmJ+s1w8GuqNXgxsTyw==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.3.tgz",
+      "integrity": "sha512-c+ltdcvC7ym+10lhwR/vWiOhsrm/bP3By2VsFcs5qTKv+6tTmxgbVrtJ5NdNjANiV5TcmOZgUN+5KYQ4llsvEw==",
       "license": "MIT",
       "dependencies": {
-        "@rushstack/terminal": "0.22.0",
+        "@rushstack/terminal": "0.22.3",
         "@types/argparse": "1.0.38",
         "argparse": "~1.0.9",
         "string-argv": "~0.3.1"
@@ -1597,15 +1090,26 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/argparse": {
@@ -1651,53 +1155,53 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.28",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.28.tgz",
-      "integrity": "sha512-kviccYxTgoE8n6OCw96BNdYlBg2GOWfBuOW4Vqwrt7mSKWKwFVvI8egdTltqRgITGPsTFYtKYfxIG8ptX2PJHQ==",
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.30.tgz",
+      "integrity": "sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
-        "@vue/shared": "3.5.28",
+        "@vue/shared": "3.5.30",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.28",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.28.tgz",
-      "integrity": "sha512-/1ZepxAb159jKR1btkefDP+J2xuWL5V3WtleRmxaT+K2Aqiek/Ab/+Ebrw2pPj0sdHO8ViAyyJWfhXXOP/+LQA==",
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.30.tgz",
+      "integrity": "sha512-eCFYESUEVYHhiMuK4SQTldO3RYxyMR/UQL4KdGD1Yrkfdx4m/HYuZ9jSfPdA+nWJY34VWndiYdW/wZXyiPEB9g==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.28",
-        "@vue/shared": "3.5.28"
+        "@vue/compiler-core": "3.5.30",
+        "@vue/shared": "3.5.30"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.28",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.28.tgz",
-      "integrity": "sha512-6TnKMiNkd6u6VeVDhZn/07KhEZuBSn43Wd2No5zaP5s3xm8IqFTHBj84HJah4UepSUJTro5SoqqlOY22FKY96g==",
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.30.tgz",
+      "integrity": "sha512-LqmFPDn89dtU9vI3wHJnwaV6GfTRD87AjWpTWpyrdVOObVtjIuSeZr181z5C4PmVx/V3j2p+0f7edFKGRMpQ5A==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
-        "@vue/compiler-core": "3.5.28",
-        "@vue/compiler-dom": "3.5.28",
-        "@vue/compiler-ssr": "3.5.28",
-        "@vue/shared": "3.5.28",
+        "@vue/compiler-core": "3.5.30",
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/compiler-ssr": "3.5.30",
+        "@vue/shared": "3.5.30",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.6",
+        "postcss": "^8.5.8",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.28",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.28.tgz",
-      "integrity": "sha512-JCq//9w1qmC6UGLWJX7RXzrGpKkroubey/ZFqTpvEIDJEKGgntuDMqkuWiZvzTzTA5h2qZvFBFHY7fAAa9475g==",
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.30.tgz",
+      "integrity": "sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.28",
-        "@vue/shared": "3.5.28"
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/shared": "3.5.30"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -1708,57 +1212,57 @@
       "peer": true
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.28",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.28.tgz",
-      "integrity": "sha512-gr5hEsxvn+RNyu9/9o1WtdYdwDjg5FgjUSBEkZWqgTKlo/fvwZ2+8W6AfKsc9YN2k/+iHYdS9vZYAhpi10kNaw==",
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.30.tgz",
+      "integrity": "sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@vue/shared": "3.5.28"
+        "@vue/shared": "3.5.30"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.28",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.28.tgz",
-      "integrity": "sha512-POVHTdbgnrBBIpnbYU4y7pOMNlPn2QVxVzkvEA2pEgvzbelQq4ZOUxbp2oiyo+BOtiYlm8Q44wShHJoBvDPAjQ==",
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.30.tgz",
+      "integrity": "sha512-e0Z+8PQsUTdwV8TtEsLzUM7SzC7lQwYKePydb7K2ZnmS6jjND+WJXkmmfh/swYzRyfP1EY3fpdesyYoymCzYfg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@vue/reactivity": "3.5.28",
-        "@vue/shared": "3.5.28"
+        "@vue/reactivity": "3.5.30",
+        "@vue/shared": "3.5.30"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.28",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.28.tgz",
-      "integrity": "sha512-4SXxSF8SXYMuhAIkT+eBRqOkWEfPu6nhccrzrkioA6l0boiq7sp18HCOov9qWJA5HML61kW8p/cB4MmBiG9dSA==",
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.30.tgz",
+      "integrity": "sha512-2UIGakjU4WSQ0T4iwDEW0W7vQj6n7AFn7taqZ9Cvm0Q/RA2FFOziLESrDL4GmtI1wV3jXg5nMoJSYO66egDUBw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@vue/reactivity": "3.5.28",
-        "@vue/runtime-core": "3.5.28",
-        "@vue/shared": "3.5.28",
+        "@vue/reactivity": "3.5.30",
+        "@vue/runtime-core": "3.5.30",
+        "@vue/shared": "3.5.30",
         "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.28",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.28.tgz",
-      "integrity": "sha512-pf+5ECKGj8fX95bNincbzJ6yp6nyzuLDhYZCeFxUNp8EBrQpPpQaLX3nNCp49+UbgbPun3CeVE+5CXVV1Xydfg==",
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.30.tgz",
+      "integrity": "sha512-v+R34icapydRwbZRD0sXwtHqrQJv38JuMB4JxbOxd8NEpGLny7cncMp53W9UH/zo4j8eDHjQ1dEJXwzFQknjtQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.28",
-        "@vue/shared": "3.5.28"
+        "@vue/compiler-ssr": "3.5.30",
+        "@vue/shared": "3.5.30"
       },
       "peerDependencies": {
-        "vue": "3.5.28"
+        "vue": "3.5.30"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.28",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.28.tgz",
-      "integrity": "sha512-cfWa1fCGBxrvaHRhvV3Is0MgmrbSCxYTXCSCau2I0a1Xw1N1pHAvkWCiXPRAqjvToILvguNyEwjevUqAuBQWvQ==",
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+      "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==",
       "license": "MIT"
     },
     "node_modules/@xstate/fsm": {
@@ -1800,15 +1304,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -1919,9 +1423,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -2273,7 +1777,6 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2364,48 +1867,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
-      }
-    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -2472,6 +1933,22 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -3089,6 +2566,267 @@
         "node": ">=10"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "license": "MPL-2.0",
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/local-pkg": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
@@ -3303,9 +3041,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -3371,15 +3109,15 @@
       }
     },
     "node_modules/mlly": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
-      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.1.tgz",
+      "integrity": "sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==",
       "license": "MIT",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "pathe": "^2.0.3",
         "pkg-types": "^1.3.1",
-        "ufo": "^1.6.1"
+        "ufo": "^1.6.3"
       }
     },
     "node_modules/mlly/node_modules/confbox": {
@@ -3696,9 +3434,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "funding": [
         {
           "type": "opencollective",
@@ -3737,15 +3475,6 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
-    },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/pusher-js": {
       "version": "8.4.0",
@@ -3934,49 +3663,38 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
-      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
+      "integrity": "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@oxc-project/types": "=0.115.0",
+        "@rolldown/pluginutils": "1.0.0-rc.9"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.57.1",
-        "@rollup/rollup-android-arm64": "4.57.1",
-        "@rollup/rollup-darwin-arm64": "4.57.1",
-        "@rollup/rollup-darwin-x64": "4.57.1",
-        "@rollup/rollup-freebsd-arm64": "4.57.1",
-        "@rollup/rollup-freebsd-x64": "4.57.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
-        "@rollup/rollup-linux-arm64-musl": "4.57.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
-        "@rollup/rollup-linux-loong64-musl": "4.57.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-musl": "4.57.1",
-        "@rollup/rollup-openbsd-x64": "4.57.1",
-        "@rollup/rollup-openharmony-arm64": "4.57.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
-        "@rollup/rollup-win32-x64-gnu": "4.57.1",
-        "@rollup/rollup-win32-x64-msvc": "4.57.1",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.9",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9"
       }
     },
     "node_modules/rrdom": {
@@ -4222,12 +3940,12 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -4390,6 +4108,14 @@
         "code-block-writer": "^11.0.3"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
@@ -4520,15 +4246,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
     "node_modules/util": {
       "version": "0.10.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
@@ -4561,17 +4278,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.0.tgz",
+      "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
+        "@oxc-project/runtime": "0.115.0",
+        "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.9",
         "tinyglobby": "^0.2.15"
       },
       "bin": {
@@ -4588,9 +4305,10 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.0.0-alpha.31",
+        "esbuild": "^0.27.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -4603,13 +4321,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -4657,24 +4378,6 @@
         "vite": ">=2.9.0"
       }
     },
-    "node_modules/vite/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/vite/node_modules/picomatch": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
@@ -4689,17 +4392,17 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.5.28",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.28.tgz",
-      "integrity": "sha512-BRdrNfeoccSoIZeIhyPBfvWSLFP4q8J3u8Ju8Ug5vu3LdD+yTM13Sg4sKtljxozbnuMu1NB1X5HBHRYUzFocKg==",
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.30.tgz",
+      "integrity": "sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.5.28",
-        "@vue/compiler-sfc": "3.5.28",
-        "@vue/runtime-dom": "3.5.28",
-        "@vue/server-renderer": "3.5.28",
-        "@vue/shared": "3.5.28"
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/compiler-sfc": "3.5.30",
+        "@vue/runtime-dom": "3.5.30",
+        "@vue/server-renderer": "3.5.30",
+        "@vue/shared": "3.5.30"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -17,7 +17,7 @@
         "laravel-echo": "^1.15.3",
         "ora": "^8.2.0",
         "pusher-js": "^8.4.0-rc2",
-        "unplugin-vue-components": "^28.5.0"
+        "unplugin-vue-components": "28.5.0"
       },
       "engines": {
         "node": ">= 8.9.0",
@@ -4474,18 +4474,18 @@
       }
     },
     "node_modules/unplugin-vue-components": {
-      "version": "28.8.0",
-      "resolved": "https://registry.npmjs.org/unplugin-vue-components/-/unplugin-vue-components-28.8.0.tgz",
-      "integrity": "sha512-2Q6ZongpoQzuXDK0ZsVzMoshH0MWZQ1pzVL538G7oIDKRTVzHjppBDS8aB99SADGHN3lpGU7frraCG6yWNoL5Q==",
+      "version": "28.5.0",
+      "resolved": "https://registry.npmjs.org/unplugin-vue-components/-/unplugin-vue-components-28.5.0.tgz",
+      "integrity": "sha512-o7fMKU/uI8NiP+E0W62zoduuguWqB0obTfHFtbr1AP2uo2lhUPnPttWUE92yesdiYfo9/0hxIrj38FMc1eaySg==",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.6.0",
-        "debug": "^4.4.1",
+        "debug": "^4.4.0",
         "local-pkg": "^1.1.1",
         "magic-string": "^0.30.17",
         "mlly": "^1.7.4",
-        "tinyglobby": "^0.2.14",
-        "unplugin": "^2.3.5",
+        "tinyglobby": "^0.2.12",
+        "unplugin": "^2.3.2",
         "unplugin-utils": "^0.2.4"
       },
       "engines": {
@@ -4496,7 +4496,7 @@
       },
       "peerDependencies": {
         "@babel/parser": "^7.15.8",
-        "@nuxt/kit": "^3.2.2 || ^4.0.0",
+        "@nuxt/kit": "^3.2.2",
         "vue": "2 || 3"
       },
       "peerDependenciesMeta": {

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
-  "version": "3.20.0-beta.14-alpha.3",
+  "version": "3.20.0-beta.14-alpha.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-app-extension-asteroid",
-      "version": "3.20.0-beta.14-alpha.3",
+      "version": "3.20.0-beta.14-alpha.4",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/quasar-app-extension-asteroid": "file:",
-        "@bildvitta/quasar-ui-asteroid": "file:../ui",
+        "@bildvitta/quasar-ui-asteroid": "3.20.0-beta.14-alpha.4",
         "@bildvitta/store-adapter": "^1.0.0",
         "execa": "^7.1.1",
         "fontfaceobserver": "^2.3.0",
@@ -32,7 +32,7 @@
     },
     "../ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.20.0-beta.14-alpha.3",
+      "version": "3.20.0-beta.14-alpha.4",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -9,7 +9,8 @@
       "version": "3.20.0-beta.14-alpha.3",
       "license": "MIT",
       "dependencies": {
-        "@bildvitta/quasar-ui-asteroid": "3.20.0-beta.14-alpha.3",
+        "@bildvitta/quasar-app-extension-asteroid": "file:",
+        "@bildvitta/quasar-ui-asteroid": "file:../ui",
         "@bildvitta/store-adapter": "^1.0.0",
         "execa": "^7.1.1",
         "fontfaceobserver": "^2.3.0",
@@ -29,78 +30,9 @@
         "quasar": "^2.18.0"
       }
     },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.0"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@bildvitta/composables": {
-      "version": "1.0.0-beta.12",
-      "resolved": "https://registry.npmjs.org/@bildvitta/composables/-/composables-1.0.0-beta.12.tgz",
-      "integrity": "sha512-pOCq3bDooOLOR5tPQybtpDkEDVQ302swBY3cLtjnITtYTVj0oSQ9QL4/JkaklB8L4RvCrBbkbtLKvZFVDoa4eg==",
-      "dependencies": {
-        "@vue/compiler-sfc": "^3.4.21",
-        "path": "^0.12.7",
-        "vue-demi": "^0.14.7"
-      },
-      "peerDependencies": {
-        "vue": "^3.0.0"
-      }
-    },
-    "node_modules/@bildvitta/quasar-ui-asteroid": {
+    "../ui": {
+      "name": "@bildvitta/quasar-ui-asteroid",
       "version": "3.20.0-beta.14-alpha.3",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.20.0-beta.14-alpha.3.tgz",
-      "integrity": "sha512-NR07AAbY15i+VjzTfZkRpFIFgNs3CpxP49sTtCY3sA2Gry/x3Fjjemt5oWEBcfRLt4VjLABYYjUII1hb0MZX7A==",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",
@@ -116,7 +48,22 @@
         "pdfjs-dist": "4.3.136",
         "pica": "^9.0.1",
         "signature_pad": "^4.1.5",
-        "sortablejs": "^1.15.3"
+        "sortablejs": "1.15.7"
+      },
+      "devDependencies": {
+        "@rollup/plugin-json": "^6.0.0",
+        "@rollup/plugin-replace": "^5.0.2",
+        "@rollup/plugin-url": "^8.0.1",
+        "@vue/compiler-sfc": "^3.3.4",
+        "autoprefixer": "^10.4.14",
+        "core-js": "^3.30.2",
+        "postcss": "^8.4.24",
+        "rimraf": "^5.0.1",
+        "rollup": "^3.23.1",
+        "rollup-plugin-local-resolve": "^1.0.7",
+        "rollup-plugin-scss": "^4.0.0",
+        "rollup-plugin-vue": "^6.0.0",
+        "sass": "^1.62.1"
       },
       "peerDependencies": {
         "@fawmi/vue-google-maps": "0.9.79",
@@ -128,6 +75,64 @@
         "vue-chartjs": "^5.2.0",
         "vue-router": "^4.3.2"
       }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bildvitta/quasar-app-extension-asteroid": {
+      "resolved": "",
+      "link": true
+    },
+    "node_modules/@bildvitta/quasar-ui-asteroid": {
+      "resolved": "../ui",
+      "link": true
     },
     "node_modules/@bildvitta/store-adapter": {
       "version": "1.0.0",
@@ -181,31 +186,6 @@
       "dependencies": {
         "@googlemaps/markerclusterer": "^2.0.3"
       }
-    },
-    "node_modules/@floating-ui/core": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/core": "^1.7.5",
-        "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
-      "license": "MIT"
     },
     "node_modules/@googlemaps/markerclusterer": {
       "version": "2.6.2",
@@ -262,34 +242,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@kurkle/color": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
-      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@mapbox/node-pre-gyp": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
-      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "make-dir": "^3.1.0",
-        "node-fetch": "^2.6.7",
-        "nopt": "^5.0.0",
-        "npmlog": "^5.0.1",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.11"
-      },
-      "bin": {
-        "node-pre-gyp": "bin/node-pre-gyp"
       }
     },
     "node_modules/@microsoft/api-extractor": {
@@ -558,17 +510,6 @@
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "node_modules/@quasar/extras": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@quasar/extras/-/extras-1.17.0.tgz",
-      "integrity": "sha512-KqAHdSJfIDauiR1nJ8rqHWT0diqD0QradZKoVIZJAilHAvgwyPIY7MbyR2z4RIMkUIMUSqBZcbshMpEw+9A30w==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://donate.quasar.dev"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -867,29 +808,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/@rrweb/record": {
-      "version": "2.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@rrweb/record/-/record-2.0.0-alpha.20.tgz",
-      "integrity": "sha512-marVOU3Lc285mwLCp+vI6M/eJ+wZ6lcTa7fX0zcdmBsM+j5loXmMQjkmIvkji5+lAbkq5/w2cwto3GS0TaCjtg==",
-      "license": "MIT",
-      "dependencies": {
-        "@rrweb/types": "^2.0.0-alpha.20",
-        "@rrweb/utils": "^2.0.0-alpha.20",
-        "rrweb": "^2.0.0-alpha.20"
-      }
-    },
-    "node_modules/@rrweb/types": {
-      "version": "2.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.0-alpha.20.tgz",
-      "integrity": "sha512-RbnDgKxA/odwB1R4gF7eUUj+rdSrq6ROQJsnMw7MIsGzlbSYvJeZN8YY4XqU0G6sKJvXI6bSzk7w/G94jNwzhw==",
-      "license": "MIT"
-    },
-    "node_modules/@rrweb/utils": {
-      "version": "2.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@rrweb/utils/-/utils-2.0.0-alpha.20.tgz",
-      "integrity": "sha512-MTQOmhPRe39C0fYaCnnVYOufQsyGzwNXpUStKiyFSfGLUJrzuwhbRoUAKR5w6W2j5XuA0bIz3ZDIBztkquOhLw==",
-      "license": "MIT"
-    },
     "node_modules/@rushstack/node-core-library": {
       "version": "3.66.1",
       "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.66.1.tgz",
@@ -1118,12 +1036,6 @@
       "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
       "license": "MIT"
     },
-    "node_modules/@types/css-font-loading-module": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
-      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1134,13 +1046,6 @@
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/hammerjs": {
-      "version": "2.0.46",
-      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
-      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
       "license": "MIT",
       "peer": true
     },
@@ -1159,6 +1064,7 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.30.tgz",
       "integrity": "sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.29.0",
         "@vue/shared": "3.5.30",
@@ -1172,6 +1078,7 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.30.tgz",
       "integrity": "sha512-eCFYESUEVYHhiMuK4SQTldO3RYxyMR/UQL4KdGD1Yrkfdx4m/HYuZ9jSfPdA+nWJY34VWndiYdW/wZXyiPEB9g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-core": "3.5.30",
         "@vue/shared": "3.5.30"
@@ -1182,6 +1089,7 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.30.tgz",
       "integrity": "sha512-LqmFPDn89dtU9vI3wHJnwaV6GfTRD87AjWpTWpyrdVOObVtjIuSeZr181z5C4PmVx/V3j2p+0f7edFKGRMpQ5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.29.0",
         "@vue/compiler-core": "3.5.30",
@@ -1199,17 +1107,11 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.30.tgz",
       "integrity": "sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.30",
         "@vue/shared": "3.5.30"
       }
-    },
-    "node_modules/@vue/devtools-api": {
-      "version": "6.6.4",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
-      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@vue/reactivity": {
       "version": "3.5.30",
@@ -1263,20 +1165,8 @@
       "version": "3.5.30",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
       "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==",
-      "license": "MIT"
-    },
-    "node_modules/@xstate/fsm": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
-      "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==",
-      "license": "MIT"
-    },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "license": "ISC",
-      "optional": true
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -1288,19 +1178,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -1375,28 +1252,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/aproba": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
-      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1406,47 +1261,11 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/autonumeric": {
-      "version": "4.10.9",
-      "resolved": "https://registry.npmjs.org/autonumeric/-/autonumeric-4.10.9.tgz",
-      "integrity": "sha512-7aStLD5zn0x8mUDvYsl7YY11xzI6NgOK8u40UB6SvdoqItfzfOz6sfVZv4CyADy2nlbM0zHJ992SXGVVJEzCGA==",
-      "license": "MIT",
-      "funding": {
-        "type": "patreon",
-        "url": "https://www.patreon.com/AlexandreBonneau"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
-    },
-    "node_modules/base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -1458,17 +1277,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
@@ -1483,35 +1291,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/canvas": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
-      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.0",
-        "nan": "^2.17.0",
-        "simple-get": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -1522,43 +1301,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chart.js": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
-      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@kurkle/color": "^0.3.0"
-      },
-      "engines": {
-        "pnpm": ">=8"
-      }
-    },
-    "node_modules/chartjs-plugin-datalabels": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz",
-      "integrity": "sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "chart.js": ">=3.0.0"
-      }
-    },
-    "node_modules/chartjs-plugin-zoom": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/chartjs-plugin-zoom/-/chartjs-plugin-zoom-2.2.0.tgz",
-      "integrity": "sha512-in6kcdiTlP6npIVLMd4zXZ08PDUXC52gZ4FAy5oyjk1zX3gKarXMAof7B9eFiisf9WOC3bh2saHg+J5WtLXZeA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/hammerjs": "^2.0.45",
-        "hammerjs": "^2.0.8"
-      },
-      "peerDependencies": {
-        "chart.js": ">=3.2.0"
       }
     },
     "node_modules/chokidar": {
@@ -1583,16 +1325,6 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/cli-cursor": {
@@ -1628,16 +1360,6 @@
       "integrity": "sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw==",
       "license": "MIT"
     },
-    "node_modules/color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
     "node_modules/colors": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
@@ -1645,18 +1367,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
-      }
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/commander": {
@@ -1669,25 +1379,11 @@
         "node": "^12.20.0 || >=14"
       }
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/confbox": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "license": "MIT"
-    },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1710,22 +1406,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1743,40 +1423,12 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "mimic-response": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1790,20 +1442,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
@@ -1815,56 +1453,12 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
       "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/estree-walker": {
@@ -1971,47 +1565,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/fontfaceobserver": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.3.0.tgz",
       "integrity": "sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg==",
       "license": "BSD-2-Clause"
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
@@ -2026,39 +1584,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2083,82 +1608,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/fuse.js": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
-      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gauge": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
-      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.2",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.1",
-        "object-assign": "^4.1.1",
-        "signal-exit": "^3.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gauge/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/gauge/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/gauge/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/gauge/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/get-east-asian-width": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
@@ -2169,43 +1618,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -2220,39 +1632,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/gleap": {
-      "version": "14.8.14",
-      "resolved": "https://registry.npmjs.org/gleap/-/gleap-14.8.14.tgz",
-      "integrity": "sha512-dZByS3taimPaGGqTgFDClxiy25RYeZkJbSuob/kONIiXif3zl7/msq9RufPpYDZuEiwFE2U6lRTKgVUoQll94w==",
-      "license": "Commercial",
-      "dependencies": {
-        "@floating-ui/dom": "^1.6.3",
-        "@rrweb/record": "^2.0.0-alpha.18",
-        "unique-selector": "^0.5.0"
-      }
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -2265,39 +1644,11 @@
         "node": ">= 6"
       }
     },
-    "node_modules/glur": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/glur/-/glur-1.1.2.tgz",
-      "integrity": "sha512-l+8esYHTKOx2G/Aao4lEQ0bnHWg4fWtJbVoZZT9Knxi01pB8C80BR85nONLFwkkQoFRCmXY+BUcGZN3yZ2QsRA==",
-      "license": "MIT"
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
-    },
-    "node_modules/hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -2307,40 +1658,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/hasown": {
       "version": "2.0.2",
@@ -2352,20 +1669,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {
@@ -2391,25 +1694,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -2445,16 +1729,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -2850,12 +2124,6 @@
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
-      "license": "MIT"
-    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -2919,41 +2187,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -2982,27 +2215,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -3026,75 +2238,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/mimic-response": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "license": "MIT"
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -3143,23 +2286,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/multimath": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/multimath/-/multimath-2.0.0.tgz",
-      "integrity": "sha512-toRx66cAMJ+Ccz7pMIg38xSIrtnbozk0dchXezwQDMgQmbGpfxjtv68H+L00iFL8hxDaVjrmwAFSb3I6bg8Q2g==",
-      "license": "MIT",
-      "dependencies": {
-        "glur": "^1.1.2",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "node_modules/nan": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.25.0.tgz",
-      "integrity": "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -3171,48 +2297,12 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/nopt": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/normalize-path": {
@@ -3249,39 +2339,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npmlog": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
-      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "are-we-there-yet": "^2.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^3.0.0",
-        "set-blocking": "^2.0.0"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -3322,31 +2379,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/path": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
-      "license": "MIT",
-      "dependencies": {
-        "process": "^0.11.1",
-        "util": "^0.10.3"
-      }
-    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "license": "MIT"
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -3363,52 +2400,18 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
-    "node_modules/path2d": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/path2d/-/path2d-0.2.2.tgz",
-      "integrity": "sha512-+vnG6S4dYcYxZd+CZxzXCNKdELYZSKfohrk98yajCo1PtRoDgCTrrwOvK1GT0UoAdVszagDVllQc0U1vaX4NUQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
     },
-    "node_modules/pdfjs-dist": {
-      "version": "4.3.136",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.3.136.tgz",
-      "integrity": "sha512-gzfnt1qc4yA+U46golPGYtU4WM2ssqP2MvFjKga8GEKOrEnzRPrA/9jogLLPYHiA3sGBPJ+p7BdAq+ytmw3jEg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "canvas": "^2.11.2",
-        "path2d": "^0.2.0"
-      }
-    },
-    "node_modules/pica": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/pica/-/pica-9.0.1.tgz",
-      "integrity": "sha512-v0U4vY6Z3ztz9b4jBIhCD3WYoecGXCQeCsYep+sXRefViL+mVVoTL+wqzdPeE+GpBFsRUtQZb6dltvAt2UkMtQ==",
-      "license": "MIT",
-      "dependencies": {
-        "glur": "^1.1.2",
-        "multimath": "^2.0.0",
-        "object-assign": "^4.1.1",
-        "webworkify": "^1.5.0"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -3452,6 +2455,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3460,21 +2464,6 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
-    },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
     },
     "node_modules/pusher-js": {
       "version": "8.4.0",
@@ -3536,21 +2525,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -3646,23 +2620,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.9",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
@@ -3697,40 +2654,6 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9"
       }
     },
-    "node_modules/rrdom": {
-      "version": "2.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.0.0-alpha.20.tgz",
-      "integrity": "sha512-hoqjS4662LtBp82qEz9GrqU36UpEmCvTA2Hns3qdF7cklLFFy3G+0Th8hLytJENleHHWxsB5nWJ3eXz5mSRxdQ==",
-      "license": "MIT",
-      "dependencies": {
-        "rrweb-snapshot": "^2.0.0-alpha.20"
-      }
-    },
-    "node_modules/rrweb": {
-      "version": "2.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.0.0-alpha.20.tgz",
-      "integrity": "sha512-CZKDlm+j1VA50Ko3gnMbpvguCAleljsTNXPnVk9aeNP8o6T6kolRbISHyDZpqZ4G+bdDLlQOignPP3jEsXs8Gg==",
-      "license": "MIT",
-      "dependencies": {
-        "@rrweb/types": "^2.0.0-alpha.20",
-        "@rrweb/utils": "^2.0.0-alpha.20",
-        "@types/css-font-loading-module": "0.0.7",
-        "@xstate/fsm": "^1.4.0",
-        "base64-arraybuffer": "^1.0.1",
-        "mitt": "^3.0.0",
-        "rrdom": "^2.0.0-alpha.20",
-        "rrweb-snapshot": "^2.0.0-alpha.20"
-      }
-    },
-    "node_modules/rrweb-snapshot": {
-      "version": "2.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.20.tgz",
-      "integrity": "sha512-YTNf9YVeaGRo/jxY3FKBge2c/Ojd/KTHmuWloUSB+oyPXuY73ZeeG873qMMmhIpqEn7hn7aBF1eWEQmP7wjf8A==",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^8.4.38"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3753,47 +2676,6 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3822,51 +2704,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
-    "node_modules/signature_pad": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-4.2.0.tgz",
-      "integrity": "sha512-YLWysmaUBaC5wosAKkgbX7XI+LBv2w5L0QUcI6Jc4moHYzv9BUBJtAyNLpWzHjtjKTeWOH6bfP4a4pzf0UinfQ==",
-      "license": "MIT"
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/simple-get": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
-      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "decompress-response": "^4.2.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
-    "node_modules/sortablejs": {
-      "version": "1.15.7",
-      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
-      "integrity": "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==",
-      "license": "MIT"
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3881,6 +2718,7 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3901,16 +2739,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-argv": {
@@ -4015,25 +2843,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4091,13 +2900,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/ts-morph": {
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-17.0.1.tgz",
@@ -4139,12 +2941,6 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
-      "license": "MIT"
-    },
-    "node_modules/unique-selector": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/unique-selector/-/unique-selector-0.5.0.tgz",
-      "integrity": "sha512-2KCiRgM19ol67lO493tF7mnQPDuYzwRM7JXrVx336+BPXqT2ccCbUOQQpErFbSc8VIdifLf5x34x4lIeebk+YA==",
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -4245,28 +3041,6 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
-    },
-    "node_modules/util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "2.0.3"
-      }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/util/node_modules/inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-      "license": "ISC"
     },
     "node_modules/validator": {
       "version": "13.15.26",
@@ -4413,88 +3187,11 @@
         }
       }
     },
-    "node_modules/vue-chartjs": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-5.3.3.tgz",
-      "integrity": "sha512-jqxtL8KZ6YJ5NTv6XzrzLS7osyegOi28UGNZW0h9OkDL7Sh1396ht4Dorh04aKrl2LiSalQ84WtqiG0RIJb0tA==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "chart.js": "^4.1.1",
-        "vue": "^3.0.0-0 || ^2.7.0"
-      }
-    },
-    "node_modules/vue-demi": {
-      "version": "0.14.10",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vue-router": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
-      "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@vue/devtools-api": "^6.6.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/posva"
-      },
-      "peerDependencies": {
-        "vue": "^3.5.0"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "optional": true
-    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "license": "MIT"
-    },
-    "node_modules/webworkify": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/webworkify/-/webworkify-1.5.0.tgz",
-      "integrity": "sha512-AMcUeyXAhbACL8S2hqqdqOLqvJ8ylmIbNwUIqQujRSouf4+eUFaXbG6F1Rbu+srlJMmxQWsiU7mOJi0nMBfM1g==",
-      "license": "MIT"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -4510,68 +3207,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
-    "node_modules/wide-align/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wide-align/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/wide-align/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wide-align/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
-  "version": "3.20.0-beta.13",
+  "version": "3.20.0-beta.14-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-app-extension-asteroid",
-      "version": "3.20.0-beta.13",
+      "version": "3.20.0-beta.14-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@bildvitta/quasar-ui-asteroid": "3.20.0-beta.13",
+        "@bildvitta/quasar-ui-asteroid": "3.20.0-beta.14-alpha.2",
         "@bildvitta/store-adapter": "^1.0.0",
         "execa": "^7.1.1",
         "fontfaceobserver": "^2.3.0",
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@bildvitta/quasar-ui-asteroid": {
-      "version": "3.20.0-beta.13",
-      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.20.0-beta.13.tgz",
-      "integrity": "sha512-hNcDrHyXZEMzDFO37iL1h+U6jPOVfc/346NVJwcreqnp7M1ReM4gt+s+RdnUIB8GKVVpRLb7Qt22WUZCBzF90w==",
+      "version": "3.20.0-beta.14-alpha.2",
+      "resolved": "https://registry.npmjs.org/@bildvitta/quasar-ui-asteroid/-/quasar-ui-asteroid-3.20.0-beta.14-alpha.2.tgz",
+      "integrity": "sha512-UCdALIujHV8IzveJCdW3B5w86JjvbEhjgR0EWscm91D+0Xt7oNqMIsgqNzI1/ejz68AzsPwnPQ7Xp4JhO6rdjA==",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -42,6 +42,6 @@
     "laravel-echo": "^1.15.3",
     "ora": "^8.2.0",
     "pusher-js": "^8.4.0-rc2",
-    "unplugin-vue-components": "^28.5.0"
+    "unplugin-vue-components": "28.5.0"
   }
 }

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
   "description": "Asteroid",
-  "version": "3.20.0-beta.14-alpha.2",
+  "version": "3.20.0-beta.14-alpha.3",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "src/index.js",
@@ -34,7 +34,7 @@
     "quasar": "^2.18.0"
   },
   "dependencies": {
-    "@bildvitta/quasar-ui-asteroid": "3.20.0-beta.14-alpha.2",
+    "@bildvitta/quasar-ui-asteroid": "3.20.0-beta.14-alpha.3",
     "@bildvitta/store-adapter": "^1.0.0",
     "execa": "^7.1.1",
     "fontfaceobserver": "^2.3.0",

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -34,7 +34,8 @@
     "quasar": "^2.18.0"
   },
   "dependencies": {
-    "@bildvitta/quasar-ui-asteroid": "3.20.0-beta.14-alpha.3",
+    "@bildvitta/quasar-app-extension-asteroid": "file:",
+    "@bildvitta/quasar-ui-asteroid": "file:../ui",
     "@bildvitta/store-adapter": "^1.0.0",
     "execa": "^7.1.1",
     "fontfaceobserver": "^2.3.0",

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
   "description": "Asteroid",
-  "version": "3.20.0-beta.13",
+  "version": "3.20.0-beta.14-alpha.2",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "src/index.js",
@@ -34,7 +34,7 @@
     "quasar": "^2.18.0"
   },
   "dependencies": {
-    "@bildvitta/quasar-ui-asteroid": "3.20.0-beta.13",
+    "@bildvitta/quasar-ui-asteroid": "3.20.0-beta.14-alpha.2",
     "@bildvitta/store-adapter": "^1.0.0",
     "execa": "^7.1.1",
     "fontfaceobserver": "^2.3.0",

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-app-extension-asteroid",
   "description": "Asteroid",
-  "version": "3.20.0-beta.14-alpha.3",
+  "version": "3.20.0-beta.14-alpha.4",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "src/index.js",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@bildvitta/quasar-app-extension-asteroid": "file:",
-    "@bildvitta/quasar-ui-asteroid": "file:../ui",
+    "@bildvitta/quasar-ui-asteroid": "3.20.0-beta.14-alpha.4",
     "@bildvitta/store-adapter": "^1.0.0",
     "execa": "^7.1.1",
     "fontfaceobserver": "^2.3.0",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid-docs",
-  "version": "3.20.0-beta.13",
+  "version": "3.20.0-beta.14-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid-docs",
-      "version": "3.20.0-beta.13",
+      "version": "3.20.0-beta.14-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-js": "^1.9.2",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid-docs",
-  "version": "3.20.0-beta.14-alpha.2",
+  "version": "3.20.0-beta.14-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid-docs",
-      "version": "3.20.0-beta.14-alpha.2",
+      "version": "3.20.0-beta.14-alpha.3",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-js": "^1.9.2",
@@ -50,7 +50,7 @@
     },
     "../ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.20.0-beta.13",
+      "version": "3.20.0-beta.14-alpha.3",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid-docs",
-  "version": "3.20.0-beta.14-alpha.3",
+  "version": "3.20.0-beta.14-alpha.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid-docs",
-      "version": "3.20.0-beta.14-alpha.3",
+      "version": "3.20.0-beta.14-alpha.4",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-js": "^1.9.2",
@@ -66,7 +66,7 @@
         "pdfjs-dist": "4.3.136",
         "pica": "^9.0.1",
         "signature_pad": "^4.1.5",
-        "sortablejs": "^1.15.3"
+        "sortablejs": "1.15.7"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^6.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid-docs",
   "description": "Asteroid",
-  "version": "3.20.0-beta.14-alpha.3",
+  "version": "3.20.0-beta.14-alpha.4",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "productName": "Asteroid Docs",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid-docs",
   "description": "Asteroid",
-  "version": "3.20.0-beta.14-alpha.2",
+  "version": "3.20.0-beta.14-alpha.3",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "productName": "Asteroid Docs",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid-docs",
   "description": "Asteroid",
-  "version": "3.20.0-beta.13",
+  "version": "3.20.0-beta.14-alpha.2",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "productName": "Asteroid Docs",

--- a/docs/src/examples/QasActionsMenu/ExMagicAi.vue
+++ b/docs/src/examples/QasActionsMenu/ExMagicAi.vue
@@ -1,10 +1,12 @@
 <template>
   <div class="container q-py-lg">
-    <qas-actions-menu v-bind="props" />
+    <qas-actions-menu :list />
   </div>
 </template>
 
 <script setup>
+defineOptions({ name: 'ExMagicAi' })
+
 const list = {
   magicAi: {
     icon: 'sym_r_wand_stars',
@@ -22,10 +24,5 @@ const list = {
     label: 'Visualizar',
     handler: () => alert('handler ativado')
   }
-}
-
-const props = {
-  list
-  // splitName: 'magicAi'
 }
 </script>

--- a/docs/src/examples/QasActionsMenu/ExMagicAi.vue
+++ b/docs/src/examples/QasActionsMenu/ExMagicAi.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="container q-py-lg">
+    <qas-actions-menu v-bind="props" />
+  </div>
+</template>
+
+<script setup>
+const list = {
+  magicAi: {
+    icon: 'sym_r_wand_stars',
+    label: 'Gerar texto',
+    handler: () => alert('handler ativado'),
+    useMagicAiColor: true
+  },
+  edit: {
+    icon: 'sym_r_create',
+    label: 'Editar',
+    handler: () => alert('handler ativado')
+  },
+  visibility: {
+    icon: 'sym_r_visibility',
+    label: 'Visualizar',
+    handler: () => alert('handler ativado')
+  }
+}
+
+const props = {
+  list
+  // splitName: 'magicAi'
+}
+</script>

--- a/docs/src/examples/QasBtn/ExBtnMagicAi.vue
+++ b/docs/src/examples/QasBtn/ExBtnMagicAi.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="q-gutter-y-md q-pa-md">
+    <qas-label label="Primary" typography="h5" />
+
+    <div class="q-gutter-sm">
+      <qas-btn icon="sym_r_wand_stars" label="Magic AI" use-magic-ai-color variant="primary" />
+
+      <qas-btn icon="sym_r_wand_stars" label="Magic AI sm" size="sm" use-magic-ai-color variant="primary" />
+
+      <qas-btn disable icon="sym_r_wand_stars" label="Desabilitado" use-magic-ai-color variant="primary" />
+    </div>
+
+    <qas-label label="Secondary" typography="h5" />
+
+    <div class="q-gutter-sm">
+      <qas-btn icon="sym_r_wand_stars" label="Magic AI" use-magic-ai-color variant="secondary" />
+
+      <qas-btn icon="sym_r_wand_stars" label="Magic AI sm" size="sm" use-magic-ai-color variant="secondary" />
+
+      <qas-btn disable icon="sym_r_wand_stars" label="Desabilitado" use-magic-ai-color variant="secondary" />
+    </div>
+
+    <qas-label label="Tertiary" typography="h5" />
+
+    <div class="q-gutter-sm">
+      <qas-btn icon="sym_r_wand_stars" label="Magic AI" use-magic-ai-color variant="tertiary" />
+
+      <qas-btn disable icon="sym_r_wand_stars" label="Desabilitado" use-magic-ai-color variant="tertiary" />
+
+      <qas-btn icon="sym_r_wand_stars" use-magic-ai-color variant="tertiary" />
+    </div>
+  </div>
+</template>

--- a/docs/src/pages/components/actions-menu.md
+++ b/docs/src/pages/components/actions-menu.md
@@ -36,6 +36,7 @@ Componente wrapper do `QasBtnDropdown` que implementa regras de negocio.
       icon: 'sym_r_visibility', // este ícone tem prioridade ao ícone passado através da prop "buttonProps".
       color: 'grey-10' // propriedade color sobrescreve a propriedade do componente `color` porém só é usada quando existe apenas um item na listagem
       disable: true, // desabilita o botão e quando ele esta dentro do dropdown (QItem).
+      useMagicAiColor: true, // aplica o estilo de cores de inteligência artificial (magic AI) no ícone e no texto do item dentro do dropdown. Quando o item se torna um botão externo (via splitName), as cores são aplicadas automaticamente ao QasBtn.
       props: {
         // Propriedades do q-item: https://quasar.dev/vue-components/list-and-list-items#api--qitem
       },
@@ -67,3 +68,10 @@ Componente wrapper do `QasBtnDropdown` que implementa regras de negocio.
 <doc-example file="QasActionsMenu/ExTooltip" title="Sem label com tooltip" />
 <doc-example file="QasActionsMenu/ExWithLoading" title="Com loading" />
 <doc-example file="QasActionsMenu/ExUseDropdownAlways" title="Sempre dropdown" />
+
+:::info
+#### Magic AI Color (`useMagicAiColor`)
+É possível aplicar o estilo de cores de inteligência artificial em um item da prop `list`, passando `useMagicAiColor: true` no objeto do item. O ícone e o texto do item dentro do dropdown receberão o gradiente de magic AI. Quando o item se torna um botão externo (em cenários com `splitName`), as cores de magic AI são aplicadas automaticamente ao `QasBtn` correspondente.
+:::
+
+<doc-example file="QasActionsMenu/ExMagicAi" title="Magic AI Color" />

--- a/docs/src/pages/components/board-generator.md
+++ b/docs/src/pages/components/board-generator.md
@@ -92,7 +92,6 @@ No payload será enviado o seguinte:
 O retorno do backend, deverá ser TODO o item atualizado em seu result, pois o componente irá pegar esse retorno para atualizar o model.
 
 #### Manipulação local de itens
-
 O `QasBoardGenerator` expõe métodos para manipular itens das colunas localmente, sem necessidade de novas requisições:
 
 - **`transferItemToColumn({ itemId, fromColumnId, toColumnId, updatedItem? })`**: Move um item de uma coluna para outra localmente. O item é inserido como primeiro elemento na coluna de destino. Passe `updatedItem` para sobrescrever os dados do item no destino.
@@ -102,5 +101,4 @@ O `QasBoardGenerator` expõe métodos para manipular itens das colunas localment
 - **`refetchColumns()`**: Alias de `fetchColumns`. Rebusca todas as colunas.
 
 #### Skeleton (carregamento)
-
-A prop `skeleton` (default `true`) controla o estado de carregamento do board. Enquanto `true`, cada coluna exibe cards fictícios (skeleton) no lugar dos itens reais. Assim que `fetchColumns` retorna com sucesso, o skeleton é substituído automaticamente pelos itens reais.
+A prop `skeleton` (default `false`) controla o estado de carregamento do board. Enquanto `true`, cada coluna exibe cards fictícios (skeleton) no lugar dos itens reais. Assim que `fetchColumns` retorna com sucesso, o skeleton é substituído automaticamente pelos itens reais.

--- a/docs/src/pages/components/board-generator.md
+++ b/docs/src/pages/components/board-generator.md
@@ -90,3 +90,17 @@ No payload será enviado o seguinte:
 ```
 
 O retorno do backend, deverá ser TODO o item atualizado em seu result, pois o componente irá pegar esse retorno para atualizar o model.
+
+#### Manipulação local de itens
+
+O `QasBoardGenerator` expõe métodos para manipular itens das colunas localmente, sem necessidade de novas requisições:
+
+- **`transferItemToColumn({ itemId, fromColumnId, toColumnId, updatedItem? })`**: Move um item de uma coluna para outra localmente. O item é inserido como primeiro elemento na coluna de destino. Passe `updatedItem` para sobrescrever os dados do item no destino.
+- **`removeItemFromList({ headerKey, itemId })`**: Remove um item de uma coluna localmente, ajustando o contador de paginação automaticamente.
+- **`updateItemInList({ headerKey, itemId, updatedItem })`**: Substitui os dados de um item existente em uma coluna localmente.
+- **`refreshColumn(header)`**: Reinicia a paginação e refaz a busca de uma coluna específica.
+- **`refetchColumns()`**: Alias de `fetchColumns`. Rebusca todas as colunas.
+
+#### Skeleton (carregamento)
+
+A prop `skeleton` (default `true`) controla o estado de carregamento do board. Enquanto `true`, cada coluna exibe cards fictícios (skeleton) no lugar dos itens reais. Assim que `fetchColumns` retorna com sucesso, o skeleton é substituído automaticamente pelos itens reais.

--- a/docs/src/pages/components/button.md
+++ b/docs/src/pages/components/button.md
@@ -144,3 +144,16 @@ Boas práticas:
 - Documente no pai quando estiver alterando os defaults (ex.: comentário `@see QasBtn.vue`) para facilitar manutenção.
 :::
 <doc-example file="QasBtn/ExWithInputDefault" title="Propriedades padrões dentro do QasInput" />
+
+:::info
+#### Magic AI Color (`use-magic-ai-color`)
+A prop `useMagicAiColor` aplica um gradiente de inteligência artificial ao botão. O comportamento visual varia conforme a variante:
+
+- **primary**: o gradiente substitui a cor de fundo do botão. O texto permanece branco.
+- **secondary**: o gradiente é aplicado como cor de texto e borda.
+- **tertiary**: o gradiente é aplicado apenas na cor do texto.
+
+Em todas as variantes, o hover utiliza a cor `$secondary-contrast`.
+:::
+
+<doc-example file="QasBtn/ExBtnMagicAi" title="Magic AI Color" />

--- a/docs/src/pages/styles/background.md
+++ b/docs/src/pages/styles/background.md
@@ -20,3 +20,8 @@ A propriedade background-position define a posição inicial de uma imagem de fu
 |`bg-position-left`  | Posiciona a imagem de fundo na parte esquerda do container |`background-position: left`  |
 |`bg-position-right` | Posiciona a imagem de fundo na parte direita do container  |`background-position: right` |
 |`bg-position-top`   | Posiciona a imagem de fundo na parte superior do container |`background-position: top`   |
+### Colors
+
+| **Nome da Classe** |                      **Descrição**                     |           **Adiciona**           |
+|--------------------|--------------------------------------------------------|----------------------------------|
+|`bg-magic-ai`       | Aplica o gradiente de magic AI como cor de fundo       |`background: linear-gradient(90deg, #0F54AE 0%, #C51162 100%)`|

--- a/docs/src/pages/styles/border.md
+++ b/docs/src/pages/styles/border.md
@@ -22,3 +22,4 @@ Define uma cor para a borda de acordo com as variáveis `$primary` `$secondary`
 |`border-secondary-contrast`| Cria uma Borda com a cor da variável `$secondary-contrast` |`border: 1px solid $secondary-contrast`|
 |`border-grey`              | Cria uma Borda com a cor da variável `$border-grey`        |`border: 1px solid $border-grey`       |
 |`bordered`                 | Cria uma Borda com a cor da variável `$border-grey` e arredondada        |`border: 1px solid $border-grey` `border-radius: $generic-border-radius`   |
+|`border-magic-ai`          | Cria uma borda com o gradiente de magic AI (nota: `border-image` não suporta `border-radius`) |`border: 1px solid; border-image: linear-gradient(90deg, #0F54AE 0%, #C51162 100%) 1`|

--- a/docs/src/pages/styles/typography.md
+++ b/docs/src/pages/styles/typography.md
@@ -77,3 +77,9 @@ title: Tipografia
 |`text-break`        | Quebras de linha podem ser inseridas entre quaisquer caracteres de texto |`word-break: break-all`     |
 |`text-underline`    | Decora o texto com um traçado na base                                    |`text-decoration: underline`|
 |`text-no-decoration`| Remove toda decoração existente no texto                                 |`text-decoration: none`     |
+
+## Colors
+
+| **Nome da Classe** |                             **Descrição**                       |           **Adiciona**           |
+|--------------------|-----------------------------------------------------------------|----------------------------------|
+|`text-magic-ai`     | Aplica o gradiente de magic AI como cor de texto                |`background: linear-gradient(90deg, #0F54AE 0%, #C51162 100%); background-clip: text; -webkit-text-fill-color: transparent`|

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid",
-  "version": "3.20.0-beta.13",
+  "version": "3.20.0-beta.14-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid",
-      "version": "3.20.0-beta.13",
+      "version": "3.20.0-beta.14-alpha.2",
       "license": "MIT",
       "devDependencies": {
         "@bildvitta/quasar-ui-asteroid": "file:ui",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid",
-  "version": "3.20.0-beta.14-alpha.3",
+  "version": "3.20.0-beta.14-alpha.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid",
-      "version": "3.20.0-beta.14-alpha.3",
+      "version": "3.20.0-beta.14-alpha.4",
       "license": "MIT",
       "devDependencies": {
         "@bildvitta/quasar-ui-asteroid": "file:ui",
@@ -5378,10 +5378,11 @@
       }
     },
     "node_modules/sortablejs": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.3.tgz",
-      "integrity": "sha512-zdK3/kwwAK1cJgy1rwl1YtNTbRmc8qW/+vgXf75A7NHag5of4pyI6uK86ktmQETyWRH7IGaE73uZOOBcGxgqZg==",
-      "dev": true
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
+      "integrity": "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.0",
@@ -6414,7 +6415,7 @@
         "pdfjs-dist": "4.3.136",
         "pica": "^9.0.1",
         "signature_pad": "^4.1.5",
-        "sortablejs": "^1.15.3"
+        "sortablejs": "1.15.7"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^6.0.0",
@@ -8459,7 +8460,7 @@
         "rollup-plugin-vue": "^6.0.0",
         "sass": "^1.62.1",
         "signature_pad": "^4.1.5",
-        "sortablejs": "^1.15.3"
+        "sortablejs": "1.15.7"
       },
       "dependencies": {
         "@babel/runtime": {
@@ -12788,9 +12789,9 @@
       }
     },
     "sortablejs": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.3.tgz",
-      "integrity": "sha512-zdK3/kwwAK1cJgy1rwl1YtNTbRmc8qW/+vgXf75A7NHag5of4pyI6uK86ktmQETyWRH7IGaE73uZOOBcGxgqZg==",
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
+      "integrity": "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==",
       "dev": true
     },
     "source-map-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/asteroid",
-  "version": "3.20.0-beta.14-alpha.2",
+  "version": "3.20.0-beta.14-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/asteroid",
-      "version": "3.20.0-beta.14-alpha.2",
+      "version": "3.20.0-beta.14-alpha.3",
       "license": "MIT",
       "devDependencies": {
         "@bildvitta/quasar-ui-asteroid": "file:ui",
@@ -6397,7 +6397,7 @@
     },
     "ui": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.20.0-beta.13",
+      "version": "3.20.0-beta.14-alpha.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid",
   "description": "Asteroid",
-  "version": "3.20.0-beta.13",
+  "version": "3.20.0-beta.14-alpha.2",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid",
   "description": "Asteroid",
-  "version": "3.20.0-beta.14-alpha.2",
+  "version": "3.20.0-beta.14-alpha.3",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/asteroid",
   "description": "Asteroid",
-  "version": "3.20.0-beta.14-alpha.3",
+  "version": "3.20.0-beta.14-alpha.4",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "scripts": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
-  "version": "3.20.0-beta.14-alpha.3",
+  "version": "3.20.0-beta.14-alpha.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.20.0-beta.14-alpha.3",
+      "version": "3.20.0-beta.14-alpha.4",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
-  "version": "3.20.0-beta.14-alpha.2",
+  "version": "3.20.0-beta.14-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.20.0-beta.14-alpha.2",
+      "version": "3.20.0-beta.14-alpha.3",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -22,7 +22,7 @@
         "pdfjs-dist": "4.3.136",
         "pica": "^9.0.1",
         "signature_pad": "^4.1.5",
-        "sortablejs": "^1.15.3"
+        "sortablejs": "1.15.7"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^6.0.0",
@@ -4246,9 +4246,9 @@
       }
     },
     "node_modules/sortablejs": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.6.tgz",
-      "integrity": "sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==",
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
+      "integrity": "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==",
       "license": "MIT"
     },
     "node_modules/source-map": {
@@ -7557,9 +7557,9 @@
       }
     },
     "sortablejs": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.6.tgz",
-      "integrity": "sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A=="
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
+      "integrity": "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A=="
     },
     "source-map": {
       "version": "0.6.1",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
-  "version": "3.20.0-beta.13",
+  "version": "3.20.0-beta.14-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bildvitta/quasar-ui-asteroid",
-      "version": "3.20.0-beta.13",
+      "version": "3.20.0-beta.14-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/ui/package.json
+++ b/ui/package.json
@@ -55,7 +55,7 @@
     "lodash-es": "^4.17.21",
     "pica": "^9.0.1",
     "signature_pad": "^4.1.5",
-    "sortablejs": "^1.15.3"
+    "sortablejs": "1.15.7"
   },
   "peerDependencies": {
     "@quasar/extras": "^1.16.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
   "description": "Asteroid",
-  "version": "3.20.0-beta.14-alpha.3",
+  "version": "3.20.0-beta.14-alpha.4",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "./src/asteroid.js",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
   "description": "Asteroid",
-  "version": "3.20.0-beta.13",
+  "version": "3.20.0-beta.14-alpha.2",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "./src/asteroid.js",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bildvitta/quasar-ui-asteroid",
   "description": "Asteroid",
-  "version": "3.20.0-beta.14-alpha.2",
+  "version": "3.20.0-beta.14-alpha.3",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "./src/asteroid.js",

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -6,11 +6,11 @@
           <q-item v-bind="getItemProps(item)" :key="key" active-class="primary" clickable data-cy="actions-menu-list-item" @click="setClickHandler(item)">
             <q-item-section avatar>
               <q-spinner v-if="item.loading" size="sm" />
-              <q-icon v-else :class="getMagicAiClass(item)" :name="item.icon" />
+              <q-icon v-else :class="getMagicAiClasses(item)" :name="item.icon" />
             </q-item-section>
 
             <q-item-section>
-              <q-item-label :class="getMagicAiClass(item)">
+              <q-item-label :class="getMagicAiClasses(item)">
                 {{ item.label }}
               </q-item-label>
             </q-item-section>
@@ -286,8 +286,8 @@ function getItemProps (item) {
   }
 }
 
-function getMagicAiClass (item) {
-  return { 'text-magic-ai': item.useMagicAiColor }
+function getMagicAiClasses ({ useMagicAiColor }) {
+  return { 'text-magic-ai': useMagicAiColor }
 }
 
 function handleMenuModel (newValue, oldValue) {

--- a/ui/src/components/actions-menu/QasActionsMenu.vue
+++ b/ui/src/components/actions-menu/QasActionsMenu.vue
@@ -6,11 +6,11 @@
           <q-item v-bind="getItemProps(item)" :key="key" active-class="primary" clickable data-cy="actions-menu-list-item" @click="setClickHandler(item)">
             <q-item-section avatar>
               <q-spinner v-if="item.loading" size="sm" />
-              <q-icon v-else :name="item.icon" />
+              <q-icon v-else :class="getMagicAiClass(item)" :name="item.icon" />
             </q-item-section>
 
             <q-item-section>
-              <q-item-label>
+              <q-item-label :class="getMagicAiClass(item)">
                 {{ item.label }}
               </q-item-label>
             </q-item-section>
@@ -284,6 +284,10 @@ function getItemProps (item) {
     to,
     ...itemProps
   }
+}
+
+function getMagicAiClass (item) {
+  return { 'text-magic-ai': item.useMagicAiColor }
 }
 
 function handleMenuModel (newValue, oldValue) {

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -28,7 +28,7 @@
 
               <template v-else>
                 <qas-lazy-loading-components :threshold="0">
-                  <div v-for="(item) in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item">
+                  <div v-for="(item) in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item" :data-disable-drag="updatingPositionItemKey === item[props.itemIdKey]">
                     <!-- <slot v-if="!props.skeleton" :column-index="index" :fields="getFieldsByHeader(header)" :header="header" :item="item" name="column-item" /> -->
                     <!-- <qas-card v-if="updatingPositionItemKey === item[props.itemIdKey]" v-bind="skeletonCards.at(0)" :key="item[props.itemIdKey]" class="q-mb-sm" :column-index="index">
                       <template #default />
@@ -215,7 +215,16 @@ const emit = defineEmits([
   'update-error'
 ])
 
-defineExpose({ fetchColumns, fetchColumn, reset, cancelDrop, refreshColumn })
+defineExpose({
+  fetchColumns,
+  fetchColumn,
+  reset,
+  cancelDrop,
+  refreshColumn,
+  transferItemToColumn,
+  removeItemFromList,
+  refetchColumns: fetchColumnsValues
+})
 
 // Inject
 const axios = inject('axios')
@@ -454,6 +463,17 @@ async function fetchColumns () {
   const hiddenHeaders = visibleKeys.size
     ? normalizedHeaders.value.filter(header => !visibleKeys.has(getKeyByHeader(header)))
     : []
+
+  /**
+   * Isto é necessário para setar o loading das colunas ocultas mesmo antes de elas serem visíveis
+   * e suas requests serem feitas, garantindo que ao entrar no viewport elas já estejam com o estado
+   * de loading correto, evitando bugs visuais.
+   */
+  hiddenHeaders.forEach(header => {
+    const headerKey = getKeyByHeader(header)
+
+    columnsLoading.value[headerKey] = true
+  })
 
   // Etapa 1: colunas visíveis (prioridade)
   const visibleColumns = await Promise.allSettled(visibleHeaders.map(header => fetchColumn(header, false)))
@@ -725,7 +745,8 @@ function setSortable (element, index) {
     swapThreshold: 1,
     delay: 50,
     delayOnTouchOnly: true,
-    emptyInsertThreshold: 0
+    emptyInsertThreshold: 0,
+    filter: '[data-disable-drag="true"]'
   }
 
   /**
@@ -968,6 +989,33 @@ function setItemList ({ headerKey, data, index }) {
 
 function destroySortable () {
   sortableInstances.value.forEach(sortable => sortable.destroy())
+}
+
+/**
+ * Transfere um item de uma coluna para outra localmente, sem realizar nenhuma requisição.
+ * O item é sempre inserido como primeiro elemento na coluna de destino.
+ * Após a transferência, o SortableJS continua funcionando normalmente sobre os elementos
+ * do DOM atualizados pelo Vue, sem necessidade de reinicialização.
+ *
+ * @param {Object} params
+ * @param {string|number} params.itemId       - ID do item a ser movido (valor correspondente à prop `itemIdKey`).
+ * @param {string|number} params.fromColumnId - ID da coluna de origem (valor correspondente à prop `columnIdKey`).
+ * @param {string|number} params.toColumnId   - ID da coluna de destino (valor correspondente à prop `columnIdKey`).
+ * @param {Object}        [params.updatedItem]- Dados atualizados do item. Quando informado, sobrescreve o item original na coluna de destino.
+ * @returns {void}
+ */
+function transferItemToColumn ({ itemId, fromColumnId, toColumnId, updatedItem }) {
+  const sourceColumn = columnsResultsModel.value[fromColumnId]
+  const itemIndex = sourceColumn?.findIndex(item => item[props.itemIdKey] === itemId)
+
+  if (!sourceColumn || itemIndex === -1) return
+
+  const item = updatedItem ?? sourceColumn[itemIndex]
+
+  removeItemFromList({ headerKey: fromColumnId, itemId })
+
+  columnsResultsModel.value[toColumnId].splice(0, 0, item)
+  columnsPagination.value[toColumnId].count += 1
 }
 
 function hasSkeletonByHeader (header) {

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -2,23 +2,33 @@
   <qas-grabbable class="qas-board-generator" v-bind="grabbableProps">
     <div ref="columnsContainer" class="no-wrap q-gutter-md q-px-xl row">
       <qas-lazy-loading-components direction="horizontal" placeholder-width="350px" :threshold="0">
-        <qas-box v-for="(header, index) in headers" :key="index" :style="containerStyle">
-          <div class="q-mb-md text-grey-10" v-bind="headerBoxProps">
-            <slot :fields="getFieldsByHeader(header)" :header="header" :index="index" name="header-column" />
+        <qas-box v-for="(header, index) in normalizedHeaders" :key="index" :style="containerStyle">
+          <div class="ellipsis q-mb-md text-grey-10" v-bind="headerBoxProps">
+            <qas-skeleton v-if="props.skeleton" type="text" use-contrast width="80%" />
+
+            <slot v-else :fields="getFieldsByHeader(header)" :header="header" :index="index" name="header-column" />
           </div>
 
           <pv-board-generator-column ref="columnContainer" class="qas-board-generator__column secondary-scroll" :data-header-key="getKeyByHeader(header)">
             <div>
               <qas-lazy-loading-components :threshold="0">
                 <div v-for="item in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item">
-                  <slot :column-index="index" :fields="getFieldsByHeader(header)" :item="item" name="column-item" />
+                  <slot v-if="!props.skeleton" :column-index="index" :fields="getFieldsByHeader(header)" :item="item" name="column-item" />
                 </div>
               </qas-lazy-loading-components>
 
               <div class="full-width justify-center row">
-                <qas-btn v-if="hasSeeMore(header)" icon="sym_r_add" label="Ver mais" :use-label-on-small-screen="false" variant="tertiary" @click="fetchColumn(header)" />
+                <qas-btn v-if="hasSeeMore(header)" icon="sym_r_add" label="Ver mais" :loading="columnsLoading[getKeyByHeader(header)]" :use-label-on-small-screen="false" variant="tertiary" @click="fetchColumn(header)" />
 
-                <q-spinner v-if="columnsLoading[getKeyByHeader(header)]" class="q-mb-md" color="grey-4" size="3em" />
+                <template v-if="hasSkeletonByHeader(header)">
+                  <div class="q-col-gutter-y-sm row">
+                    <div v-for="item in skeletonCards" :key="item[props.itemIdKey]" class="col-12">
+                      <qas-card v-bind="item">
+                        <template #default />
+                      </qas-card>
+                    </div>
+                  </div>
+                </template>
               </div>
 
               <qas-empty-result-text v-if="hasEmptyResultText(header)" />
@@ -35,6 +45,8 @@
 <script setup>
 import PvBoardGeneratorColumn from './private/PvBoardGeneratorColumn.vue'
 
+import QasSkeleton from '../skeleton/QasSkeleton.vue'
+import QasCard from '../card/QasCard.vue'
 import QasBox from '../box/QasBox.vue'
 import QasBtn from '../btn/QasBtn.vue'
 import QasDialog from '../dialog/QasDialog.vue'
@@ -115,6 +127,11 @@ const props = defineProps({
     default: () => ({})
   },
 
+  skeleton: {
+    type: Boolean,
+    default: true
+  },
+
   useMarkRaw: {
     type: Boolean,
     default: true
@@ -165,7 +182,6 @@ const isInsideListView = inject('isListView', false)
 
 // Refs
 const columnContainer = ref(null)
-const columnsContainer = ref(null)
 const columnsPagination = ref({})
 const columnsLoading = ref({})
 const columnsFieldsModel = ref({})
@@ -189,7 +205,7 @@ const onConfirmDrop = ref(() => {})
  */
 const isUpdatingPosition = ref(false)
 
-// Consts
+// consts
 const hasDragAndDrop = !!props.useDragAndDropX || !!props.useDragAndDropY
 
 const grabbableProps = {
@@ -200,8 +216,32 @@ const grabbableProps = {
   })
 }
 
+/**
+ * Gera cards de skeleton para exibir enquanto carrega os itens da coluna, o mesmo é usado para preencher a coluna
+ * quando a prop "skeleton" for true, indicando que é para simular o carregamento.
+ */
+const skeletonCards = Array.from({ length: 6 }).map(() => ({
+  skeleton: true,
+  title: '-',
+  expansionProps: { label: '-' },
+  useSelection: true
+}))
+
+// computeds
 const columnContainerElements = computed(() => {
   return columnContainer.value?.map(columnProxy => columnProxy.$el) || []
+})
+
+const normalizedHeaders = computed(() => {
+  if (props.skeleton) {
+    return Array.from({ length: 4 }).map((_, index) => {
+      return {
+        [props.columnIdKey]: `${props.columnIdKey}-${index}`
+      }
+    })
+  }
+
+  return props.headers
 })
 
 // Watchers
@@ -219,7 +259,7 @@ watch(
 )
 
 watch(
-  () => props.headers,
+  () => normalizedHeaders.value,
   () => {
     if (isUpdatingPosition.value) return
 
@@ -246,6 +286,18 @@ onUnmounted(destroySortable)
 // Computeds
 const columnsResultsModel = computed({
   get () {
+    if (props.skeleton) {
+      return normalizedHeaders.value.reduce((acc, header) => {
+        const headerKey = getKeyByHeader(header)
+
+        acc[headerKey] = Array.from({ length: props.limitPerColumn }).map((_, index) => ({
+          [props.itemIdKey]: `${headerKey}-item-${index}`
+        }))
+
+        return acc
+      }, {})
+    }
+
     return props.results
   },
 
@@ -332,7 +384,9 @@ function setColumnHeightContainer () {
 * Bater API pra cada header
 */
 async function fetchColumns () {
-  const promises = props.headers.map(header => fetchColumn(header))
+  if (props.skeleton) return
+
+  const promises = normalizedHeaders.value.map(header => fetchColumn(header))
 
   const { error } = await promiseHandler(promises, { useLoading: false })
 
@@ -463,7 +517,7 @@ function getColumnItemById (id) {
  * @returns {Object} // { date: '2024-02-15'... }
  */
 function getHeaderById (id) {
-  return props.headers.find(header => String(getKeyByHeader(header)) === String(id))
+  return normalizedHeaders.value.find(header => String(getKeyByHeader(header)) === String(id))
 }
 
 /**
@@ -490,7 +544,7 @@ function setColumnsPagination () {
   columnsPagination.value = {}
   columnsLoading.value = {}
 
-  props.headers.forEach(header => {
+  normalizedHeaders.value.forEach(header => {
     const headerKey = getKeyByHeader(header)
 
     columnsPagination.value[headerKey] = { limit: props.limitPerColumn, offset: 0 }
@@ -515,6 +569,8 @@ function fetchColumnsValues () {
  * @param {Object} header
  */
 function hasEmptyResultText (header) {
+  if (props.skeleton) return false
+
   return !columnsLoading.value[getKeyByHeader(header)] && !getItemsByHeader(header)?.length && !isDragging.value
 }
 
@@ -526,7 +582,7 @@ function hasSeeMore (header) {
   const headerKey = getKeyByHeader(header)
   const hasMorePagination = columnsResultsModel.value[headerKey]?.length < columnsPagination.value[headerKey]?.count
 
-  return hasMorePagination && !columnsLoading.value[headerKey]
+  return hasMorePagination
 }
 
 function reset () {
@@ -769,6 +825,12 @@ function setItemList ({ headerKey, data, index }) {
 
 function destroySortable () {
   sortableInstances.value.forEach(sortable => sortable.destroy())
+}
+
+function hasSkeletonByHeader (header) {
+  const headerKey = getKeyByHeader(header)
+
+  return props.skeleton || columnsLoading.value[headerKey]
 }
 </script>
 

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -1,16 +1,30 @@
 <template>
   <qas-grabbable class="qas-board-generator" v-bind="grabbableProps">
-    <div ref="columnsContainer" class="no-wrap q-gutter-md q-px-xl row">
+    <div ref="columnsContainer" class="no-wrap q-gutter-md q-pb-xs q-px-lg row">
       <qas-lazy-loading-components direction="horizontal" placeholder-width="350px" :threshold="0">
-        <qas-box v-for="(header, index) in normalizedHeaders" :key="index" :style="containerStyle">
+        <qas-box v-for="(header, index) in normalizedHeaders" :key="index" :class="getColumnClass(header)" :style="containerStyle">
           <div class="ellipsis q-mb-md text-grey-10" v-bind="headerBoxProps">
             <qas-skeleton v-if="props.skeleton" type="text" use-contrast width="80%" />
-
             <slot v-else :fields="getFieldsByHeader(header)" :header="header" :index="index" name="header-column" />
           </div>
 
-          <pv-board-generator-column ref="columnContainer" class="qas-board-generator__column secondary-scroll" :data-header-key="getKeyByHeader(header)">
-            <div>
+          <pv-board-generator-cards-container ref="columnContainer" class="qas-board-generator__column secondary-scroll" v-bind="getCardsContainerProps(header)">
+            <!-- COLUNA COM ERRO -->
+            <div v-if="columnsWithError[getKeyByHeader(header)]" class="column full-height items-center justify-center">
+              <div class="text-center">
+                <q-icon color="negative" name="sym_r_error" size="md" />
+
+                <div class="q-mt-sm text-subtitle1">
+                  {{ props.errorColumnText }}
+                </div>
+              </div>
+
+              <div class="text-center">
+                <qas-btn class="q-mt-md" icon="sym_r_refresh" label="Tentar novamente" :loading="columnsLoading[getKeyByHeader(header)]" @click="fetchColumn(header, true)" />
+              </div>
+            </div>
+
+            <template v-else>
               <qas-lazy-loading-components :threshold="0">
                 <div v-for="item in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item">
                   <slot v-if="!props.skeleton" :column-index="index" :fields="getFieldsByHeader(header)" :item="item" name="column-item" />
@@ -18,7 +32,7 @@
               </qas-lazy-loading-components>
 
               <div class="full-width justify-center row">
-                <qas-btn v-if="hasSeeMore(header)" icon="sym_r_add" label="Ver mais" :loading="columnsLoading[getKeyByHeader(header)]" :use-label-on-small-screen="false" variant="tertiary" @click="fetchColumn(header)" />
+                <qas-btn v-if="hasSeeMore(header)" icon="sym_r_add" :label="props.seeMoreButtonLabel" :loading="columnsLoading[getKeyByHeader(header)]" :use-label-on-small-screen="false" variant="tertiary" @click="fetchColumn(header, true)" />
 
                 <template v-if="hasSkeletonByHeader(header)">
                   <div class="q-col-gutter-y-sm row">
@@ -32,8 +46,8 @@
               </div>
 
               <qas-empty-result-text v-if="hasEmptyResultText(header)" />
-            </div>
-          </pv-board-generator-column>
+            </template>
+          </pv-board-generator-cards-container>
         </qas-box>
       </qas-lazy-loading-components>
     </div>
@@ -43,7 +57,7 @@
 </template>
 
 <script setup>
-import PvBoardGeneratorColumn from './private/PvBoardGeneratorColumn.vue'
+import PvBoardGeneratorCardsContainer from './private/PvBoardGeneratorCardsContainer.vue'
 
 import QasSkeleton from '../skeleton/QasSkeleton.vue'
 import QasCard from '../card/QasCard.vue'
@@ -56,6 +70,7 @@ import QasLazyLoadingComponents from '../lazy-loading-components/QasLazyLoadingC
 
 import { ref, watch, computed, onUnmounted, markRaw, inject, onMounted, nextTick } from 'vue'
 import promiseHandler from '../../helpers/promise-handler'
+import NotifyError from '../../plugins/notify-error/NotifyError'
 
 import Sortable from 'sortablejs'
 
@@ -102,6 +117,11 @@ const props = defineProps({
     default: () => ({})
   },
 
+  errorColumnText: {
+    type: String,
+    default: 'Não foi possível carregar os itens desta coluna.'
+  },
+
   height: {
     type: String,
     default: ''
@@ -120,6 +140,11 @@ const props = defineProps({
   columnWidth: {
     type: String,
     default: '350px'
+  },
+
+  seeMoreButtonLabel: {
+    type: String,
+    default: 'Ver mais'
   },
 
   sortableConfig: {
@@ -188,6 +213,8 @@ const columnsFieldsModel = ref({})
 const showConfirmDialog = ref(false)
 const isDragging = ref(false)
 const isLoadingUpdatePosition = ref(false)
+const isLoadingFromSeeMore = ref(false)
+const columnsWithError = ref({})
 
 /**
  * Instâncias do sortable, que são utilizadas para realizar o destroy ao sair da página
@@ -224,6 +251,7 @@ const skeletonCards = Array.from({ length: 6 }).map(() => ({
   skeleton: true,
   title: '-',
   expansionProps: { label: '-' },
+  actionsMenuProps: { list: {} },
   useSelection: true
 }))
 
@@ -267,7 +295,10 @@ watch(
   }
 )
 
-watch(() => columnContainerElements.value, setColumnHeightContainer)
+watch(() => columnContainerElements.value, () => {
+  setColumnHeightContainer()
+  handleElementsList()
+})
 
 // Lifecycles
 onMounted(() => {
@@ -286,18 +317,6 @@ onUnmounted(destroySortable)
 // Computeds
 const columnsResultsModel = computed({
   get () {
-    if (props.skeleton) {
-      return normalizedHeaders.value.reduce((acc, header) => {
-        const headerKey = getKeyByHeader(header)
-
-        acc[headerKey] = Array.from({ length: props.limitPerColumn }).map((_, index) => ({
-          [props.itemIdKey]: `${headerKey}-item-${index}`
-        }))
-
-        return acc
-      }, {})
-    }
-
     return props.results
   },
 
@@ -386,17 +405,33 @@ function setColumnHeightContainer () {
 async function fetchColumns () {
   if (props.skeleton) return
 
-  const promises = normalizedHeaders.value.map(header => fetchColumn(header))
+  const promises = normalizedHeaders.value.map((header, index) => {
+    if (index === 2 || !index) {
+      return fetchColumn(header, false, true)
+    }
+
+    return fetchColumn(header, false)
+  })
+  // const promises = normalizedHeaders.value.map(header => fetchColumn(header))
 
   const { error } = await promiseHandler(promises, { useLoading: false })
 
-  if (error) {
+  const allPromises = await Promise.allSettled(promises)
+
+  const hasAllPromisesSucceeded = allPromises.every(promise => promise.status === 'fulfilled')
+  const hasAllPromisesFailed = allPromises.every(promise => promise.status === 'rejected')
+
+  if (hasAllPromisesFailed) {
     emit('fetch-columns-error', error)
+
+    NotifyError('Ocorreu um erro ao carregar as colunas. Tente novamente mais tarde.')
 
     return
   }
 
-  emit('fetch-columns-success')
+  if (hasAllPromisesSucceeded) {
+    emit('fetch-columns-success')
+  }
 
   if (hasDragAndDrop) handleElementsList()
 }
@@ -404,12 +439,14 @@ async function fetchColumns () {
 /*
 * Busca a coluna com base no header recebido.
 */
-async function fetchColumn (header) {
+async function fetchColumn (header, fromSeeMore, setEr) {
   const headerKey = getKeyByHeader(header)
   const { limit, offset } = columnsPagination.value[headerKey] || {}
 
+  isLoadingFromSeeMore.value = fromSeeMore
+
   const { data: response, error } = await promiseHandler(
-    axios.get(`${props.columnUrl}/${headerKey}`, {
+    axios.get(`${props.columnUrl}/${headerKey}/${setEr ? 'setError' : ''}`, {
       params: {
         ...props.columnParams,
         limit,
@@ -420,16 +457,21 @@ async function fetchColumn (header) {
       onLoading: value => {
         columnsLoading.value[headerKey] = value
       },
-      useLoading: false,
-      errorMessage: 'Não conseguimos buscar as colunas do board. Por favor, tente novamente em alguns minutos.'
+      useLoading: false
     }
   )
+
+  isLoadingFromSeeMore.value = false
 
   if (error) {
     emit('fetch-column-error', error)
 
+    columnsWithError.value[headerKey] = true
+
     throw error
   }
+
+  columnsWithError.value[headerKey] = false
 
   const newValues = response.data?.results || []
   const resultsModel = columnsResultsModel.value[headerKey] || []
@@ -602,6 +644,9 @@ function getFieldsByHeader (header) {
  */
 function handleElementsList () {
   columnContainerElements.value.forEach((columnElement, index) => {
+    // não adiciona os elementos com erro para o drag and drop.
+    if (columnElement.dataset.hasError === 'true') return
+
     const sortable = setSortable(columnElement, index)
 
     sortableInstances.value.push(sortable)
@@ -830,7 +875,24 @@ function destroySortable () {
 function hasSkeletonByHeader (header) {
   const headerKey = getKeyByHeader(header)
 
-  return props.skeleton || columnsLoading.value[headerKey]
+  return (props.skeleton || columnsLoading.value[headerKey]) && !isLoadingFromSeeMore.value
+}
+
+function getColumnClass (header) {
+  const headerKey = getKeyByHeader(header)
+
+  return {
+    'qas-board-generator__column-error': columnsWithError.value[headerKey]
+  }
+}
+
+function getCardsContainerProps (header) {
+  const headerKey = getKeyByHeader(header)
+
+  return {
+    'data-header-key': headerKey,
+    'data-has-error': columnsWithError.value[headerKey]
+  }
 }
 </script>
 
@@ -858,6 +920,10 @@ function hasSkeletonByHeader (header) {
   // 60px é o valor do padding definido no container da column.
   &__column-items {
     height: calc(100% - 60px);
+  }
+
+  &__column-error {
+    border: 1px solid $negative;
   }
 }
 </style>

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -568,13 +568,17 @@ async function fetchColumns () {
 async function fetchColumn (header, fromSeeMore, setEr) {
   const headerKey = getKeyByHeader(header)
 
-  // Cancela qualquer request anterior para esta mesma coluna antes de iniciar a nova.
-  // Garante que nunca haja duas requests paralelas para a mesma coluna.
+  /**
+   * Cancela qualquer request anterior para esta mesma coluna antes de iniciar a nova.
+   * Garante que nunca haja duas requests paralelas para a mesma coluna.
+   */
   abortColumnRequest(headerKey)
 
-  // Incrementa a geração desta coluna para invalidar callbacks onLoading da request cancelada,
-  // evitando que o onLoading(false) antigo sobrescreva o estado da nova request.
-  // Usa ?? 0 pois ++undefined retorna NaN, e NaN === NaN é sempre false, travando o skeleton.
+  /**
+   * Incrementa a geração desta coluna para invalidar callbacks onLoading da request cancelada,
+   * evitando que o onLoading(false) antigo sobrescreva o estado da nova request.
+   * Usa ?? 0 pois ++undefined retorna NaN, e NaN === NaN é sempre false, travando o skeleton.
+   */
   columnFetchGenerations[headerKey] = (columnFetchGenerations[headerKey] ?? 0) + 1
   const generation = columnFetchGenerations[headerKey]
 
@@ -596,8 +600,10 @@ async function fetchColumn (header, fromSeeMore, setEr) {
     }),
     {
       onLoading: value => {
-        // Só atualiza o loading se ainda for a request atual desta coluna,
-        // evitando que o onLoading(false) de uma request cancelada sobrescreva o da nova.
+        /**
+         * Só atualiza o loading se ainda for a request atual desta coluna,
+         * evitando que o onLoading(false) de uma request cancelada sobrescreva o da nova.
+         */
         if (columnFetchGenerations[headerKey] === generation) {
           columnsLoading.value[headerKey] = value
         }
@@ -876,8 +882,6 @@ function setSortable (element, index) {
 
     group: useOnlyDragAndDropY ? `column-${index}` : 'shared',
 
-    // direction: 'vertical',
-
     /**
      * invertSwap muda o algoritmo de swap: em vez de trocar quando o centro do item arrastado
      * cruza o centro do alvo (instável, causa oscilação), troca apenas quando cruza a BORDA
@@ -962,10 +966,11 @@ function handleSortableScroll (offsetX, offsetY, evt, _touchEvt, scrollEl) {
     return
   }
 
-  // Scroll vertical (dentro da coluna): aplica manualmente com velocidade independente do scrollSpeed horizontal.
-  // offsetY já vem escalado pelo scrollSpeed (60), então normalizamos para VERTICAL_SCROLL_SPEED (10).
-  // Além disso, como scrollSensitivity está em HORIZONTAL_SCROLL_SENSITIVITY (200), verificamos manualmente
-  // se o cursor está dentro de VERTICAL_SCROLL_SENSITIVITY (80) da borda da coluna antes de rolar.
+  /**
+   * SortableJS chama essa função com offsets de scroll.
+   * Para scroll vertical: retorna 'continue' para deixar o comportamento nativo.
+   * Para scroll horizontal: aplica smooth scroll customizado via rAF.
+   */
   if (offsetY) {
     const clientY = evt?.clientY ?? evt?.touches?.[0]?.clientY
 
@@ -1309,7 +1314,7 @@ function isCancelledError (error) {
  * @param {string|number} params.itemId - ID do item a ser movido (valor correspondente à prop `itemIdKey`).
  * @param {string|number} params.fromColumnId - ID da coluna de origem (valor correspondente à prop `columnIdKey`).
  * @param {string|number} params.toColumnId - ID da coluna de destino (valor correspondente à prop `columnIdKey`).
- * @param {Object}        [params.updatedItem] - Dados atualizados do item. Quando informado, sobrescreve o item original na coluna de destino.
+ * @param {Object} [params.updatedItem] - Dados atualizados do item. Quando informado, sobrescreve o item original na coluna de destino.
  * @returns {void}
  */
 function transferItemToColumn ({ itemId, fromColumnId, toColumnId, updatedItem }) {

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -29,12 +29,12 @@
               <template v-else>
                 <qas-lazy-loading-components :threshold="0">
                   <div v-for="(item) in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item">
-                    <slot v-if="!props.skeleton" :column-index="index" :fields="getFieldsByHeader(header)" :header="header" :item="item" name="column-item" />
-                    <!-- <qas-card v-if="updatingPositionItemKey === item[props.itemIdKey]" v-bind="skeletonCards.at(0)" :key="item[props.itemIdKey]" class="q-mb-sm" :column-index="index">
+                    <!-- <slot v-if="!props.skeleton" :column-index="index" :fields="getFieldsByHeader(header)" :header="header" :item="item" name="column-item" /> -->
+                    <qas-card v-if="updatingPositionItemKey === item[props.itemIdKey]" v-bind="skeletonCards.at(0)" :key="item[props.itemIdKey]" class="q-mb-sm" :column-index="index">
                       <template #default />
                     </qas-card>
 
-                    <slot v-else-if="!props.skeleton && updatingPositionItemKey !== item[props.itemIdKey]" :column-index="index" :fields="getFieldsByHeader(header)" :header="header" :item="item" name="column-item" /> -->
+                    <slot v-else-if="!props.skeleton && updatingPositionItemKey !== item[props.itemIdKey]" :column-index="index" :fields="getFieldsByHeader(header)" :header="header" :item="item" name="column-item" />
                   </div>
                 </qas-lazy-loading-components>
 
@@ -833,28 +833,28 @@ function confirmDrop (event) {
  *  itemId: string
  * }}
  */
-// function removeItemFromList ({ headerKey, itemId }) {
-//   /**
-//    * Coluna referente ao model de resultado
-//    */
-//   const columnItemList = columnsResultsModel.value[headerKey]
+function removeItemFromList ({ headerKey, itemId }) {
+  /**
+   * Coluna referente ao model de resultado
+   */
+  const columnItemList = columnsResultsModel.value[headerKey]
 
-//   /**
-//    * Busca o item com base em seu ID na lista de itens da coluna
-//    */
-//   const itemIndex = columnItemList.findIndex(itemContent => itemContent[props.itemIdKey] === itemId)
-//   console.log('🚀 ~ removeItemFromList ~ itemIndex:', itemIndex)
+  /**
+   * Busca o item com base em seu ID na lista de itens da coluna
+   */
+  const itemIndex = columnItemList.findIndex(itemContent => itemContent[props.itemIdKey] === itemId)
+  console.log('🚀 ~ removeItemFromList ~ itemIndex:', itemIndex)
 
-//   /**
-//    * Remove o item da listagem com base no index, sendo que preciso subtrair 1 para pegar o index correto
-//    */
-//   columnItemList.splice(itemIndex, 1)
+  /**
+   * Remove o item da listagem com base no index, sendo que preciso subtrair 1 para pegar o index correto
+   */
+  columnItemList.splice(itemIndex, 1)
 
-//   /**
-//    * Remove o item do count da coluna para não mostrar o botão de "Ver mais¨.
-//    */
-//   columnsPagination.value[headerKey].count -= 1
-// }
+  /**
+   * Remove o item do count da coluna para não mostrar o botão de "Ver mais¨.
+   */
+  columnsPagination.value[headerKey].count -= 1
+}
 
 /**
  * Método que realiza a request de update
@@ -906,9 +906,35 @@ async function updatePosition ({ newHeaderKey, oldHeaderKey, itemId, event }) {
     return
   }
 
-  // removeItemFromList({ headerKey: oldHeaderKey, itemId })
+  /**
+   * Reverte a mutação de DOM feita pelo SortableJS antes de atualizar os dados reativos.
+   *
+   * O SortableJS move elementos físicos do DOM imediatamente ao soltar o card,
+   * mas o virtual DOM do Vue ainda "pensa" que eles estão na posição original.
+   * Se atualizarmos os dados reativos sem primeiro restaurar o DOM, o Vue irá
+   * patchar os elementos errados (ex: sobrescreve o card movido com os dados do
+   * próximo card da coluna de origem), causando exibição incorreta.
+   *
+   * Ao reverter o DOM para o estado pré-drag, o Vue parte de um estado consistente
+   * e renderiza corretamente a nova ordenação via dados reativos.
+   */
+  if (props.useDragAndDropX) {
+    event.from.insertBefore(event.item, event.from.children[event.oldIndex] || null)
+  }
 
-  // setItemList({ headerKey: newHeaderKey, data: data.data, index: event.newIndex })
+  if (props.useDragAndDropY) {
+    const oldIndex = event.oldIndex
+    const targetIndex = oldIndex === 0 ? oldIndex : oldIndex + 1
+    const insertBeforeElement = targetIndex < event.from.children.length
+      ? event.from.children[targetIndex]
+      : null
+
+    event.from.insertBefore(event.item, insertBeforeElement)
+  }
+
+  removeItemFromList({ headerKey: oldHeaderKey, itemId })
+
+  setItemList({ headerKey: newHeaderKey, data: data.data, index: event.newIndex })
 
   isUpdatingPosition.value = true
 
@@ -919,19 +945,17 @@ async function updatePosition ({ newHeaderKey, oldHeaderKey, itemId, event }) {
   emit('update-success', data.data)
 }
 
-// function setItemList ({ headerKey, data, index }) {
-//   console.log('🚀 ~ setItemList ~ { headerKey, data, index }:', { headerKey, data, index })
-//   /**
-//    * Coluna referente ao model de resultado
-//    */
-//   const columnItemList = columnsResultsModel.value[headerKey]
+function setItemList ({ headerKey, data, index }) {
+  /**
+   * Coluna referente ao model de resultado
+   */
+  const columnItemList = columnsResultsModel.value[headerKey]
 
-//   /**
-//    * Adiciona o item na posição do event escolhido.
-//    */
-//   columnItemList.splice(index, 1, data.result)
-//   console.log('🚀 ~ setItemList ~ columnsResultsModel.value[headerKey]:', columnsResultsModel.value[headerKey])
-// }
+  /**
+   * Adiciona o item na posição do event escolhido.
+   */
+  columnItemList.splice(index, 0, data.result)
+}
 
 function destroySortable () {
   sortableInstances.value.forEach(sortable => sortable.destroy())

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -1,59 +1,68 @@
 <template>
-  <qas-grabbable class="qas-board-generator" v-bind="grabbableProps">
-    <div ref="columnsContainer" class="no-wrap q-gutter-md q-pb-xs q-px-lg row">
-      <qas-lazy-loading-components v-model:visible-items="visibleItems" direction="horizontal" placeholder-width="350px" :threshold="0">
-        <qas-box v-for="(header, index) in normalizedHeaders" :key="index" :class="getColumnClass(header)" :style="containerStyle">
-          <div class="ellipsis q-mb-md text-grey-10" v-bind="headerBoxProps">
-            <qas-skeleton v-if="props.skeleton" type="text" use-contrast width="80%" />
-            <slot v-else :fields="getFieldsByHeader(header)" :header="header" :index="index" name="header-column" />
-          </div>
-
-          <pv-board-generator-cards-container ref="columnContainer" class="qas-board-generator__column secondary-scroll" v-bind="getCardsContainerProps(header)">
-            <!-- COLUNA COM ERRO -->
-            <div v-if="columnsWithError[getKeyByHeader(header)]" class="column full-height items-center justify-center">
-              <div class="text-center">
-                <q-icon color="negative" name="sym_r_error" size="md" />
-
-                <div class="q-mt-sm text-subtitle1">
-                  {{ props.errorColumnText }}
-                </div>
-              </div>
-
-              <div class="text-center">
-                <qas-btn class="q-mt-md" icon="sym_r_refresh" label="Tentar novamente" :loading="columnsLoading[getKeyByHeader(header)]" @click="fetchColumn(header, true)" />
-              </div>
+  <div>
+    <qas-grabbable class="qas-board-generator" v-bind="grabbableProps">
+      <div ref="columnsContainer" class="no-wrap q-gutter-md q-pb-xs q-px-lg row">
+        <qas-lazy-loading-components v-model:visible-items="visibleItems" direction="horizontal" placeholder-width="350px" :threshold="0">
+          <qas-box v-for="(header, index) in normalizedHeaders" :key="index" :class="getColumnClass(header)" :style="containerStyle">
+            <div class="ellipsis q-mb-md text-grey-10" v-bind="headerBoxProps">
+              <qas-skeleton v-if="props.skeleton" type="text" use-contrast width="80%" />
+              <slot v-else :fields="getFieldsByHeader(header)" :header="header" :index="index" name="header-column" />
             </div>
 
-            <template v-else>
-              <qas-lazy-loading-components :threshold="0">
-                <div v-for="item in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item">
-                  <slot v-if="!props.skeleton" :column-index="index" :fields="getFieldsByHeader(header)" :item="item" name="column-item" />
-                </div>
-              </qas-lazy-loading-components>
+            <pv-board-generator-cards-container ref="columnContainer" class="qas-board-generator__column secondary-scroll" v-bind="getCardsContainerProps(header)">
+              <!-- COLUNA COM ERRO -->
+              <div v-if="columnsWithError[getKeyByHeader(header)]" class="column full-height items-center justify-center">
+                <div class="text-center">
+                  <q-icon color="negative" name="sym_r_error" size="md" />
 
-              <div class="full-width justify-center row">
-                <qas-btn v-if="hasSeeMore(header)" icon="sym_r_add" :label="props.seeMoreButtonLabel" :loading="columnsLoading[getKeyByHeader(header)]" :use-label-on-small-screen="false" variant="tertiary" @click="fetchColumn(header, true)" />
-
-                <template v-if="hasSkeletonByHeader(header)">
-                  <div class="q-col-gutter-y-sm row">
-                    <div v-for="item in skeletonCards" :key="item[props.itemIdKey]" class="col-12">
-                      <qas-card v-bind="item">
-                        <template #default />
-                      </qas-card>
-                    </div>
+                  <div class="q-mt-sm text-subtitle1">
+                    {{ props.errorColumnText }}
                   </div>
-                </template>
+                </div>
+
+                <div class="text-center">
+                  <qas-btn class="q-mt-md" icon="sym_r_refresh" label="Tentar novamente" :loading="columnsLoading[getKeyByHeader(header)]" @click="fetchColumn(header, true)" />
+                </div>
               </div>
 
-              <qas-empty-result-text v-if="hasEmptyResultText(header)" />
-            </template>
-          </pv-board-generator-cards-container>
-        </qas-box>
-      </qas-lazy-loading-components>
-    </div>
+              <template v-else>
+                <qas-lazy-loading-components :threshold="0">
+                  <div v-for="item in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item">
+                    <slot v-if="!props.skeleton" :column-index="index" :fields="getFieldsByHeader(header)" :item="item" name="column-item" />
+                  </div>
+                </qas-lazy-loading-components>
 
-    <qas-dialog v-model="showConfirmDialog" v-bind="defaultConfirmDialogProps" />
-  </qas-grabbable>
+                <div class="full-width justify-center row">
+                  <qas-btn v-if="hasSeeMore(header)" icon="sym_r_add" :label="props.seeMoreButtonLabel" :loading="columnsLoading[getKeyByHeader(header)]" :use-label-on-small-screen="false" variant="tertiary" @click="fetchColumn(header, true)" />
+
+                  <template v-if="hasSkeletonByHeader(header)">
+                    <div class="q-col-gutter-y-sm row">
+                      <div v-for="item in skeletonCards" :key="item[props.itemIdKey]" class="col-12">
+                        <qas-card v-bind="item">
+                          <template #default />
+                        </qas-card>
+                      </div>
+                    </div>
+                  </template>
+                </div>
+
+                <qas-empty-result-text v-if="hasEmptyResultText(header)" />
+              </template>
+            </pv-board-generator-cards-container>
+          </qas-box>
+        </qas-lazy-loading-components>
+      </div>
+
+      <qas-dialog v-model="showConfirmDialog" v-bind="defaultConfirmDialogProps" />
+    </qas-grabbable>
+
+    <q-inner-loading :showing="loading">
+      <q-spinner
+        color="grey"
+        size="3em"
+      />
+    </q-inner-loading>
+  </div>
 </template>
 
 <script setup>
@@ -135,6 +144,10 @@ const props = defineProps({
   limitPerColumn: {
     type: Number,
     default: 12
+  },
+
+  loading: {
+    type: Boolean
   },
 
   columnWidth: {
@@ -419,7 +432,6 @@ async function fetchColumns () {
 
   // Mapeia os índices visíveis para os IDs de coluna correspondentes
   const visibleKeys = new Set(visibleItems.value.map(i => getKeyByHeader(normalizedHeaders.value[i])))
-  console.log('🚀 ~ fetchColumns ~ visibleKeys:', visibleItems.value)
 
   const visibleHeaders = visibleKeys.size
     ? normalizedHeaders.value.filter(header => visibleKeys.has(getKeyByHeader(header)))

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -313,6 +313,20 @@ let currentFetchColumnsSession = 0
  */
 const SMOOTH_SCROLL_LERP = 0.2
 
+/**
+ * Velocidade de scroll vertical (dentro da coluna), independente do scrollSpeed horizontal.
+ * O offsetY recebido no scrollFn é proporcional ao scrollSpeed (60), então normalizamos
+ * para que o scroll vertical se comporte como se scrollSpeed fosse 10 (padrão do SortableJS).
+ */
+const HORIZONTAL_SCROLL_SPEED = 60
+const VERTICAL_SCROLL_SPEED = 20
+
+/**
+ * Sensibilidade para iniciar o scroll automático ao arrastar próximo às bordas do container.
+ */
+const HORIZONTAL_SCROLL_SENSITIVITY = 150
+const VERTICAL_SCROLL_SENSITIVITY = 80
+
 let smoothScrollTarget = 0
 let smoothScrollRafId = null
 let smoothScrollEl = null
@@ -821,21 +835,20 @@ function handleElementsList () {
  * Seta a instancia do sortable, no qual varia de acordo com as props passadas.
  *
  * @param {HTMLElement} element
- * @param {Number} index
+ * @param {number} index
  */
 function setSortable (element, index) {
   const defaultSortableConfig = {
-    animation: 500,
+    animation: 150,
     group: 'shared',
-    ghostClass: 'ghost',
-    sort: false,
+    ghostClass: 'qas-board-generator__ghost',
     swapThreshold: 1,
-    delay: 50,
+    delay: 0,
     delayOnTouchOnly: true,
     emptyInsertThreshold: 0,
     filter: '[data-disable-drag="true"]',
-    scrollSensitivity: 200,
-    scrollSpeed: 60,
+    scrollSensitivity: HORIZONTAL_SCROLL_SENSITIVITY,
+    scrollSpeed: HORIZONTAL_SCROLL_SPEED,
     bubbleScroll: true,
     forceAutoScrollFallback: true,
     scrollFn: handleSortableScroll
@@ -854,15 +867,28 @@ function setSortable (element, index) {
   let dropHandled = false
 
   const sortable = new Sortable(element, {
-    sort: props.useDragAndDropY,
-
     ...defaultSortableConfig,
 
     ...props.sortableConfig,
 
+    /**
+     * `sort` deve vir APÓS os spreads para não ser sobrescrito pelo defaultSortableConfig.
+     * Quando useDragAndDropY é true, o sort precisa estar habilitado para que o SortableJS
+     * rastreie ativamente a posição do item dentro da coluna durante o drag. Sem isso,
+     * o item oscila entre colunas porque o Sortable do destino não "assume" o controle do item.
+     */
+    sort: props.useDragAndDropY,
+
     group: useOnlyDragAndDropY ? `column-${index}` : 'shared',
 
-    direction: useOnlyDragAndDropY ? 'vertical' : 'horizontal',
+    // direction: 'vertical',
+
+    /**
+     * invertSwap muda o algoritmo de swap: em vez de trocar quando o centro do item arrastado
+     * cruza o centro do alvo (instável, causa oscilação), troca apenas quando cruza a BORDA
+     * superior/inferior do alvo. Isso cria uma "zona morta" que elimina o jitter.
+     */
+    invertSwap: true,
 
     onStart: () => {
       dropHandled = false
@@ -886,6 +912,18 @@ function setSortable (element, index) {
     ...(props.useDragAndDropY && {
       onSort: event => {
         dropHandled = true
+
+        /**
+         * O SortableJS dispara onSort em AMBAS as listas envolvidas quando um item
+         * é arrastado entre colunas (cross-column): na lista de origem porque perdeu
+         * um item e na lista de destino porque ganhou um.
+         * O onAdd já trata o cross-column na lista de destino, então ao ignorar o
+         * onSort para eventos cross-column evitamos processar o mesmo drop duas vezes,
+         * o que causava corrupção do model (item duplicado no destino e remoção
+         * incorreta do último item da origem via splice(-1, 1)).
+         */
+        if (event.from !== event.to) return
+
         onDropCard(event)
       }
     })
@@ -908,7 +946,7 @@ function stopDragging () {
  * - Scroll vertical (colunas): retorna 'continue' para manter o comportamento nativo.
  * - Scroll horizontal (container do board): aplica smooth scroll via rAF.
  */
-function handleSortableScroll (offsetX, _offsetY, _evt, _touchEvt, scrollEl) {
+function handleSortableScroll (offsetX, offsetY, evt, _touchEvt, scrollEl) {
   // Obtém o container com scroll horizontal (`.qas-grabbable__container`).
   const horizontalContainer = columnContainerElements.value[0]?.closest('.qas-grabbable__container')
 
@@ -926,6 +964,24 @@ function handleSortableScroll (offsetX, _offsetY, _evt, _touchEvt, scrollEl) {
     if (!smoothScrollRafId) {
       smoothScrollRafId = requestAnimationFrame(smoothScrollStep)
     }
+    return
+  }
+
+  // Scroll vertical (dentro da coluna): aplica manualmente com velocidade independente do scrollSpeed horizontal.
+  // offsetY já vem escalado pelo scrollSpeed (60), então normalizamos para VERTICAL_SCROLL_SPEED (10).
+  // Além disso, como scrollSensitivity está em HORIZONTAL_SCROLL_SENSITIVITY (200), verificamos manualmente
+  // se o cursor está dentro de VERTICAL_SCROLL_SENSITIVITY (80) da borda da coluna antes de rolar.
+  if (offsetY) {
+    const clientY = evt?.clientY ?? evt?.touches?.[0]?.clientY
+
+    if (clientY !== undefined) {
+      const rect = scrollEl.getBoundingClientRect()
+      const distFromEdge = Math.min(clientY - rect.top, rect.bottom - clientY)
+
+      if (distFromEdge > VERTICAL_SCROLL_SENSITIVITY) return
+    }
+
+    scrollEl.scrollTop += offsetY * (VERTICAL_SCROLL_SPEED / HORIZONTAL_SCROLL_SPEED)
     return
   }
 
@@ -1327,6 +1383,29 @@ function getCardsContainerProps (header) {
 
   &__column-error {
     border: 1px solid $negative;
+  }
+
+  &__ghost {
+    border: 1px solid $grey-4 !important;
+    overflow: hidden;
+    border-radius: $generic-border-radius;
+    position: relative;
+    margin-bottom: var(--qas-spacing-sm);
+
+    &::after {
+      align-items: center;
+      background-color: $grey-3;
+      border-radius: inherit;
+      color: $grey-8;
+      content: 'place_item';
+      display: flex;
+      font-family: 'Material Symbols Rounded';
+      font-size: 40px;
+      inset: 0;
+      justify-content: center;
+      position: absolute;
+      z-index: 999;
+    }
   }
 }
 </style>

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -1,7 +1,7 @@
 <template>
   <qas-grabbable class="qas-board-generator" v-bind="grabbableProps">
     <div ref="columnsContainer" class="no-wrap q-gutter-md q-pb-xs q-px-lg row">
-      <qas-lazy-loading-components direction="horizontal" placeholder-width="350px" :threshold="0">
+      <qas-lazy-loading-components v-model:visible-items="visibleItems" direction="horizontal" placeholder-width="350px" :threshold="0">
         <qas-box v-for="(header, index) in normalizedHeaders" :key="index" :class="getColumnClass(header)" :style="containerStyle">
           <div class="ellipsis q-mb-md text-grey-10" v-bind="headerBoxProps">
             <qas-skeleton v-if="props.skeleton" type="text" use-contrast width="80%" />
@@ -217,6 +217,12 @@ const isLoadingFromSeeMore = ref(false)
 const columnsWithError = ref({})
 
 /**
+ * Índices das colunas visíveis no viewport
+ * Populado pelo QasLazyLoadingComponents via v-model:visible-items
+ */
+const visibleItems = ref([])
+
+/**
  * Instâncias do sortable, que são utilizadas para realizar o destroy ao sair da página
  */
 const sortableInstances = ref([])
@@ -261,6 +267,7 @@ const columnContainerElements = computed(() => {
 })
 
 const normalizedHeaders = computed(() => {
+  // retorna dados fakes para criar colunas de skeleton, caso a prop skeleton seja true.
   if (props.skeleton) {
     return Array.from({ length: 4 }).map((_, index) => {
       return {
@@ -277,7 +284,7 @@ watch(
   () => isFetchSuccessHeader.value,
   value => {
     /**
-     * isFetchSuccessHeader é uma variavel que pego do listView por inject/provide, no qual caso eu faça request do header e dê sucesso, eu chamo as demais funções.
+     * isFetchSuccessHeader é uma variável que pego do listView por inject/provide, no qual caso eu faça request do header e dê sucesso, eu chamo as demais funções.
      * Valido se não houve sucesso na requisição do header ou se não é uma atualização de posição, para assim não bater novamente nas colunas apenas no header.
      */
     if (!value || isUpdatingPosition.value) return
@@ -300,16 +307,19 @@ watch(() => columnContainerElements.value, () => {
   handleElementsList()
 })
 
-// Lifecycles
-onMounted(() => {
-  window.addEventListener('resize', setColumnHeightContainer)
-
-  /**
-   * Caso eu use o listView (valor pego por provide), a request é feito pelo watch quando se ocorre o sucesso do `fetchList`
-   */
-  if (isInsideListView) return
+/**
+ * Dispara o fetch inicial quando as colunas visíveis são detectadas pela primeira vez.
+ * Usado no fluxo sem listView (onMounted não chama mais fetchColumnsValues diretamente).
+ */
+watch(visibleItems, () => {
+  if (isInsideListView || props.skeleton) return
 
   fetchColumnsValues()
+}, { once: true })
+
+// hooks
+onMounted(() => {
+  window.addEventListener('resize', setColumnHeightContainer)
 })
 
 onUnmounted(destroySortable)
@@ -401,28 +411,37 @@ function setColumnHeightContainer () {
 
 /*
 * Bater API pra cada header
+* Etapa 1: faz as requests das colunas visíveis no carregamento inicial
+* Etapa 2: após finalizar, faz as requests das colunas não visíveis
 */
 async function fetchColumns () {
   if (props.skeleton) return
 
-  const promises = normalizedHeaders.value.map((header, index) => {
-    if (index === 2 || !index) {
-      return fetchColumn(header, false, true)
-    }
+  // Mapeia os índices visíveis para os IDs de coluna correspondentes
+  const visibleKeys = new Set(visibleItems.value.map(i => getKeyByHeader(normalizedHeaders.value[i])))
+  console.log('🚀 ~ fetchColumns ~ visibleKeys:', visibleItems.value)
 
-    return fetchColumn(header, false)
-  })
-  // const promises = normalizedHeaders.value.map(header => fetchColumn(header))
+  const visibleHeaders = visibleKeys.size
+    ? normalizedHeaders.value.filter(header => visibleKeys.has(getKeyByHeader(header)))
+    : normalizedHeaders.value
 
-  const { error } = await promiseHandler(promises, { useLoading: false })
+  const hiddenHeaders = visibleKeys.size
+    ? normalizedHeaders.value.filter(header => !visibleKeys.has(getKeyByHeader(header)))
+    : []
 
-  const allPromises = await Promise.allSettled(promises)
+  // Etapa 1: colunas visíveis (prioridade)
+  const visibleColumns = await Promise.allSettled(visibleHeaders.map(header => fetchColumn(header, false)))
+
+  // Etapa 2: colunas não visíveis (só executa após etapa 1 finalizar, menor prioridade)
+  const hiddenColumns = await Promise.allSettled(hiddenHeaders.map(header => fetchColumn(header, false)))
+
+  const allPromises = [...visibleColumns, ...hiddenColumns]
 
   const hasAllPromisesSucceeded = allPromises.every(promise => promise.status === 'fulfilled')
-  const hasAllPromisesFailed = allPromises.every(promise => promise.status === 'rejected')
+  const hasAllPromisesFailed = allPromises.length > 0 && allPromises.every(promise => promise.status === 'rejected')
 
   if (hasAllPromisesFailed) {
-    emit('fetch-columns-error', error)
+    emit('fetch-columns-error')
 
     NotifyError('Ocorreu um erro ao carregar as colunas. Tente novamente mais tarde.')
 

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -73,7 +73,6 @@
 
 <script setup>
 import PvBoardGeneratorCardsContainer from './private/PvBoardGeneratorCardsContainer.vue'
-
 import QasSkeleton from '../skeleton/QasSkeleton.vue'
 import QasCard from '../card/QasCard.vue'
 import QasBox from '../box/QasBox.vue'
@@ -83,9 +82,20 @@ import QasEmptyResultText from '../empty-result-text/QasEmptyResultText.vue'
 import QasGrabbable from '../grabbable/QasGrabbable.vue'
 import QasLazyLoadingComponents from '../lazy-loading-components/QasLazyLoadingComponents.vue'
 
-import { ref, watch, computed, onUnmounted, onBeforeUnmount, markRaw, inject, onMounted, nextTick } from 'vue'
 import promiseHandler from '../../helpers/promise-handler'
 import NotifyError from '../../plugins/notify-error/NotifyError'
+
+import {
+  ref,
+  watch,
+  computed,
+  onBeforeUnmount,
+  markRaw,
+  inject,
+  provide,
+  onMounted,
+  nextTick
+} from 'vue'
 
 import Sortable from 'sortablejs'
 
@@ -227,14 +237,10 @@ defineExpose({
   refetchColumns: fetchColumnsValues
 })
 
-// Inject
+// globals
 const axios = inject('axios')
 
-// const isFetchSuccessHeader = inject('isFetchListSucceeded', false)
-
-const isInsideListView = inject('isListView', false)
-
-// Refs
+// refs
 const columnContainer = ref(null)
 const columnsPagination = ref({})
 const columnsLoading = ref({})
@@ -348,20 +354,7 @@ const normalizedHeaders = computed(() => {
   return props.headers
 })
 
-// Watchers
-// watch(
-//   () => isFetchSuccessHeader.value,
-//   value => {
-//     /**
-//      * isFetchSuccessHeader é uma variável que pego do listView por inject/provide, no qual caso eu faça request do header e dê sucesso, eu chamo as demais funções.
-//      * Valido se não houve sucesso na requisição do header ou se não é uma atualização de posição, para assim não bater novamente nas colunas apenas no header.
-//      */
-//     if (!value || isUpdatingPosition.value) return
-
-//     fetchColumnsValues()
-//   }
-// )
-
+// watchers
 watch(
   () => normalizedHeaders.value,
   value => {
@@ -377,24 +370,17 @@ watch(() => columnContainerElements.value, () => {
   handleElementsList()
 })
 
-/**
- * Dispara o fetch inicial quando as colunas visíveis são detectadas pela primeira vez.
- * Usado no fluxo sem listView (onMounted não chama mais fetchColumnsValues diretamente).
- */
-watch(visibleItems, () => {
-  if (isInsideListView || props.skeleton) return
-
-  fetchColumnsValues()
-}, { once: true })
-
 // hooks
 onMounted(() => {
   window.addEventListener('resize', setColumnHeightContainer)
 })
 
-onBeforeUnmount(abortAllColumnRequests)
+onBeforeUnmount(() => {
+  abortAllColumnRequests()
+  destroySortable()
 
-onUnmounted(destroySortable)
+  window.removeEventListener('resize', setColumnHeightContainer)
+})
 
 // Computeds
 const columnsResultsModel = computed({
@@ -408,6 +394,8 @@ const columnsResultsModel = computed({
 })
 
 const isDragging = computed(() => draggingCount.value > 0)
+
+provide('isDragging', isDragging)
 
 const hasColumnsLength = computed(() => !!Object.keys(columnsResultsModel.value).length)
 

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -28,13 +28,13 @@
 
               <template v-else>
                 <qas-lazy-loading-components :threshold="0">
-                  <div v-for="(item) in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item" :data-disable-drag="updatingPositionItemKey === item[props.itemIdKey]">
+                  <div v-for="(item) in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item" :data-disable-drag="updatingPositionItemKeys.has(item[props.itemIdKey])">
                     <!-- <slot v-if="!props.skeleton" :column-index="index" :fields="getFieldsByHeader(header)" :header="header" :item="item" name="column-item" /> -->
                     <!-- <qas-card v-if="updatingPositionItemKey === item[props.itemIdKey]" v-bind="skeletonCards.at(0)" :key="item[props.itemIdKey]" class="q-mb-sm" :column-index="index">
                       <template #default />
                     </qas-card> -->
 
-                    <slot v-if="!props.skeleton" :column-index="index" :fields="getFieldsByHeader(header)" :header="header" :is-updating-position="updatingPositionItemKey === item[props.itemIdKey]" :item="item" name="column-item" />
+                    <slot v-if="!props.skeleton" :column-index="index" :fields="getFieldsByHeader(header)" :header="header" :is-updating-position="updatingPositionItemKeys.has(item[props.itemIdKey])" :item="item" name="column-item" />
                   </div>
                 </qas-lazy-loading-components>
 
@@ -240,11 +240,10 @@ const columnsPagination = ref({})
 const columnsLoading = ref({})
 const columnsFieldsModel = ref({})
 const showConfirmDialog = ref(false)
-const isDragging = ref(false)
 const isLoadingUpdatePosition = ref(false)
 const isLoadingFromSeeMore = ref(false)
 const columnsWithError = ref({})
-const updatingPositionItemKey = ref(null)
+const updatingPositionItemKeys = ref(new Set())
 
 /**
  * Índices das colunas visíveis no viewport
@@ -276,11 +275,19 @@ const onConfirmDrop = ref(() => {})
 const isUpdatingPosition = ref(false)
 
 /**
- * Chave da coluna de origem durante um drag and drop confirmado.
- * Usada para exibir o texto "Não há itens" imediatamente na coluna de origem
- * antes da requisição de updatePosition ser finalizada.
+ * Contador de drags ativos. Usado em vez de um booleano com toggle para
+ * evitar race conditions quando múltiplos drags acontecem em sequência rápida.
+ * isDragging continua existindo como computed derivado deste contador.
  */
-const draggingFromHeaderKey = ref(null)
+const draggingCount = ref(0)
+
+/**
+ * Fila de chamadas de updatePosition para garantir execução sequencial.
+ * Cada entrada é uma função que retorna uma Promise (a chamada updatePosition).
+ * Isso evita race conditions causadas por múltiplas requests concorrentes
+ * que compartilham estado (updatingPositionItemKey, isLoadingUpdatePosition, etc).
+ */
+let updatePositionQueue = Promise.resolve()
 
 // consts
 const hasDragAndDrop = !!props.useDragAndDropX || !!props.useDragAndDropY
@@ -379,6 +386,8 @@ const columnsResultsModel = computed({
     emit('update:results', newValues)
   }
 })
+
+const isDragging = computed(() => draggingCount.value > 0)
 
 const hasColumnsLength = computed(() => !!Object.keys(columnsResultsModel.value).length)
 
@@ -701,13 +710,6 @@ function hasEmptyResultText (header) {
   const headerKey = getKeyByHeader(header)
   const items = getItemsByHeader(header)
 
-  // Durante drag and drop, exibe o texto imediatamente na coluna de origem
-  // enquanto a requisição de updatePosition ainda está em andamento
-  // (o item ainda está no model, mas já foi movido visualmente pelo SortableJS)
-  if (draggingFromHeaderKey.value === headerKey && items?.length <= 1) {
-    return !columnsLoading.value[headerKey]
-  }
-
   return !columnsLoading.value[headerKey] && !items?.length && !isDragging.value
 }
 
@@ -773,6 +775,13 @@ function setSortable (element, index) {
    */
   const useOnlyDragAndDropY = !!props.useDragAndDropY && !props.useDragAndDropX
 
+  /**
+   * Flag local por instância do Sortable para rastrear se o drop foi tratado
+   * pelo onAdd/onSort. Isso permite que o onEnd saiba se deve chamar stopDragging
+   * (caso o usuário arraste e devolva o card sem mover para outra coluna).
+   */
+  let dropHandled = false
+
   const sortable = new Sortable(element, {
     sort: props.useDragAndDropY,
 
@@ -784,20 +793,78 @@ function setSortable (element, index) {
 
     direction: useOnlyDragAndDropY ? 'vertical' : 'horizontal',
 
-    onStart: toggleIsDragging,
+    onStart: () => {
+      dropHandled = false
+      startDragging()
+    },
 
-    onAdd: event => onDropCard(event),
+    onAdd: event => {
+      dropHandled = true
+      onDropCard(event)
+    },
+
+    /**
+     * Chamado sempre que o drag termina, independente do resultado.
+     * Só chama stopDragging se onAdd/onSort não trataram o drop,
+     * ou seja, o usuário abandonou o drag sem mover o card.
+     */
+    onEnd: () => {
+      if (!dropHandled) stopDragging()
+    },
 
     ...(props.useDragAndDropY && {
-      onSort: event => onDropCard(event)
+      onSort: event => {
+        dropHandled = true
+        onDropCard(event)
+      }
     })
   })
 
   return sortable
 }
 
-function toggleIsDragging () {
-  isDragging.value = !isDragging.value
+function startDragging () {
+  draggingCount.value++
+}
+
+function stopDragging () {
+  draggingCount.value = Math.max(0, draggingCount.value - 1)
+}
+
+/**
+ * Reverte a manipulação de DOM feita pelo SortableJS.
+ * Deve ser chamada ANTES de qualquer atualização reativa do model,
+ * para que o Vue parta de um estado DOM consistente ao re-renderizar.
+ */
+function revertDomDrag (event) {
+  if (props.useDragAndDropX) {
+    event.from.insertBefore(event.item, event.from.children[event.oldIndex] || null)
+  }
+
+  if (props.useDragAndDropY) {
+    const oldIndex = event.oldIndex
+    const targetIndex = oldIndex === 0 ? oldIndex : oldIndex + 1
+    const insertBeforeElement = targetIndex < event.from.children.length
+      ? event.from.children[targetIndex]
+      : null
+
+    event.from.insertBefore(event.item, insertBeforeElement)
+  }
+}
+
+/**
+ * Adiciona um item na lista de resultados de uma coluna, criando uma nova
+ * referência de array para garantir reatividade com markRaw.
+ */
+function addItemToList ({ headerKey, item, index }) {
+  const columnItemList = columnsResultsModel.value[headerKey]
+  const updatedList = [...columnItemList]
+  const insertIndex = Math.min(index, updatedList.length)
+
+  updatedList.splice(insertIndex, 0, item)
+
+  columnsResultsModel.value[headerKey] = props.useMarkRaw ? markRaw(updatedList) : updatedList
+  columnsPagination.value[headerKey].count += 1
 }
 
 function onDropCard (event) {
@@ -836,36 +903,11 @@ function closeConfirmDialog () {
  * @param {event} event
  */
 function cancelDrop (event) {
-  draggingFromHeaderKey.value = null
-
-  /**
-   * Insere na posição antiga que pertencia (event.oldIndex) dentro do seu antigo pai (event.from)
-   */
-  if (props.useDragAndDropX) event.from.insertBefore(event.item, event.from.children[event.oldIndex])
-
-  if (props.useDragAndDropY) {
-    const oldIndex = event.oldIndex
-
-    /**
-     * Se oldIndex for 0, o targetIndex deverá ser 0, pois isso indica que se o item é o primeiro da lista, ele não será movido para outra posição.
-     *
-     * Caso o oldIndex for diferente, devo incrementar 1 para adicionar, pois isso permite que o item seja inserido logo após sua posição original.
-     */
-    const targetIndex = oldIndex === 0 ? oldIndex : oldIndex + 1
-
-    /**
-     * Verifica se o índice alvo é válido, caso contrário, define como o final
-     */
-    const insertBeforeElement = targetIndex < event.from.children.length
-      ? event.from.children[targetIndex]
-      : null
-
-    event.from.insertBefore(event.item, insertBeforeElement)
-  }
+  revertDomDrag(event)
 
   if (hasConfirmDialogProps.value) closeConfirmDialog()
 
-  toggleIsDragging()
+  stopDragging()
 }
 
 function confirmDrop (event) {
@@ -874,9 +916,47 @@ function confirmDrop (event) {
   const { headerKey: newHeaderKey } = to.dataset
   const { headerKey: oldHeaderKey } = from.dataset
 
-  draggingFromHeaderKey.value = oldHeaderKey
+  /**
+   * 1. Reverte o DOM imediatamente para que o Vue parta de um estado consistente.
+   * O SortableJS já moveu o elemento fisicamente, mas precisamos devolvê-lo
+   * antes de atualizar o model reativo.
+   */
+  revertDomDrag(event)
 
-  updatePosition({ newHeaderKey, oldHeaderKey, itemId, event })
+  /**
+   * 2. Atualização otimista: move o item no model ANTES da request de API.
+   * Isso garante que a UI esteja sempre sincronizada com o model,
+   * eliminando race conditions entre múltiplos drops rápidos.
+   */
+  const item = getColumnItemById(itemId)
+
+  removeItemFromList({ headerKey: oldHeaderKey, itemId })
+  addItemToList({ headerKey: newHeaderKey, item, index: event.newIndex })
+
+  stopDragging()
+
+  /**
+   * 3. Marca o item como "em atualização" imediatamente, antes mesmo
+   * da request de API iniciar (pode estar na fila).
+   */
+  updatingPositionItemKeys.value = new Set([...updatingPositionItemKeys.value, itemId])
+
+  /**
+   * 4. Enfileira a chamada de API para confirmação no servidor.
+   * Se falhar, o model é revertido automaticamente.
+   */
+  enqueueUpdatePosition({ newHeaderKey, oldHeaderKey, itemId, event, optimisticItem: item })
+}
+
+/**
+ * Enfileira a chamada de updatePosition para execução sequencial.
+ * Garante que a próxima chamada só inicia após a anterior ter finalizado,
+ * evitando race conditions no estado compartilhado.
+ */
+function enqueueUpdatePosition (params) {
+  updatePositionQueue = updatePositionQueue.then(
+    () => updatePosition(params)
+  )
 }
 
 /**
@@ -932,14 +1012,12 @@ function updateItemInList ({ headerKey, itemId, updatedItem }) {
  *  event: event
  * }}
  */
-async function updatePosition ({ newHeaderKey, oldHeaderKey, itemId, event }) {
+async function updatePosition ({ newHeaderKey, oldHeaderKey, itemId, event, optimisticItem }) {
   const params = {
     [props.columnIdKey]: newHeaderKey,
     ...(props.useDragAndDropY && { newIndex: event.newIndex }),
     ...props.updatePositionParams
   }
-
-  updatingPositionItemKey.value = itemId
 
   const isFnUpdatePositionUrl = typeof props.updatePositionUrl === 'function'
 
@@ -950,7 +1028,10 @@ async function updatePosition ({ newHeaderKey, oldHeaderKey, itemId, event }) {
     : `${props.updatePositionUrl}/${itemId}/update-position`
 
   const { data, error } = await promiseHandler(
-    axios.patch(url, params),
+    axios.patch(url, params, {
+      adapter: 'fetch',
+      fetchOptions: { priority: 'low' }
+    }),
     {
       errorMessage: 'Ocorreu um erro ao atualizar a posição de seu item.',
       useLoading: false,
@@ -962,10 +1043,17 @@ async function updatePosition ({ newHeaderKey, oldHeaderKey, itemId, event }) {
     }
   )
 
-  updatingPositionItemKey.value = null
+  const updatedKeys = new Set(updatingPositionItemKeys.value)
+  updatedKeys.delete(itemId)
+  updatingPositionItemKeys.value = updatedKeys
 
   if (error) {
-    onCancelDrop.value()
+    /**
+     * Reverte a atualização otimista: move o item de volta da coluna de destino
+     * para a coluna de origem no model.
+     */
+    removeItemFromList({ headerKey: newHeaderKey, itemId })
+    addItemToList({ headerKey: oldHeaderKey, item: optimisticItem, index: event.oldIndex })
 
     emit('update-error', error)
 
@@ -973,56 +1061,18 @@ async function updatePosition ({ newHeaderKey, oldHeaderKey, itemId, event }) {
   }
 
   /**
-   * Reverte a mutação de DOM feita pelo SortableJS antes de atualizar os dados reativos.
-   *
-   * O SortableJS move elementos físicos do DOM imediatamente ao soltar o card,
-   * mas o virtual DOM do Vue ainda "pensa" que eles estão na posição original.
-   * Se atualizarmos os dados reativos sem primeiro restaurar o DOM, o Vue irá
-   * patchar os elementos errados (ex: sobrescreve o card movido com os dados do
-   * próximo card da coluna de origem), causando exibição incorreta.
-   *
-   * Ao reverter o DOM para o estado pré-drag, o Vue parte de um estado consistente
-   * e renderiza corretamente a nova ordenação via dados reativos.
+   * Atualiza o item na coluna de destino com os dados retornados pelo servidor,
+   * que podem conter campos atualizados (timestamps, status, etc).
    */
-  if (props.useDragAndDropX) {
-    event.from.insertBefore(event.item, event.from.children[event.oldIndex] || null)
+  if (data.data?.result) {
+    updateItemInList({ headerKey: newHeaderKey, itemId, updatedItem: data.data.result })
   }
-
-  if (props.useDragAndDropY) {
-    const oldIndex = event.oldIndex
-    const targetIndex = oldIndex === 0 ? oldIndex : oldIndex + 1
-    const insertBeforeElement = targetIndex < event.from.children.length
-      ? event.from.children[targetIndex]
-      : null
-
-    event.from.insertBefore(event.item, insertBeforeElement)
-  }
-
-  removeItemFromList({ headerKey: oldHeaderKey, itemId })
-
-  setItemList({ headerKey: newHeaderKey, data: data.data, index: event.newIndex })
 
   isUpdatingPosition.value = true
 
-  toggleIsDragging()
-
   closeConfirmDialog()
 
-  draggingFromHeaderKey.value = null
-
   emit('update-success', data.data)
-}
-
-function setItemList ({ headerKey, data, index }) {
-  /**
-   * Coluna referente ao model de resultado
-   */
-  const columnItemList = columnsResultsModel.value[headerKey]
-
-  /**
-   * Adiciona o item na posição do event escolhido.
-   */
-  columnItemList.splice(index, 0, data.result)
 }
 
 function destroySortable () {

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -1,27 +1,31 @@
 <template>
   <qas-grabbable class="qas-board-generator" v-bind="grabbableProps">
-    <div class="no-wrap q-col-gutter-sm q-px-xl row">
-      <div v-for="(header, index) in headers" :key="index" class="q-mr-sm">
-        <qas-box class="q-mb-md" v-bind="headerBoxProps">
-          <slot :fields="getFieldsByHeader(header)" :header="header" :index="index" name="header-column" />
-        </qas-box>
-
-        <div ref="columnContainer" class="qas-board-generator__column secondary-scroll" :data-header-key="getKeyByHeader(header)" :style="containerStyle">
-          <qas-lazy-loading-components :threshold="0">
-            <div v-for="item in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item">
-              <slot :column-index="index" :fields="getFieldsByHeader(header)" :item="item" name="column-item" />
-            </div>
-          </qas-lazy-loading-components>
-
-          <div class="full-width justify-center row">
-            <qas-btn v-if="hasSeeMore(header)" icon="sym_r_add" label="Ver mais" :use-label-on-small-screen="false" variant="tertiary" @click="fetchColumn(header)" />
-
-            <q-spinner v-if="columnsLoading[getKeyByHeader(header)]" class="q-mb-md" color="grey-4" size="3em" />
+    <div ref="columnsContainer" class="no-wrap q-gutter-md q-px-xl row">
+      <qas-lazy-loading-components direction="horizontal" placeholder-width="350px" :threshold="0">
+        <qas-box v-for="(header, index) in headers" :key="index" :style="containerStyle">
+          <div class="q-mb-md text-grey-10" v-bind="headerBoxProps">
+            <slot :fields="getFieldsByHeader(header)" :header="header" :index="index" name="header-column" />
           </div>
 
-          <qas-empty-result-text v-if="hasEmptyResultText(header)" />
-        </div>
-      </div>
+          <pv-board-generator-column ref="columnContainer" class="qas-board-generator__column secondary-scroll" :data-header-key="getKeyByHeader(header)">
+            <div>
+              <qas-lazy-loading-components :threshold="0">
+                <div v-for="item in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item">
+                  <slot :column-index="index" :fields="getFieldsByHeader(header)" :item="item" name="column-item" />
+                </div>
+              </qas-lazy-loading-components>
+
+              <div class="full-width justify-center row">
+                <qas-btn v-if="hasSeeMore(header)" icon="sym_r_add" label="Ver mais" :use-label-on-small-screen="false" variant="tertiary" @click="fetchColumn(header)" />
+
+                <q-spinner v-if="columnsLoading[getKeyByHeader(header)]" class="q-mb-md" color="grey-4" size="3em" />
+              </div>
+
+              <qas-empty-result-text v-if="hasEmptyResultText(header)" />
+            </div>
+          </pv-board-generator-column>
+        </qas-box>
+      </qas-lazy-loading-components>
     </div>
 
     <qas-dialog v-model="showConfirmDialog" v-bind="defaultConfirmDialogProps" />
@@ -29,6 +33,8 @@
 </template>
 
 <script setup>
+import PvBoardGeneratorColumn from './private/PvBoardGeneratorColumn.vue'
+
 import QasBox from '../box/QasBox.vue'
 import QasBtn from '../btn/QasBtn.vue'
 import QasDialog from '../dialog/QasDialog.vue'
@@ -36,7 +42,7 @@ import QasEmptyResultText from '../empty-result-text/QasEmptyResultText.vue'
 import QasGrabbable from '../grabbable/QasGrabbable.vue'
 import QasLazyLoadingComponents from '../lazy-loading-components/QasLazyLoadingComponents.vue'
 
-import { ref, watch, computed, onUnmounted, markRaw, inject, onMounted } from 'vue'
+import { ref, watch, computed, onUnmounted, markRaw, inject, onMounted, nextTick } from 'vue'
 import promiseHandler from '../../helpers/promise-handler'
 
 import Sortable from 'sortablejs'
@@ -101,7 +107,7 @@ const props = defineProps({
 
   columnWidth: {
     type: String,
-    default: '300px'
+    default: '350px'
   },
 
   sortableConfig: {
@@ -159,6 +165,7 @@ const isInsideListView = inject('isListView', false)
 
 // Refs
 const columnContainer = ref(null)
+const columnsContainer = ref(null)
 const columnsPagination = ref({})
 const columnsLoading = ref({})
 const columnsFieldsModel = ref({})
@@ -193,6 +200,10 @@ const grabbableProps = {
   })
 }
 
+const columnContainerElements = computed(() => {
+  return columnContainer.value?.map(columnProxy => columnProxy.$el) || []
+})
+
 // Watchers
 watch(
   () => isFetchSuccessHeader.value,
@@ -216,10 +227,12 @@ watch(
   }
 )
 
-watch(columnContainer, setColumnHeightContainer)
+watch(() => columnContainerElements.value, setColumnHeightContainer)
 
 // Lifecycles
 onMounted(() => {
+  window.addEventListener('resize', setColumnHeightContainer)
+
   /**
    * Caso eu use o listView (valor pego por provide), a request é feito pelo watch quando se ocorre o sucesso do `fetchList`
    */
@@ -272,12 +285,46 @@ const defaultConfirmDialogProps = computed(() => {
 * de espaço que ele conseguir considerando a altura do container em relação ao topo.
 */
 function setColumnHeightContainer () {
-  columnContainer.value?.forEach(columnElement => {
-    const heightToTop = columnElement?.getBoundingClientRect()?.top
-    const paddingSpacing = 60
-    const value = heightToTop + paddingSpacing
+  // Primeira etapa: calcula e aplica a altura inicial de cada coluna
+  columnContainerElements.value.forEach(columnElement => {
+    // Pega a posição atual da coluna em relação ao topo da viewport
+    const rect = columnElement.getBoundingClientRect()
+    const heightToTop = rect.top
 
-    columnElement.style.setProperty('height', props.height ? props.height : `calc(100vh - ${value}px)`)
+    // clientHeight dá a altura da viewport SEM incluir as scrollbars
+    const viewportHeight = document.documentElement.clientHeight
+
+    // Padding inferior aplicado no container para dar espaçamento visual
+    const paddingBottom = 8
+
+    // Calcula quanto de espaço temos disponível do topo da coluna até o fim da tela
+    const availableHeight = viewportHeight - heightToTop - paddingBottom
+
+    // Aplica essa altura na coluna
+    columnElement.style.height = `${availableHeight}px`
+  })
+
+  // Segunda etapa: após o DOM atualizar, verifica se algum scroll vertical foi criado
+  nextTick(() => {
+    /**
+     * scrollHeight é a altura total do conteúdo (incluindo o que não está visível)
+     * clientHeight é a altura visível da viewport
+     * Se scrollHeight > clientHeight, significa que há conteúdo "sobrando" e foi criado scroll vertical.
+     */
+    const hasVerticalScroll = document.documentElement.scrollHeight > document.documentElement.clientHeight
+
+    if (hasVerticalScroll) {
+      // Calcula exatamente quantos pixels estão "sobrando" e causando o scroll
+      const adjustment = document.documentElement.scrollHeight - document.documentElement.clientHeight
+
+      // Reduz a altura de todas as colunas pelo valor exato do scroll + 2px de margem de segurança
+      columnContainerElements.value.forEach(columnElement => {
+        const safetyMargin = 2
+
+        const currentHeight = parseInt(columnElement.style.height, 10)
+        columnElement.style.height = `${currentHeight - adjustment - safetyMargin}px`
+      })
+    }
   })
 }
 
@@ -498,8 +545,8 @@ function getFieldsByHeader (header) {
  * Loopa todos os itens da coluna com base no ref para pegar o elemento HTML e setar e instaciar o sortable.
  */
 function handleElementsList () {
-  columnContainer.value.forEach((element, index) => {
-    const sortable = setSortable(element, index)
+  columnContainerElements.value.forEach((columnElement, index) => {
+    const sortable = setSortable(columnElement, index)
 
     sortableInstances.value.push(sortable)
   })

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -2,7 +2,7 @@
   <div>
     <qas-grabbable class="qas-board-generator" v-bind="grabbableProps">
       <div ref="columnsContainer" class="no-wrap q-gutter-md q-pb-xs q-px-lg row">
-        <qas-lazy-loading-components v-model:visible-items="visibleItems" direction="horizontal" placeholder-width="350px" :threshold="0">
+        <qas-lazy-loading-components :key="lazyLoadingKey" v-model:visible-items="visibleItems" direction="horizontal" placeholder-width="350px" :threshold="0">
           <qas-box v-for="(header, index) in normalizedHeaders" :key="index" :class="getColumnClass(header)" :style="containerStyle">
             <div class="ellipsis q-mb-md text-grey-10" v-bind="headerBoxProps">
               <qas-skeleton v-if="props.skeleton" type="text" use-contrast width="80%" />
@@ -30,11 +30,11 @@
                 <qas-lazy-loading-components :threshold="0">
                   <div v-for="(item) in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item">
                     <!-- <slot v-if="!props.skeleton" :column-index="index" :fields="getFieldsByHeader(header)" :header="header" :item="item" name="column-item" /> -->
-                    <qas-card v-if="updatingPositionItemKey === item[props.itemIdKey]" v-bind="skeletonCards.at(0)" :key="item[props.itemIdKey]" class="q-mb-sm" :column-index="index">
+                    <!-- <qas-card v-if="updatingPositionItemKey === item[props.itemIdKey]" v-bind="skeletonCards.at(0)" :key="item[props.itemIdKey]" class="q-mb-sm" :column-index="index">
                       <template #default />
-                    </qas-card>
+                    </qas-card> -->
 
-                    <slot v-else-if="!props.skeleton && updatingPositionItemKey !== item[props.itemIdKey]" :column-index="index" :fields="getFieldsByHeader(header)" :header="header" :item="item" name="column-item" />
+                    <slot v-if="!props.skeleton" :column-index="index" :fields="getFieldsByHeader(header)" :header="header" :is-updating-position="updatingPositionItemKey === item[props.itemIdKey]" :item="item" name="column-item" />
                   </div>
                 </qas-lazy-loading-components>
 
@@ -241,6 +241,13 @@ const updatingPositionItemKey = ref(null)
  * Populado pelo QasLazyLoadingComponents via v-model:visible-items
  */
 const visibleItems = ref([])
+
+/**
+ * Chave reativa para forçar o remount do QasLazyLoadingComponents externo.
+ * Ao incrementar, o componente é destruído e recriado com estado limpo,
+ * evitando render de VNodes obsoletos que causam crash.
+ */
+const lazyLoadingKey = ref(0)
 
 /**
  * Instâncias do sortable, que são utilizadas para realizar o destroy ao sair da página
@@ -642,6 +649,8 @@ function setColumnsPagination () {
 }
 
 function fetchColumnsValues () {
+  lazyLoadingKey.value++
+
   reset()
   setColumnHeightContainer()
   setColumnsPagination()

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -178,12 +178,7 @@ const props = defineProps({
 
   skeleton: {
     type: Boolean,
-    default: true
-  },
-
-  useMarkRaw: {
-    type: Boolean,
-    default: true
+    default: false
   },
 
   useDragAndDropX: {
@@ -450,6 +445,14 @@ const defaultConfirmDialogProps = computed(() => {
 * de espaço que ele conseguir considerando a altura do container em relação ao topo.
 */
 function setColumnHeightContainer () {
+  if (props.height) {
+    columnContainerElements.value.forEach(columnElement => {
+      columnElement.style.height = props.height
+    })
+
+    return
+  }
+
   // Primeira etapa: calcula e aplica a altura inicial de cada coluna
   columnContainerElements.value.forEach(columnElement => {
     // Pega a posição atual da coluna em relação ao topo da viewport
@@ -648,7 +651,7 @@ async function fetchColumn (header, fromSeeMore, setEr) {
    * onde cada item do objeto é uma coluna no board. O mesmo vale para "columnsFieldsModel", "columnsLoading" e
    * "columnPagination", organizando os fields, loadings e o controle de paginação por chave identificadora do header.
    */
-  columnsResultsModel.value[headerKey] = props.useMarkRaw ? markRaw(newColumnValues) : newColumnValues
+  columnsResultsModel.value[headerKey] = hasDragAndDrop ? newColumnValues : markRaw(newColumnValues)
 
   /*
   * Pode acontecer das options nos fields da segunda página serem diferentes da primeira página,
@@ -1051,7 +1054,7 @@ function addItemToList ({ headerKey, item, index }) {
 
   updatedList.splice(insertIndex, 0, item)
 
-  columnsResultsModel.value[headerKey] = props.useMarkRaw ? markRaw(updatedList) : updatedList
+  columnsResultsModel.value[headerKey] = updatedList
   columnsPagination.value[headerKey].count += 1
 }
 
@@ -1172,7 +1175,7 @@ function removeItemFromList ({ headerKey, itemId }) {
   const updatedList = [...columnItemList]
   updatedList.splice(itemIndex, 1)
 
-  columnsResultsModel.value[headerKey] = props.useMarkRaw ? markRaw(updatedList) : updatedList
+  columnsResultsModel.value[headerKey] = updatedList
 
   /**
    * Remove o item do count da coluna para não mostrar o botão de "Ver mais¨.

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -83,7 +83,7 @@ import QasEmptyResultText from '../empty-result-text/QasEmptyResultText.vue'
 import QasGrabbable from '../grabbable/QasGrabbable.vue'
 import QasLazyLoadingComponents from '../lazy-loading-components/QasLazyLoadingComponents.vue'
 
-import { ref, watch, computed, onUnmounted, markRaw, inject, onMounted, nextTick } from 'vue'
+import { ref, watch, computed, onUnmounted, onBeforeUnmount, markRaw, inject, onMounted, nextTick } from 'vue'
 import promiseHandler from '../../helpers/promise-handler'
 import NotifyError from '../../plugins/notify-error/NotifyError'
 
@@ -289,6 +289,24 @@ const draggingCount = ref(0)
  */
 let updatePositionQueue = Promise.resolve()
 
+/**
+ * Mapa de AbortControllers por chave de coluna para cancelar requests em andamento.
+ * Não é reativo pois não precisamos de reatividade sobre os controllers.
+ */
+let columnAbortControllers = {}
+
+/**
+ * Contador de sessão para o fetchColumns em execução.
+ * Incrementado a cada nova chamada, permitindo que sessões antigas detectem que foram substituídas.
+ */
+let currentFetchColumnsSession = 0
+
+/**
+ * Geração por coluna para invalidar callbacks onLoading de requests canceladas.
+ * Evita que o onLoading(false) de uma request cancelada sobrescreva o estado da nova request.
+ */
+const columnFetchGenerations = {}
+
 // consts
 const hasDragAndDrop = !!props.useDragAndDropX || !!props.useDragAndDropY
 
@@ -373,6 +391,8 @@ watch(visibleItems, () => {
 onMounted(() => {
   window.addEventListener('resize', setColumnHeightContainer)
 })
+
+onBeforeUnmount(abortAllColumnRequests)
 
 onUnmounted(destroySortable)
 
@@ -471,6 +491,13 @@ function setColumnHeightContainer () {
 async function fetchColumns () {
   if (props.skeleton) return
 
+  /**
+   * Cada chamada a fetchColumns recebe um ID de sessão único.
+   * Se um novo fetchColumnsValues for chamado durante a execução, a sessão anterior
+   * detecta que foi substituída e para de processar, evitando emissão de eventos falsos.
+   */
+  const mySession = ++currentFetchColumnsSession
+
   // Mapeia os índices visíveis para os IDs de coluna correspondentes
   const visibleKeys = new Set(visibleItems.value.map(i => getKeyByHeader(normalizedHeaders.value[i])))
 
@@ -496,8 +523,14 @@ async function fetchColumns () {
   // Etapa 1: colunas visíveis (prioridade)
   const visibleColumns = await Promise.allSettled(visibleHeaders.map(header => fetchColumn(header, false)))
 
+  // Sessão foi substituída por um novo fetchColumnsValues — encerra sem emitir eventos
+  if (currentFetchColumnsSession !== mySession) return
+
   // Etapa 2: colunas não visíveis (só executa após etapa 1 finalizar, menor prioridade)
   const hiddenColumns = await Promise.allSettled(hiddenHeaders.map(header => fetchColumn(header, false)))
+
+  // Verifica novamente pois outro fetchColumnsValues pode ter sido chamado durante a etapa 2
+  if (currentFetchColumnsSession !== mySession) return
 
   const allPromises = [...visibleColumns, ...hiddenColumns]
 
@@ -524,12 +557,27 @@ async function fetchColumns () {
 */
 async function fetchColumn (header, fromSeeMore, setEr) {
   const headerKey = getKeyByHeader(header)
+
+  // Cancela qualquer request anterior para esta mesma coluna antes de iniciar a nova.
+  // Garante que nunca haja duas requests paralelas para a mesma coluna.
+  abortColumnRequest(headerKey)
+
+  // Incrementa a geração desta coluna para invalidar callbacks onLoading da request cancelada,
+  // evitando que o onLoading(false) antigo sobrescreva o estado da nova request.
+  // Usa ?? 0 pois ++undefined retorna NaN, e NaN === NaN é sempre false, travando o skeleton.
+  columnFetchGenerations[headerKey] = (columnFetchGenerations[headerKey] ?? 0) + 1
+  const generation = columnFetchGenerations[headerKey]
+
+  const abortController = new AbortController()
+  columnAbortControllers[headerKey] = abortController
+
   const { limit, offset } = columnsPagination.value[headerKey] || {}
 
   isLoadingFromSeeMore.value = fromSeeMore
 
   const { data: response, error } = await promiseHandler(
     axios.get(`${props.columnUrl}/${headerKey}/${setEr ? 'setError' : ''}`, {
+      signal: abortController.signal,
       params: {
         ...props.columnParams,
         limit,
@@ -538,15 +586,24 @@ async function fetchColumn (header, fromSeeMore, setEr) {
     }),
     {
       onLoading: value => {
-        columnsLoading.value[headerKey] = value
+        // Só atualiza o loading se ainda for a request atual desta coluna,
+        // evitando que o onLoading(false) de uma request cancelada sobrescreva o da nova.
+        if (columnFetchGenerations[headerKey] === generation) {
+          columnsLoading.value[headerKey] = value
+        }
       },
       useLoading: false
     }
   )
 
+  delete columnAbortControllers[headerKey]
+
   isLoadingFromSeeMore.value = false
 
   if (error) {
+    // Request cancelada intencionalmente (novo fetchColumnsValues chamado): ignora silenciosamente.
+    if (isCancelledError(error)) return
+
     emit('fetch-column-error', error)
 
     columnsWithError.value[headerKey] = true
@@ -682,11 +739,18 @@ function setColumnsPagination () {
     const headerKey = getKeyByHeader(header)
 
     columnsPagination.value[headerKey] = { limit: props.limitPerColumn, offset: 0 }
-    columnsLoading.value[headerKey] = false
+
+    // Inicia como true para exibir skeleton imediatamente, evitando flash de tela vazia
+    // entre o reset e o início das novas requests.
+    columnsLoading.value[headerKey] = true
   })
 }
 
 function fetchColumnsValues () {
+  // Cancela todas as requests em andamento antes de iniciar novas,
+  // evitando resposta de requests antigas sobrescrevendo dados da nova sessão.
+  abortAllColumnRequests()
+
   lazyLoadingKey.value++
 
   reset()
@@ -1080,16 +1144,53 @@ function destroySortable () {
 }
 
 /**
+ * Cancela a request em andamento de uma coluna específica.
+ */
+function abortColumnRequest (headerKey) {
+  columnAbortControllers[headerKey]?.abort()
+  delete columnAbortControllers[headerKey]
+}
+
+/**
+ * Cancela todas as requests de colunas em andamento.
+ * Chamado em onBeforeUnmount e no início de fetchColumnsValues.
+ */
+function abortAllColumnRequests () {
+  /**
+   * Invalida a sessão atual de fetchColumns para que, após as requests visíveis
+   * serem canceladas, a verificação de sessão impeça o início das requests das
+   * colunas ocultas (que ainda não haviam sido disparadas).
+   * Sem isso, fetchColumns passaria na verificação e iniciaria as hidden columns
+   * mesmo após o componente ter iniciado o processo de unmount.
+   */
+  currentFetchColumnsSession++
+
+  Object.keys(columnAbortControllers).forEach(key => {
+    columnAbortControllers[key]?.abort()
+  })
+
+  columnAbortControllers = {}
+}
+
+/**
+ * Verifica se o erro é resultado de um cancelamento intencional de request
+ * (AbortController.abort() via axios ou fetch).
+ */
+function isCancelledError (error) {
+  return error?.code === 'ERR_CANCELED' || error?.name === 'CanceledError' || error?.name === 'AbortError'
+}
+
+/**
  * Transfere um item de uma coluna para outra localmente, sem realizar nenhuma requisição.
  * O item é sempre inserido como primeiro elemento na coluna de destino.
  * Após a transferência, o SortableJS continua funcionando normalmente sobre os elementos
  * do DOM atualizados pelo Vue, sem necessidade de reinicialização.
  *
  * @param {Object} params
- * @param {string|number} params.itemId       - ID do item a ser movido (valor correspondente à prop `itemIdKey`).
+ * @param {string|number} params.itemId - ID do item a ser movido (valor correspondente à prop `itemIdKey`).
  * @param {string|number} params.fromColumnId - ID da coluna de origem (valor correspondente à prop `columnIdKey`).
- * @param {string|number} params.toColumnId   - ID da coluna de destino (valor correspondente à prop `columnIdKey`).
- * @param {Object}        [params.updatedItem]- Dados atualizados do item. Quando informado, sobrescreve o item original na coluna de destino.
+ * @param {string|number} params.toColumnId - ID da coluna de destino (valor correspondente à prop `columnIdKey`).
+ * @param {Object}        [params.updatedItem] - Dados atualizados do item. Quando informado, sobrescreve o item original na coluna de destino.
  * @returns {void}
  */
 function transferItemToColumn ({ itemId, fromColumnId, toColumnId, updatedItem }) {

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -4,11 +4,11 @@
       <div ref="columnsContainer" class="no-wrap q-gutter-md q-pb-xs q-px-lg row">
         <qas-lazy-loading-components :key="lazyLoadingKey" v-model:visible-items="visibleItems" direction="horizontal" placeholder-width="350px" :threshold="0">
           <qas-box v-for="(header, index) in normalizedHeaders" :key="index" :class="getColumnClasses(header)" :style="containerStyle">
-            <qas-header class="ellipsis q-mb-md text-grey-10" v-bind="headerBoxProps">
+            <div class="ellipsis q-mb-md text-grey-10">
               <qas-skeleton v-if="props.skeleton" type="text" use-contrast width="80%" />
 
               <slot v-else :fields="getFieldsByHeader(header)" :header="header" :index="index" name="header-column" />
-            </qas-header>
+            </div>
 
             <pv-board-generator-cards-container ref="columnContainer" class="qas-board-generator__column secondary-scroll" v-bind="getCardsContainerProps(header)">
               <!-- COLUNA COM ERRO -->
@@ -22,7 +22,7 @@
                 </div>
 
                 <div class="text-center">
-                  <qas-btn class="q-mt-md" icon="sym_r_refresh" label="Tentar novamente" :loading="columnsLoading[getKeyByHeader(header)]" @click="fetchColumn(header, true)" />
+                  <qas-btn class="q-mt-md" icon="sym_r_refresh" label="Tentar novamente" :loading="columnsLoading[getKeyByHeader(header)]" @click="handleFetchColumnClick(header)" />
                 </div>
               </div>
 
@@ -34,7 +34,7 @@
                 </qas-lazy-loading-components>
 
                 <div class="full-width justify-center row">
-                  <qas-btn v-if="hasSeeMore(header)" icon="sym_r_add" :label="props.seeMoreButtonLabel" :loading="columnsLoading[getKeyByHeader(header)]" :use-label-on-small-screen="false" variant="tertiary" @click="fetchColumn(header, true)" />
+                  <qas-btn v-if="hasSeeMore(header)" icon="sym_r_add" :label="props.seeMoreButtonLabel" :loading="columnsLoading[getKeyByHeader(header)]" :use-label-on-small-screen="false" variant="tertiary" @click="handleFetchColumnClick(header)" />
 
                   <template v-if="hasSkeletonByHeader(header)">
                     <div class="q-col-gutter-y-sm row">
@@ -69,7 +69,6 @@
 <script setup>
 import PvBoardGeneratorCardsContainer from './private/PvBoardGeneratorCardsContainer.vue'
 import QasSkeleton from '../skeleton/QasSkeleton.vue'
-import QasHeader from '../header/QasHeader.vue'
 import QasCard from '../card/QasCard.vue'
 import QasBox from '../box/QasBox.vue'
 import QasBtn from '../btn/QasBtn.vue'
@@ -109,11 +108,6 @@ const props = defineProps({
   },
 
   results: {
-    type: Object,
-    default: () => ({})
-  },
-
-  headerBoxProps: {
     type: Object,
     default: () => ({})
   },
@@ -178,8 +172,7 @@ const props = defineProps({
   },
 
   skeleton: {
-    type: Boolean,
-    default: false
+    type: Boolean
   },
 
   useDragAndDropX: {
@@ -238,8 +231,13 @@ const columnsLoading = ref({})
 const columnsFieldsModel = ref({})
 const showConfirmDialog = ref(false)
 const isLoadingUpdatePosition = ref(false)
-const isLoadingFromSeeMore = ref(false)
+const hideSkeleton = ref(false)
 const columnsWithError = ref({})
+
+/**
+ * Set de IDs dos itens com update de posição em andamento.
+ * Usamos Set para evitar duplicatas e ter O(1) no has().
+ */
 const updatingPositionItemKeys = ref(new Set())
 
 /**
@@ -374,6 +372,46 @@ const normalizedHeaders = computed(() => {
   return props.headers
 })
 
+const columnsResultsModel = computed({
+  get () {
+    return props.results
+  },
+
+  set (newValues) {
+    emit('update:results', newValues)
+  }
+})
+
+const isDragging = computed(() => draggingCount.value > 0)
+
+const hasColumnsLength = computed(() => !!Object.keys(columnsResultsModel.value).length)
+
+const containerStyle = computed(() => `width: ${props.columnWidth};`)
+
+const hasConfirmDialogProps = computed(() => !!Object.keys(props.confirmDialogProps).length)
+
+const defaultConfirmDialogProps = computed(() => {
+  const defaultProps = {
+    ok: {
+      label: 'Confirmar',
+      onClick: onConfirmDrop.value,
+      loading: isLoadingUpdatePosition.value
+    },
+
+    cancel: {
+      onClick: onCancelDrop.value
+    }
+  }
+
+  return {
+    ...props.confirmDialogProps,
+    ...defaultProps
+  }
+})
+
+// provide
+provide('isDragging', isDragging)
+
 // watchers
 watch(
   () => normalizedHeaders.value,
@@ -403,46 +441,6 @@ onBeforeUnmount(() => {
   destroySortable()
 
   window.removeEventListener('resize', setColumnHeightContainer)
-})
-
-// Computeds
-const columnsResultsModel = computed({
-  get () {
-    return props.results
-  },
-
-  set (newValues) {
-    emit('update:results', newValues)
-  }
-})
-
-const isDragging = computed(() => draggingCount.value > 0)
-
-provide('isDragging', isDragging)
-
-const hasColumnsLength = computed(() => !!Object.keys(columnsResultsModel.value).length)
-
-const containerStyle = computed(() => `width: ${props.columnWidth};`)
-
-const hasConfirmDialogProps = computed(() => !!Object.keys(props.confirmDialogProps).length)
-
-const defaultConfirmDialogProps = computed(() => {
-  const defaultProps = {
-    ok: {
-      label: 'Confirmar',
-      onClick: onConfirmDrop.value,
-      loading: isLoadingUpdatePosition.value
-    },
-
-    cancel: {
-      onClick: onCancelDrop.value
-    }
-  }
-
-  return {
-    ...props.confirmDialogProps,
-    ...defaultProps
-  }
 })
 
 // functions
@@ -552,6 +550,7 @@ async function fetchColumns () {
   if (currentFetchColumnsSession !== mySession) return
 
   const allPromises = [...visibleColumns, ...hiddenColumns]
+  console.log('🚀 ~ fetchColumns ~ allPromises:', allPromises)
 
   const hasAllPromisesSucceeded = allPromises.every(promise => promise.status === 'fulfilled')
   const hasAllPromisesFailed = allPromises.length > 0 && allPromises.every(promise => promise.status === 'rejected')
@@ -572,11 +571,24 @@ async function fetchColumns () {
 }
 
 /*
-* Busca a coluna com base no header recebido.
+* Wrapper para chamadas de fetchColumn originadas de eventos de clique do usuário.
+* fetchColumn relança o erro para que Promise.allSettled em fetchColumns consiga
+* detectar colunas com falha; aqui o erro já foi tratado internamente, portanto
+* é suprimido para evitar o warning "Unhandled error during execution of component
+* event handler" do Vue.
 */
-async function fetchColumn (header, fromSeeMore) {
+function handleFetchColumnClick (header) {
+  fetchColumn(header, true)
+}
+
+/**
+ * Busca a coluna com base no header recebido.
+ *
+ * @param header - payload do header da coluna a ser buscada, exemplo: { date: '2024-02-12', ... }
+ * @param shouldHideSkeleton - flag para controlar se o skeleton de carregamento deve ser ocultado durante a busca
+ */
+async function fetchColumn (header, shouldHideSkeleton) {
   const headerKey = getKeyByHeader(header)
-  console.log('🚀 ~ fetchColumn ~ header:', { headerKey, header, url: `${props.columnUrl}/${headerKey}` })
 
   /**
    * Cancela qualquer request anterior para esta mesma coluna antes de iniciar a nova.
@@ -597,7 +609,7 @@ async function fetchColumn (header, fromSeeMore) {
 
   const { limit, offset } = columnsPagination.value[headerKey] || {}
 
-  isLoadingFromSeeMore.value = fromSeeMore
+  hideSkeleton.value = shouldHideSkeleton
 
   const { data: response, error } = await promiseHandler(
     axios.get(`${props.columnUrl}/${headerKey}`, {
@@ -624,7 +636,7 @@ async function fetchColumn (header, fromSeeMore) {
 
   delete columnAbortControllers[headerKey]
 
-  isLoadingFromSeeMore.value = false
+  hideSkeleton.value = false
 
   if (error) {
     // Request cancelada intencionalmente (novo fetchColumnsValues chamado): ignora silenciosamente.
@@ -1263,7 +1275,7 @@ async function updatePosition ({ newHeaderKey, oldHeaderKey, itemId, event, opti
 
   const isFnUpdatePositionUrl = typeof props.updatePositionUrl === 'function'
 
-  isLoadingFromSeeMore.value = true
+  hideSkeleton.value = true
 
   const url = isFnUpdatePositionUrl
     ? props.updatePositionUrl({ newHeaderKey, oldHeaderKey, itemId })
@@ -1388,7 +1400,7 @@ function transferItemToColumn ({ itemId, fromColumnId, toColumnId, updatedItem }
 function hasSkeletonByHeader (header) {
   const headerKey = getKeyByHeader(header)
 
-  return (props.skeleton || columnsLoading.value[headerKey]) && !isLoadingFromSeeMore.value
+  return (props.skeleton || columnsLoading.value[headerKey]) && !hideSkeleton.value
 }
 
 function getColumnClasses (header) {

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -223,6 +223,7 @@ defineExpose({
   refreshColumn,
   transferItemToColumn,
   removeItemFromList,
+  updateItemInList,
   refetchColumns: fetchColumnsValues
 })
 
@@ -873,7 +874,6 @@ function removeItemFromList ({ headerKey, itemId }) {
    * Busca o item com base em seu ID na lista de itens da coluna
    */
   const itemIndex = columnItemList.findIndex(itemContent => itemContent[props.itemIdKey] === itemId)
-  console.log('🚀 ~ removeItemFromList ~ itemIndex:', itemIndex)
 
   /**
    * Remove o item da listagem com base no index, sendo que preciso subtrair 1 para pegar o index correto
@@ -884,6 +884,16 @@ function removeItemFromList ({ headerKey, itemId }) {
    * Remove o item do count da coluna para não mostrar o botão de "Ver mais¨.
    */
   columnsPagination.value[headerKey].count -= 1
+}
+
+function updateItemInList ({ headerKey, itemId, updatedItem }) {
+  const columnItemList = columnsResultsModel.value[headerKey]
+
+  const itemIndex = columnItemList.findIndex(itemContent => itemContent[props.itemIdKey] === itemId)
+
+  if (!~itemIndex) return
+
+  columnItemList.splice(itemIndex, 1, updatedItem)
 }
 
 /**

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -361,8 +361,7 @@ watch(
     if (isLoadingUpdatePosition.value || !value?.length) return
 
     fetchColumnsValues()
-  },
-  { immediate: true }
+  }
 )
 
 watch(() => columnContainerElements.value, () => {
@@ -372,6 +371,10 @@ watch(() => columnContainerElements.value, () => {
 
 // hooks
 onMounted(() => {
+  if (normalizedHeaders.value.length) {
+    fetchColumnsValues()
+  }
+
   window.addEventListener('resize', setColumnHeightContainer)
 })
 
@@ -748,11 +751,12 @@ function fetchColumnsValues () {
 }
 
 /**
- * Descricao:
+ * Descrição:
  * Exibe o texto quando:
  * - Nao esta carregando a coluna
  * - Nao tem itens na coluna
  * - Nao estou fazendo o drag and drop
+ * - Nao esta exibindo o dialog de confirmação
  *
  * @param {Object} header
  */
@@ -762,7 +766,7 @@ function hasEmptyResultText (header) {
   const headerKey = getKeyByHeader(header)
   const items = getItemsByHeader(header)
 
-  return !columnsLoading.value[headerKey] && !items?.length && !isDragging.value
+  return !columnsLoading.value[headerKey] && !items?.length && !isDragging.value && !showConfirmDialog.value
 }
 
 /*

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -3,12 +3,12 @@
     <qas-grabbable class="qas-board-generator" v-bind="grabbableProps">
       <div ref="columnsContainer" class="no-wrap q-gutter-md q-pb-xs q-px-lg row">
         <qas-lazy-loading-components :key="lazyLoadingKey" v-model:visible-items="visibleItems" direction="horizontal" placeholder-width="350px" :threshold="0">
-          <qas-box v-for="(header, index) in normalizedHeaders" :key="index" :class="getColumnClass(header)" :style="containerStyle">
-            <div class="ellipsis q-mb-md text-grey-10" v-bind="headerBoxProps">
+          <qas-box v-for="(header, index) in normalizedHeaders" :key="index" :class="getColumnClasses(header)" :style="containerStyle">
+            <qas-header class="ellipsis q-mb-md text-grey-10" v-bind="headerBoxProps">
               <qas-skeleton v-if="props.skeleton" type="text" use-contrast width="80%" />
 
               <slot v-else :fields="getFieldsByHeader(header)" :header="header" :index="index" name="header-column" />
-            </div>
+            </qas-header>
 
             <pv-board-generator-cards-container ref="columnContainer" class="qas-board-generator__column secondary-scroll" v-bind="getCardsContainerProps(header)">
               <!-- COLUNA COM ERRO -->
@@ -69,6 +69,7 @@
 <script setup>
 import PvBoardGeneratorCardsContainer from './private/PvBoardGeneratorCardsContainer.vue'
 import QasSkeleton from '../skeleton/QasSkeleton.vue'
+import QasHeader from '../header/QasHeader.vue'
 import QasCard from '../card/QasCard.vue'
 import QasBox from '../box/QasBox.vue'
 import QasBtn from '../btn/QasBtn.vue'
@@ -299,7 +300,10 @@ let currentFetchColumnsSession = 0
 
 /**
  * Estado do smooth scroll horizontal.
- * Acumula o target e interpola suavemente via requestAnimationFrame.
+ * Acumula o target e interpola suavemente via requestAnimationFrame (rAF).
+ *
+ * rAF (requestAnimationFrame) sincroniza a animação com o refresh da tela (~60fps).
+ * Isso evita "saltos" de scroll, tornando o movimento suave e fluido.
  */
 const SMOOTH_SCROLL_LERP = 0.2
 
@@ -342,13 +346,15 @@ const grabbableProps = {
  * Gera cards de skeleton para exibir enquanto carrega os itens da coluna, o mesmo é usado para preencher a coluna
  * quando a prop "skeleton" for true, indicando que é para simular o carregamento.
  */
-const skeletonCards = Array.from({ length: 6 }).map(() => ({
-  skeleton: true,
-  title: '-',
-  expansionProps: { label: '-' },
-  actionsMenuProps: { list: {} },
-  useSelection: true
-}))
+const skeletonCards = Array.from({ length: 6 }).map(() => {
+  return {
+    skeleton: true,
+    title: '-',
+    expansionProps: { label: '-' },
+    actionsMenuProps: { list: {} },
+    useSelection: true
+  }
+})
 
 // computeds
 const columnContainerElements = computed(() => {
@@ -512,7 +518,7 @@ async function fetchColumns () {
   const mySession = ++currentFetchColumnsSession
 
   // Mapeia os índices visíveis para os IDs de coluna correspondentes
-  const visibleKeys = new Set(visibleItems.value.map(i => getKeyByHeader(normalizedHeaders.value[i])))
+  const visibleKeys = new Set(visibleItems.value.map(item => getKeyByHeader(normalizedHeaders.value[item])))
 
   const visibleHeaders = visibleKeys.size
     ? normalizedHeaders.value.filter(header => visibleKeys.has(getKeyByHeader(header)))
@@ -568,8 +574,9 @@ async function fetchColumns () {
 /*
 * Busca a coluna com base no header recebido.
 */
-async function fetchColumn (header, fromSeeMore, setEr) {
+async function fetchColumn (header, fromSeeMore) {
   const headerKey = getKeyByHeader(header)
+  console.log('🚀 ~ fetchColumn ~ header:', { headerKey, header, url: `${props.columnUrl}/${headerKey}` })
 
   /**
    * Cancela qualquer request anterior para esta mesma coluna antes de iniciar a nova.
@@ -593,7 +600,7 @@ async function fetchColumn (header, fromSeeMore, setEr) {
   isLoadingFromSeeMore.value = fromSeeMore
 
   const { data: response, error } = await promiseHandler(
-    axios.get(`${props.columnUrl}/${headerKey}/${setEr ? 'setError' : ''}`, {
+    axios.get(`${props.columnUrl}/${headerKey}`, {
       signal: abortController.signal,
       params: {
         ...props.columnParams,
@@ -759,15 +766,19 @@ function setColumnsPagination () {
 
     columnsPagination.value[headerKey] = { limit: props.limitPerColumn, offset: 0 }
 
-    // Inicia como true para exibir skeleton imediatamente, evitando flash de tela vazia
-    // entre o reset e o início das novas requests.
+    /**
+     * Inicia como true para exibir skeleton imediatamente, evitando flash de tela vazia
+     * entre o reset e o início das novas requests.
+     */
     columnsLoading.value[headerKey] = true
   })
 }
 
 function fetchColumnsValues () {
-  // Cancela todas as requests em andamento antes de iniciar novas,
-  // evitando resposta de requests antigas sobrescrevendo dados da nova sessão.
+  /**
+   * Cancela todas as requests em andamento antes de iniciar novas, evitando resposta de requests
+   * antigas sobrescrevendo dados da nova sessão.
+   */
   abortAllColumnRequests()
 
   lazyLoadingKey.value++
@@ -781,10 +792,10 @@ function fetchColumnsValues () {
 /**
  * Descrição:
  * Exibe o texto quando:
- * - Nao esta carregando a coluna
- * - Nao tem itens na coluna
- * - Nao estou fazendo o drag and drop
- * - Nao esta exibindo o dialog de confirmação
+ * - Não está carregando a coluna
+ * - Não tem itens na coluna
+ * - Não estou fazendo o drag and drop
+ * - Não está exibindo o dialog de confirmação
  *
  * @param {Object} header
  */
@@ -946,7 +957,10 @@ function stopDragging () {
 /**
  * Intercepta cada chamada de scroll do SortableJS.
  * - Scroll vertical (colunas): retorna 'continue' para manter o comportamento nativo.
- * - Scroll horizontal (container do board): aplica smooth scroll via rAF.
+ * - Scroll horizontal (container do board): aplica smooth scroll interpolado via rAF.
+ *
+ * rAF (requestAnimationFrame) sincroniza com o refresh da tela (~60fps),
+ * tornando o scroll suave. Sem rAF, seria um "salto" abrupto.
  */
 function handleSortableScroll (offsetX, offsetY, evt, _touchEvt, scrollEl) {
   // Obtém o container com scroll horizontal (`.qas-grabbable__container`).
@@ -963,9 +977,17 @@ function handleSortableScroll (offsetX, offsetY, evt, _touchEvt, scrollEl) {
 
     smoothScrollTarget = Math.max(0, Math.min(smoothScrollTarget + offsetX, maxScroll))
 
+    // Se não há animação em andamento, inicia uma.
+    // rAF (requestAnimationFrame) agenda a função smoothScrollStep para o próximo frame (~16ms a 60fps).
+
+    /**
+     * Se não há animação em andamento, inicia uma. rAF (requestAnimationFrame) agenda a função smoothScrollStep
+     * para o próximo frame (~16ms a 60fps).
+     */
     if (!smoothScrollRafId) {
       smoothScrollRafId = requestAnimationFrame(smoothScrollStep)
     }
+
     return
   }
 
@@ -994,6 +1016,14 @@ function handleSortableScroll (offsetX, offsetY, evt, _touchEvt, scrollEl) {
 /**
  * Loop de animação que interpola o scrollLeft em direção ao target
  * usando fator de lerp (move 20% da distância restante por frame).
+ *
+ * Funciona assim:
+ * 1. Calcula a diferença entre a posição atual e a posição desejada (target).
+ * 2. Se ainda há diferença significativa, move 20% da distância restante.
+ * 3. Agenda o próximo frame via rAF para continuar a interpolação.
+ * 4. Quando chega perto o suficiente (~0.5px), para a animação.
+ *
+ * Resultado: scroll suave e progressivo, não um "salto" abrupto.
  */
 function smoothScrollStep () {
   smoothScrollRafId = null
@@ -1003,16 +1033,21 @@ function smoothScrollStep () {
   const current = smoothScrollEl.scrollLeft
   const diff = smoothScrollTarget - current
 
+  // Se chegou bem perto do target, para na posição exata.
   if (Math.abs(diff) < 0.5) {
     smoothScrollEl.scrollLeft = smoothScrollTarget
     return
   }
 
+  // Move 20% da distância restante (interpolação suave).
   smoothScrollEl.scrollLeft = current + diff * SMOOTH_SCROLL_LERP
+
+  // Agenda o próximo frame para continuar a animação (chamada recursiva via rAF).
   smoothScrollRafId = requestAnimationFrame(smoothScrollStep)
 }
 
 function resetSmoothScroll () {
+  // Cancela a animação agendada (rAF) para evitar que continue executando após o drag terminar.
   if (smoothScrollRafId) {
     cancelAnimationFrame(smoothScrollRafId)
     smoothScrollRafId = null
@@ -1183,13 +1218,29 @@ function removeItemFromList ({ headerKey, itemId }) {
   columnsPagination.value[headerKey].count -= 1
 }
 
+/**
+ * Substitui um item na lista de uma coluna pelos dados atualizados do servidor.
+ *
+ * 1. Localiza a lista de itens da coluna
+ * 2. Encontra o índice do item usando o itemIdKey como identificador
+ * 3. Se encontrado, altera o item localmente (sem criar nova referência de array)
+ *
+ * @param {Object} params
+ * @param {string} params.headerKey - ID da coluna
+ * @param {string|number} params.itemId - ID do item a atualizar (deve corresponder a props.itemIdKey)
+ * @param {Object} params.updatedItem - Novo objeto do item com dados atualizados
+ *
+ */
 function updateItemInList ({ headerKey, itemId, updatedItem }) {
   const columnItemList = columnsResultsModel.value[headerKey]
 
+  // Encontra o índice do item na lista usando o identificador (itemIdKey)
   const itemIndex = columnItemList.findIndex(itemContent => itemContent[props.itemIdKey] === itemId)
 
+  // Se não encontrar (itemIndex === -1), retorna sem fazer nada
   if (!~itemIndex) return
 
+  // Substitui o item antigo pelo item atualizado na mesma posição
   columnItemList.splice(itemIndex, 1, updatedItem)
 }
 
@@ -1340,7 +1391,7 @@ function hasSkeletonByHeader (header) {
   return (props.skeleton || columnsLoading.value[headerKey]) && !isLoadingFromSeeMore.value
 }
 
-function getColumnClass (header) {
+function getColumnClasses (header) {
   const headerKey = getKeyByHeader(header)
 
   return {

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -6,6 +6,7 @@
           <qas-box v-for="(header, index) in normalizedHeaders" :key="index" :class="getColumnClass(header)" :style="containerStyle">
             <div class="ellipsis q-mb-md text-grey-10" v-bind="headerBoxProps">
               <qas-skeleton v-if="props.skeleton" type="text" use-contrast width="80%" />
+
               <slot v-else :fields="getFieldsByHeader(header)" :header="header" :index="index" name="header-column" />
             </div>
 
@@ -27,8 +28,13 @@
 
               <template v-else>
                 <qas-lazy-loading-components :threshold="0">
-                  <div v-for="item in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item">
+                  <div v-for="(item) in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item">
                     <slot v-if="!props.skeleton" :column-index="index" :fields="getFieldsByHeader(header)" :header="header" :item="item" name="column-item" />
+                    <!-- <qas-card v-if="updatingPositionItemKey === item[props.itemIdKey]" v-bind="skeletonCards.at(0)" :key="item[props.itemIdKey]" class="q-mb-sm" :column-index="index">
+                      <template #default />
+                    </qas-card>
+
+                    <slot v-else-if="!props.skeleton && updatingPositionItemKey !== item[props.itemIdKey]" :column-index="index" :fields="getFieldsByHeader(header)" :header="header" :item="item" name="column-item" /> -->
                   </div>
                 </qas-lazy-loading-components>
 
@@ -184,7 +190,7 @@ const props = defineProps({
   },
 
   updatePositionUrl: {
-    type: String,
+    type: [String, Function],
     default: ''
   },
 
@@ -228,6 +234,7 @@ const isDragging = ref(false)
 const isLoadingUpdatePosition = ref(false)
 const isLoadingFromSeeMore = ref(false)
 const columnsWithError = ref({})
+const updatingPositionItemKey = ref(null)
 
 /**
  * Índices das colunas visíveis no viewport
@@ -826,27 +833,28 @@ function confirmDrop (event) {
  *  itemId: string
  * }}
  */
-function removeItemFromList ({ headerKey, itemId }) {
-  /**
-   * Coluna referente ao model de resultado
-   */
-  const columnItemList = columnsResultsModel.value[headerKey]
+// function removeItemFromList ({ headerKey, itemId }) {
+//   /**
+//    * Coluna referente ao model de resultado
+//    */
+//   const columnItemList = columnsResultsModel.value[headerKey]
 
-  /**
-   * Busca o item com base em seu ID na lista de itens da coluna
-   */
-  const itemIndex = columnItemList.findIndex(itemContent => itemContent[props.itemIdKey] === itemId)
+//   /**
+//    * Busca o item com base em seu ID na lista de itens da coluna
+//    */
+//   const itemIndex = columnItemList.findIndex(itemContent => itemContent[props.itemIdKey] === itemId)
+//   console.log('🚀 ~ removeItemFromList ~ itemIndex:', itemIndex)
 
-  /**
-   * Remove o item da listagem com base no index, sendo que preciso subtrair 1 para pegar o index correto
-   */
-  columnItemList.splice(itemIndex, 1)
+//   /**
+//    * Remove o item da listagem com base no index, sendo que preciso subtrair 1 para pegar o index correto
+//    */
+//   columnItemList.splice(itemIndex, 1)
 
-  /**
-   * Remove o item do count da coluna para não mostrar o botão de "Ver mais¨.
-   */
-  columnsPagination.value[headerKey].count -= 1
-}
+//   /**
+//    * Remove o item do count da coluna para não mostrar o botão de "Ver mais¨.
+//    */
+//   columnsPagination.value[headerKey].count -= 1
+// }
 
 /**
  * Método que realiza a request de update
@@ -865,8 +873,18 @@ async function updatePosition ({ newHeaderKey, oldHeaderKey, itemId, event }) {
     ...props.updatePositionParams
   }
 
+  updatingPositionItemKey.value = itemId
+
+  const isFnUpdatePositionUrl = typeof props.updatePositionUrl === 'function'
+
+  isLoadingFromSeeMore.value = true
+
+  const url = isFnUpdatePositionUrl
+    ? props.updatePositionUrl({ newHeaderKey, oldHeaderKey, itemId })
+    : `${props.updatePositionUrl}/${itemId}/update-position`
+
   const { data, error } = await promiseHandler(
-    axios.patch(`${props.updatePositionUrl}/${itemId}/update-position`, params),
+    axios.patch(url, params),
     {
       errorMessage: 'Ocorreu um erro ao atualizar a posição de seu item.',
       useLoading: false,
@@ -878,6 +896,8 @@ async function updatePosition ({ newHeaderKey, oldHeaderKey, itemId, event }) {
     }
   )
 
+  updatingPositionItemKey.value = null
+
   if (error) {
     onCancelDrop.value()
 
@@ -886,9 +906,9 @@ async function updatePosition ({ newHeaderKey, oldHeaderKey, itemId, event }) {
     return
   }
 
-  removeItemFromList({ headerKey: oldHeaderKey, itemId })
+  // removeItemFromList({ headerKey: oldHeaderKey, itemId })
 
-  setItemList({ headerKey: newHeaderKey, data: data.data, index: event.newIndex })
+  // setItemList({ headerKey: newHeaderKey, data: data.data, index: event.newIndex })
 
   isUpdatingPosition.value = true
 
@@ -899,17 +919,19 @@ async function updatePosition ({ newHeaderKey, oldHeaderKey, itemId, event }) {
   emit('update-success', data.data)
 }
 
-function setItemList ({ headerKey, data, index }) {
-  /**
-   * Coluna referente ao model de resultado
-   */
-  const columnItemList = columnsResultsModel.value[headerKey]
+// function setItemList ({ headerKey, data, index }) {
+//   console.log('🚀 ~ setItemList ~ { headerKey, data, index }:', { headerKey, data, index })
+//   /**
+//    * Coluna referente ao model de resultado
+//    */
+//   const columnItemList = columnsResultsModel.value[headerKey]
 
-  /**
-   * Adiciona o item na posição do event escolhido.
-   */
-  columnItemList.splice(index, 0, data.result)
-}
+//   /**
+//    * Adiciona o item na posição do event escolhido.
+//    */
+//   columnItemList.splice(index, 1, data.result)
+//   console.log('🚀 ~ setItemList ~ columnsResultsModel.value[headerKey]:', columnsResultsModel.value[headerKey])
+// }
 
 function destroySortable () {
   sortableInstances.value.forEach(sortable => sortable.destroy())

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -308,6 +308,16 @@ let columnAbortControllers = {}
 let currentFetchColumnsSession = 0
 
 /**
+ * Estado do smooth scroll horizontal.
+ * Acumula o target e interpola suavemente via requestAnimationFrame.
+ */
+const SMOOTH_SCROLL_LERP = 0.2
+
+let smoothScrollTarget = 0
+let smoothScrollRafId = null
+let smoothScrollEl = null
+
+/**
  * Geração por coluna para invalidar callbacks onLoading de requests canceladas.
  * Evita que o onLoading(false) de uma request cancelada sobrescreva o estado da nova request.
  */
@@ -823,7 +833,12 @@ function setSortable (element, index) {
     delay: 50,
     delayOnTouchOnly: true,
     emptyInsertThreshold: 0,
-    filter: '[data-disable-drag="true"]'
+    filter: '[data-disable-drag="true"]',
+    scrollSensitivity: 200,
+    scrollSpeed: 60,
+    bubbleScroll: true,
+    forceAutoScrollFallback: true,
+    scrollFn: handleSortableScroll
   }
 
   /**
@@ -885,6 +900,67 @@ function startDragging () {
 
 function stopDragging () {
   draggingCount.value = Math.max(0, draggingCount.value - 1)
+  resetSmoothScroll()
+}
+
+/**
+ * Intercepta cada chamada de scroll do SortableJS.
+ * - Scroll vertical (colunas): retorna 'continue' para manter o comportamento nativo.
+ * - Scroll horizontal (container do board): aplica smooth scroll via rAF.
+ */
+function handleSortableScroll (offsetX, _offsetY, _evt, _touchEvt, scrollEl) {
+  // Obtém o container com scroll horizontal (`.qas-grabbable__container`).
+  const horizontalContainer = columnContainerElements.value[0]?.closest('.qas-grabbable__container')
+
+  // Acumula o offset no target e inicia a interpolação via rAF.
+  if (scrollEl === horizontalContainer && offsetX) {
+    if (smoothScrollEl !== scrollEl) {
+      smoothScrollTarget = scrollEl.scrollLeft
+      smoothScrollEl = scrollEl
+    }
+
+    const maxScroll = scrollEl.scrollWidth - scrollEl.clientWidth
+
+    smoothScrollTarget = Math.max(0, Math.min(smoothScrollTarget + offsetX, maxScroll))
+
+    if (!smoothScrollRafId) {
+      smoothScrollRafId = requestAnimationFrame(smoothScrollStep)
+    }
+    return
+  }
+
+  return 'continue'
+}
+
+/**
+ * Loop de animação que interpola o scrollLeft em direção ao target
+ * usando fator de lerp (move 20% da distância restante por frame).
+ */
+function smoothScrollStep () {
+  smoothScrollRafId = null
+
+  if (!smoothScrollEl) return
+
+  const current = smoothScrollEl.scrollLeft
+  const diff = smoothScrollTarget - current
+
+  if (Math.abs(diff) < 0.5) {
+    smoothScrollEl.scrollLeft = smoothScrollTarget
+    return
+  }
+
+  smoothScrollEl.scrollLeft = current + diff * SMOOTH_SCROLL_LERP
+  smoothScrollRafId = requestAnimationFrame(smoothScrollStep)
+}
+
+function resetSmoothScroll () {
+  if (smoothScrollRafId) {
+    cancelAnimationFrame(smoothScrollRafId)
+    smoothScrollRafId = null
+  }
+
+  smoothScrollEl = null
+  smoothScrollTarget = 0
 }
 
 /**

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -28,7 +28,7 @@
               <template v-else>
                 <qas-lazy-loading-components :threshold="0">
                   <div v-for="item in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item">
-                    <slot v-if="!props.skeleton" :column-index="index" :fields="getFieldsByHeader(header)" :item="item" name="column-item" />
+                    <slot v-if="!props.skeleton" :column-index="index" :fields="getFieldsByHeader(header)" :header="header" :item="item" name="column-item" />
                   </div>
                 </qas-lazy-loading-components>
 
@@ -209,7 +209,7 @@ const emit = defineEmits([
   'update-error'
 ])
 
-defineExpose({ fetchColumns, fetchColumn, reset, cancelDrop })
+defineExpose({ fetchColumns, fetchColumn, reset, cancelDrop, refreshColumn })
 
 // Inject
 const axios = inject('axios')
@@ -541,6 +541,15 @@ async function fetchColumn (header, fromSeeMore, setEr) {
   emit('fetch-column-success', { response, header })
 }
 
+function refreshColumn (header) {
+  const headerKey = getKeyByHeader(header)
+
+  columnsResultsModel.value[headerKey] = []
+  columnsPagination.value[headerKey] = { limit: props.limitPerColumn, offset: 0 }
+
+  fetchColumn(header)
+}
+
 /*
 * Mergeia os options antigos com os novos de cada field.
 */
@@ -694,6 +703,9 @@ function handleElementsList () {
 function setSortable (element, index) {
   const defaultSortableConfig = {
     animation: 500,
+    group: 'shared',
+    ghostClass: 'ghost',
+    sort: false,
     swapThreshold: 1,
     delay: 50,
     delayOnTouchOnly: true,

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -275,6 +275,13 @@ const onConfirmDrop = ref(() => {})
  */
 const isUpdatingPosition = ref(false)
 
+/**
+ * Chave da coluna de origem durante um drag and drop confirmado.
+ * Usada para exibir o texto "Não há itens" imediatamente na coluna de origem
+ * antes da requisição de updatePosition ser finalizada.
+ */
+const draggingFromHeaderKey = ref(null)
+
 // consts
 const hasDragAndDrop = !!props.useDragAndDropX || !!props.useDragAndDropY
 
@@ -690,7 +697,17 @@ function fetchColumnsValues () {
 function hasEmptyResultText (header) {
   if (props.skeleton) return false
 
-  return !columnsLoading.value[getKeyByHeader(header)] && !getItemsByHeader(header)?.length && !isDragging.value
+  const headerKey = getKeyByHeader(header)
+  const items = getItemsByHeader(header)
+
+  // Durante drag and drop, exibe o texto imediatamente na coluna de origem
+  // enquanto a requisição de updatePosition ainda está em andamento
+  // (o item ainda está no model, mas já foi movido visualmente pelo SortableJS)
+  if (draggingFromHeaderKey.value === headerKey && items?.length <= 1) {
+    return !columnsLoading.value[headerKey]
+  }
+
+  return !columnsLoading.value[headerKey] && !items?.length && !isDragging.value
 }
 
 /*
@@ -818,6 +835,8 @@ function closeConfirmDialog () {
  * @param {event} event
  */
 function cancelDrop (event) {
+  draggingFromHeaderKey.value = null
+
   /**
    * Insere na posição antiga que pertencia (event.oldIndex) dentro do seu antigo pai (event.from)
    */
@@ -854,6 +873,8 @@ function confirmDrop (event) {
   const { headerKey: newHeaderKey } = to.dataset
   const { headerKey: oldHeaderKey } = from.dataset
 
+  draggingFromHeaderKey.value = oldHeaderKey
+
   updatePosition({ newHeaderKey, oldHeaderKey, itemId, event })
 }
 
@@ -876,9 +897,13 @@ function removeItemFromList ({ headerKey, itemId }) {
   const itemIndex = columnItemList.findIndex(itemContent => itemContent[props.itemIdKey] === itemId)
 
   /**
-   * Remove o item da listagem com base no index, sendo que preciso subtrair 1 para pegar o index correto
+   * Cria uma nova referência de array para garantir que o Vue detecte a mudança de estado,
+   * mesmo quando o array é marcado com markRaw (que não rastreia mutações in-place).
    */
-  columnItemList.splice(itemIndex, 1)
+  const updatedList = [...columnItemList]
+  updatedList.splice(itemIndex, 1)
+
+  columnsResultsModel.value[headerKey] = props.useMarkRaw ? markRaw(updatedList) : updatedList
 
   /**
    * Remove o item do count da coluna para não mostrar o botão de "Ver mais¨.
@@ -981,6 +1006,8 @@ async function updatePosition ({ newHeaderKey, oldHeaderKey, itemId, event }) {
   toggleIsDragging()
 
   closeConfirmDialog()
+
+  draggingFromHeaderKey.value = null
 
   emit('update-success', data.data)
 }

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -230,7 +230,7 @@ defineExpose({
 // Inject
 const axios = inject('axios')
 
-const isFetchSuccessHeader = inject('isFetchListSucceeded', false)
+// const isFetchSuccessHeader = inject('isFetchListSucceeded', false)
 
 const isInsideListView = inject('isListView', false)
 
@@ -324,26 +324,27 @@ const normalizedHeaders = computed(() => {
 })
 
 // Watchers
-watch(
-  () => isFetchSuccessHeader.value,
-  value => {
-    /**
-     * isFetchSuccessHeader é uma variável que pego do listView por inject/provide, no qual caso eu faça request do header e dê sucesso, eu chamo as demais funções.
-     * Valido se não houve sucesso na requisição do header ou se não é uma atualização de posição, para assim não bater novamente nas colunas apenas no header.
-     */
-    if (!value || isUpdatingPosition.value) return
+// watch(
+//   () => isFetchSuccessHeader.value,
+//   value => {
+//     /**
+//      * isFetchSuccessHeader é uma variável que pego do listView por inject/provide, no qual caso eu faça request do header e dê sucesso, eu chamo as demais funções.
+//      * Valido se não houve sucesso na requisição do header ou se não é uma atualização de posição, para assim não bater novamente nas colunas apenas no header.
+//      */
+//     if (!value || isUpdatingPosition.value) return
 
-    fetchColumnsValues()
-  }
-)
+//     fetchColumnsValues()
+//   }
+// )
 
 watch(
   () => normalizedHeaders.value,
-  () => {
-    if (isUpdatingPosition.value) return
+  value => {
+    if (isLoadingUpdatePosition.value || !value?.length) return
 
-    isUpdatingPosition.value = false
-  }
+    fetchColumnsValues()
+  },
+  { immediate: true }
 )
 
 watch(() => columnContainerElements.value, () => {

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -29,11 +29,6 @@
               <template v-else>
                 <qas-lazy-loading-components :threshold="0">
                   <div v-for="(item) in getItemsByHeader(header)" :id="item[props.itemIdKey]" :key="item[props.itemIdKey]" class="qas-board-generator__item" :data-disable-drag="updatingPositionItemKeys.has(item[props.itemIdKey])">
-                    <!-- <slot v-if="!props.skeleton" :column-index="index" :fields="getFieldsByHeader(header)" :header="header" :item="item" name="column-item" /> -->
-                    <!-- <qas-card v-if="updatingPositionItemKey === item[props.itemIdKey]" v-bind="skeletonCards.at(0)" :key="item[props.itemIdKey]" class="q-mb-sm" :column-index="index">
-                      <template #default />
-                    </qas-card> -->
-
                     <slot v-if="!props.skeleton" :column-index="index" :fields="getFieldsByHeader(header)" :header="header" :is-updating-position="updatingPositionItemKeys.has(item[props.itemIdKey])" :item="item" name="column-item" />
                   </div>
                 </qas-lazy-loading-components>

--- a/ui/src/components/board-generator/QasBoardGenerator.yml
+++ b/ui/src/components/board-generator/QasBoardGenerator.yml
@@ -219,3 +219,26 @@ methods:
 
   'fetchColumn: (header) => void':
     desc: Busca uma coluna específica com base no header fornecido.
+
+  'transferItemToColumn: ({ itemId, fromColumnId, toColumnId, updatedItem? }) => void':
+    desc: |
+      Transfere um item de uma coluna para outra localmente, sem realizar nenhuma requisição.
+      O item é sempre inserido como primeiro elemento na coluna de destino.
+      Após a transferência, o SortableJS continua funcionando normalmente sobre os elementos do DOM atualizados pelo Vue.
+    params:
+      itemId:
+        desc: ID do item a ser movido (valor correspondente à prop `item-id-key`).
+        type: String | Number
+        required: true
+      fromColumnId:
+        desc: ID da coluna de origem (valor correspondente à prop `column-id-key`).
+        type: String | Number
+        required: true
+      toColumnId:
+        desc: ID da coluna de destino (valor correspondente à prop `column-id-key`).
+        type: String | Number
+        required: true
+      updatedItem:
+        desc: Dados atualizados do item. Quando informado, sobrescreve o item original na coluna de destino.
+        type: Object
+        required: false

--- a/ui/src/components/board-generator/QasBoardGenerator.yml
+++ b/ui/src/components/board-generator/QasBoardGenerator.yml
@@ -97,8 +97,8 @@ props:
     type: Number
     default: 12
 
-  use-mark-raw:
-    desc: Define se os valores dos itens das colunas irão ser atribuídos utilizando o "markRaw", onde somente a primeira camada do model será reativa. (https://vuejs.org/api/reactivity-advanced.html#markraw)
+  skeleton:
+    desc: Exibe o estado de esqueleto de carregamento das colunas. Enquanto `true`, cada coluna renderiza cards fictícios no lugar dos itens reais.
     type: Boolean
     default: true
 
@@ -150,10 +150,25 @@ slots:
   column-item:
     desc: Slot para acessar o item da coluna.
     scope:
+      column-index:
+        desc: Índice da coluna atual.
+        type: Number
+        default: 0
+
       fields:
         desc: Fields referente à coluna atual do template.
         type: Object
         default: {}
+
+      header:
+        desc: Informações do header da coluna atual.
+        type: Object
+        default: {}
+
+      is-updating-position:
+        desc: Indica se o item está sendo atualizado via drag-and-drop (aguardando retorno da API de update).
+        type: Boolean
+        default: false
 
       item:
         desc: Informações de cada item da coluna que foi buscado através da API.
@@ -219,6 +234,45 @@ methods:
 
   'fetchColumn: (header) => void':
     desc: Busca uma coluna específica com base no header fornecido.
+
+  'refreshColumn: (header) => void':
+    desc: Reinicia a paginação da coluna e refaz a busca, substituindo completamente os itens existentes.
+    params:
+      header:
+        desc: Header da coluna a ser recarregada (mesmo formato da prop `headers`).
+        type: Object
+        required: true
+
+  'removeItemFromList: ({ headerKey, itemId }) => void':
+    desc: Remove um item da lista de uma coluna localmente, sem realizar nenhuma requisição. Também decrementa o contador de paginação.
+    params:
+      headerKey:
+        desc: Chave identificadora da coluna de origem (valor correspondente à prop `column-id-key`).
+        type: String | Number
+        required: true
+      itemId:
+        desc: ID do item a ser removido (valor correspondente à prop `item-id-key`).
+        type: String | Number
+        required: true
+
+  'updateItemInList: ({ headerKey, itemId, updatedItem }) => void':
+    desc: Substitui os dados de um item existente em uma coluna localmente, sem realizar nenhuma requisição.
+    params:
+      headerKey:
+        desc: Chave identificadora da coluna (valor correspondente à prop `column-id-key`).
+        type: String | Number
+        required: true
+      itemId:
+        desc: ID do item a ser atualizado (valor correspondente à prop `item-id-key`).
+        type: String | Number
+        required: true
+      updatedItem:
+        desc: Dados atualizados que substituirão o item original.
+        type: Object
+        required: true
+
+  'refetchColumns: () => void':
+    desc: Alias de `fetchColumns`. Busca novamente todas as colunas com base nos headers fornecidos.
 
   'transferItemToColumn: ({ itemId, fromColumnId, toColumnId, updatedItem? }) => void':
     desc: |

--- a/ui/src/components/board-generator/private/PvBoardGeneratorCardsContainer.vue
+++ b/ui/src/components/board-generator/private/PvBoardGeneratorCardsContainer.vue
@@ -5,7 +5,6 @@
 </template>
 
 <script setup>
-
 import setScrollGradient from '../../../helpers/set-scroll-gradient'
 
 import { ref, onMounted, onBeforeUnmount } from 'vue'

--- a/ui/src/components/board-generator/private/PvBoardGeneratorCardsContainer.vue
+++ b/ui/src/components/board-generator/private/PvBoardGeneratorCardsContainer.vue
@@ -10,7 +10,7 @@ import setScrollGradient from '../../../helpers/set-scroll-gradient'
 
 import { ref, onMounted, onBeforeUnmount } from 'vue'
 
-defineOptions({ name: 'PvBoardGeneratorColumn' })
+defineOptions({ name: 'PvBoardGeneratorCardsContainer' })
 
 // refs
 const columnContainer = ref(null)

--- a/ui/src/components/board-generator/private/PvBoardGeneratorColumn.vue
+++ b/ui/src/components/board-generator/private/PvBoardGeneratorColumn.vue
@@ -15,8 +15,6 @@ defineOptions({ name: 'PvBoardGeneratorColumn' })
 // refs
 const columnContainer = ref(null)
 
-console.log('PvBoardGeneratorColumn rendered')
-
 // consts
 const { initializeScrollGradient, removeScrollGradient } = setScrollGradient({
   styles: { gradientLevel: 2 }

--- a/ui/src/components/board-generator/private/PvBoardGeneratorColumn.vue
+++ b/ui/src/components/board-generator/private/PvBoardGeneratorColumn.vue
@@ -1,0 +1,28 @@
+<template>
+  <div ref="columnContainer">
+    <slot />
+  </div>
+</template>
+
+<script setup>
+
+import setScrollGradient from '../../../helpers/set-scroll-gradient'
+
+import { ref, onMounted, onBeforeUnmount } from 'vue'
+
+defineOptions({ name: 'PvBoardGeneratorColumn' })
+
+// refs
+const columnContainer = ref(null)
+
+console.log('PvBoardGeneratorColumn rendered')
+
+// consts
+const { initializeScrollGradient, removeScrollGradient } = setScrollGradient({
+  styles: { gradientLevel: 2 }
+})
+
+// hooks
+onMounted(() => initializeScrollGradient(columnContainer.value))
+onBeforeUnmount(() => removeScrollGradient(columnContainer.value))
+</script>

--- a/ui/src/components/btn/QasBtn.vue
+++ b/ui/src/components/btn/QasBtn.vue
@@ -10,7 +10,7 @@
 
       <q-icon v-if="hasIcon" :class="iconClasses" :name="props.icon" />
 
-      <div v-if="showLabel" :class="labelClasses">
+      <div v-if="showLabel" class="qas-btn__label" :class="labelClasses">
         {{ props.label }}
       </div>
 
@@ -112,6 +112,10 @@ const props = defineProps({
   useHoverOnWhiteColor: {
     default: true,
     type: Boolean
+  },
+
+  useMagicAiColor: {
+    type: Boolean
   }
 })
 
@@ -208,6 +212,9 @@ const classes = computed(() => {
 
       // loading
       'qas-btn--loading': props.loading,
+
+      // magic ai
+      'qas-btn--magic-ai': props.useMagicAiColor,
 
       // ellipsis
       'full-width': props.useEllipsis

--- a/ui/src/components/btn/QasBtn.yml
+++ b/ui/src/components/btn/QasBtn.yml
@@ -64,6 +64,11 @@ props:
     desc: Texto do tooltip que aparecerá ao passar o mouse sobre o botão.
     type: String
 
+  use-magic-ai-color:
+    desc: Aplica o estilo de cores de inteligência artificial (magic AI) ao botão, usando um gradiente como cor principal. O comportamento varia conforme a variante do botão. Na variante "primary", o gradiente substitui a cor de fundo. Na "secondary", o gradiente é aplicado na cor do texto e na borda. Na "tertiary", o gradiente é aplicado apenas na cor do texto. O hover em todas as variantes utiliza a cor "$secondary-contrast".
+    default: false
+    type: Boolean
+
   variant:
     desc: Variantes do botão, que define para qual comportamento o botão será usado, podendo ser "primary", "secondary" ou "tertiary".
     default: tertiary

--- a/ui/src/components/card/QasCard.vue
+++ b/ui/src/components/card/QasCard.vue
@@ -34,6 +34,7 @@
 
         <div class="qas-card__content relative-position" :class="contentClasses">
           <qas-skeleton v-if="props.skeleton" height="100px" />
+
           <slot v-else name="default" />
         </div>
 

--- a/ui/src/components/card/QasCard.vue
+++ b/ui/src/components/card/QasCard.vue
@@ -33,9 +33,8 @@
         </header>
 
         <div class="qas-card__content relative-position" :class="contentClasses">
-          <qas-skeleton v-if="props.skeleton" use-overlay />
-
-          <slot name="default" />
+          <qas-skeleton v-if="props.skeleton" height="100px" />
+          <slot v-else name="default" />
         </div>
 
         <div class="full-width q-mt-auto">

--- a/ui/src/components/dialog/QasDialog.vue
+++ b/ui/src/components/dialog/QasDialog.vue
@@ -5,10 +5,8 @@
         <slot name="header">
           <div class="items-center justify-between row">
             <qas-label data-cy="dialog-title" :label="props.card.title" margin="none">
-              <slot name="title"></slot>
+              <slot name="title" />
             </qas-label>
-            <!-- <slot name="title">
-            </slot> -->
 
             <qas-btn v-if="isInfoDialog" v-close-popup color="grey-10" data-cy="dialog-close-btn" icon="sym_r_close" variant="tertiary" />
           </div>

--- a/ui/src/components/dialog/QasDialog.vue
+++ b/ui/src/components/dialog/QasDialog.vue
@@ -4,7 +4,11 @@
       <header v-if="hasHeader" class="q-mb-md">
         <slot name="header">
           <div class="items-center justify-between row">
-            <qas-label data-cy="dialog-title" :label="props.card.title" margin="none" />
+            <qas-label data-cy="dialog-title" :label="props.card.title" margin="none">
+              <slot name="title"></slot>
+            </qas-label>
+            <!-- <slot name="title">
+            </slot> -->
 
             <qas-btn v-if="isInfoDialog" v-close-popup color="grey-10" data-cy="dialog-close-btn" icon="sym_r_close" variant="tertiary" />
           </div>

--- a/ui/src/components/dialog/QasDialog.yml
+++ b/ui/src/components/dialog/QasDialog.yml
@@ -111,6 +111,9 @@ selectors:
     desc: Seletor do botão de confirmar do componente.
     examples: ['data-cy="dialog-ok-btn"']
 
+  title:
+    desc: Slot para inserir conteúdo adicional ao lado do título do card do dialog.
+
   dialog-title:
     desc: Seletor do título do componente.
     examples: ['data-cy="dialog-title"']

--- a/ui/src/components/lazy-loading-components/QasLazyLoadingComponents.vue
+++ b/ui/src/components/lazy-loading-components/QasLazyLoadingComponents.vue
@@ -30,6 +30,8 @@ import { ref, onMounted, onBeforeUnmount, useSlots, nextTick, watch } from 'vue'
 
 defineOptions({ name: 'QasLazyLoadingComponents' })
 
+// const emit = defineEmits(['update:visibleItems'])
+
 const props = defineProps({
   // Porcentagem de visibilidade necessária para ativar (0.0 a 1.0)
   threshold: {
@@ -62,6 +64,9 @@ const props = defineProps({
     default: '300px'
   }
 })
+
+// models
+const visibleItemsModel = defineModel('visibleItems', { type: Array, default: () => [] })
 
 // refs
 /**
@@ -152,6 +157,9 @@ function createObserver () {
 
         // Para de observar - componente já foi renderizado
         observer.unobserve(entry.target)
+
+        // Emite os índices atualmente visíveis
+        visibleItemsModel.value = Array.from(visibleItems.value)
       })
     },
     {

--- a/ui/src/components/lazy-loading-components/QasLazyLoadingComponents.vue
+++ b/ui/src/components/lazy-loading-components/QasLazyLoadingComponents.vue
@@ -30,8 +30,6 @@ import { ref, onMounted, onBeforeUnmount, useSlots, nextTick, watch } from 'vue'
 
 defineOptions({ name: 'QasLazyLoadingComponents' })
 
-// const emit = defineEmits(['update:visibleItems'])
-
 const props = defineProps({
   // Porcentagem de visibilidade necessária para ativar (0.0 a 1.0)
   threshold: {

--- a/ui/src/components/lazy-loading-components/QasLazyLoadingComponents.vue
+++ b/ui/src/components/lazy-loading-components/QasLazyLoadingComponents.vue
@@ -31,32 +31,27 @@ import { ref, onMounted, onBeforeUnmount, useSlots, nextTick, watch } from 'vue'
 defineOptions({ name: 'QasLazyLoadingComponents' })
 
 const props = defineProps({
-  // Porcentagem de visibilidade necessária para ativar (0.0 a 1.0)
   threshold: {
     type: Number,
     default: 0.1 // 10% visível
   },
 
-  // Margem extra ao redor do viewport para pré-carregamento
   rootMargin: {
     type: String,
     default: '0px'
   },
 
-  // Direção do scroll: 'vertical' (padrão) ou 'horizontal'
   direction: {
     type: String,
     default: 'vertical',
     validator: value => ['vertical', 'horizontal'].includes(value)
   },
 
-  // Altura dos placeholders antes de carregar (usado em direction='vertical')
   placeholderHeight: {
     type: String,
     default: '500px'
   },
 
-  // Largura dos placeholders antes de carregar (usado em direction='horizontal')
   placeholderWidth: {
     type: String,
     default: '300px'

--- a/ui/src/components/lazy-loading-components/QasLazyLoadingComponents.vue
+++ b/ui/src/components/lazy-loading-components/QasLazyLoadingComponents.vue
@@ -20,7 +20,6 @@
       <div
         v-else
         :ref="element => setPlaceholderRef(element, index)"
-        :style="{ height: placeholderHeight }"
       />
     </transition>
   </template>
@@ -44,10 +43,23 @@ const props = defineProps({
     default: '0px'
   },
 
-  // Altura dos placeholders antes de carregar
+  // Direção do scroll: 'vertical' (padrão) ou 'horizontal'
+  direction: {
+    type: String,
+    default: 'vertical',
+    validator: value => ['vertical', 'horizontal'].includes(value)
+  },
+
+  // Altura dos placeholders antes de carregar (usado em direction='vertical')
   placeholderHeight: {
     type: String,
     default: '500px'
+  },
+
+  // Largura dos placeholders antes de carregar (usado em direction='horizontal')
+  placeholderWidth: {
+    type: String,
+    default: '300px'
   }
 })
 
@@ -229,10 +241,21 @@ function setPlaceholderRef (element, index) {
 
   placeholderRefs.set(index, element)
 
-  /**
-   * Define a altura do placeholder com base no atributo "data-placeholder-height" caso queira customizar pra
-   * o elemento específico, e não o definido na prop placeholderHeight.
-   */
-  element.style.height = items.value[index].props?.['data-placeholder-height'] || props.placeholderHeight
+  const itemProps = items.value[index].props
+
+  if (props.direction === 'horizontal') {
+    /**
+     * Define a largura do placeholder com base no atributo "data-placeholder-width" caso queira customizar
+     * para o elemento específico, e não o definido na prop placeholderWidth.
+     */
+    element.style.width = itemProps?.['data-placeholder-width'] || props.placeholderWidth
+    element.style.flexShrink = '0'
+  } else {
+    /**
+     * Define a altura do placeholder com base no atributo "data-placeholder-height" caso queira customizar
+     * para o elemento específico, e não o definido na prop placeholderHeight.
+     */
+    element.style.height = itemProps?.['data-placeholder-height'] || props.placeholderHeight
+  }
 }
 </script>

--- a/ui/src/components/lazy-loading-components/QasLazyLoadingComponents.yml
+++ b/ui/src/components/lazy-loading-components/QasLazyLoadingComponents.yml
@@ -4,21 +4,46 @@ meta:
   desc: Componente para carregar elementos do slot somente quando ficam visíveis na viewport, otimizando performance da página.
 
 props:
-  threshold:
-    desc: Threshold do IntersectionObserver (0 = aparece um pouco, 1 = totalmente visível)
-    default: 0.1
-    type: Number
-  
+  direction:
+    desc: Direção do scroll e do lazy loading. Use `vertical` (padrão) para listas de rolagem vertical e `horizontal` para listas de rolagem horizontal.
+    type: String
+    default: vertical
+    values: vertical | horizontal
+
+  placeholder-height:
+    desc: Altura do placeholder exibido enquanto o elemento não está visível (usado quando `direction` é `vertical`).
+    default: '500px'
+    type: String
+
+  placeholder-width:
+    desc: Largura do placeholder exibido enquanto o elemento não está visível (usado quando `direction` é `horizontal`).
+    default: '300px'
+    type: String
+
   root-margin:
     desc: Margem extra ao redor do viewport para pré-carregamento
     default: '0px'
     type: String
 
-  placeholder-height:
-    desc: Altura do placeholder exibido enquanto o elemento não está visível
-    default: '500px'
-    type: String
+  threshold:
+    desc: Threshold do IntersectionObserver (0 = aparece um pouco, 1 = totalmente visível)
+    default: 0.1
+    type: Number
+
+  visible-items:
+    desc: Expõe os índices (0-based) dos itens atualmente visíveis na viewport. Útil para otimizar renders e priorizar carregamento de dados.
+    type: Array
+    default: []
+    model: true
 
 slots:
   default:
     desc: Elementos/componentes que serão carregados conforme ficam visíveis, onde cada elemento irmão dentro do slot será tratado individualmente para o lazy loading.
+
+events:
+  '@update:visible-items -> function(value)':
+    desc: Dispara toda vez que os índices dos itens visíveis são atualizados, também utilizado para v-model:visible-items.
+    params:
+      value:
+        desc: Array de índices (0-based) dos itens atualmente visíveis na viewport.
+        type: Array

--- a/ui/src/components/lazy-loading-components/QasLazyLoadingComponents.yml
+++ b/ui/src/components/lazy-loading-components/QasLazyLoadingComponents.yml
@@ -31,7 +31,7 @@ props:
     type: Number
 
   visible-items:
-    desc: Expõe os índices (0-based) dos itens atualmente visíveis na viewport. Útil para otimizar renders e priorizar carregamento de dados.
+    desc: Expõe os índices dos itens atualmente visíveis na viewport. Útil para otimizar renders e priorizar carregamento de dados.
     type: Array
     default: []
     model: true
@@ -45,5 +45,5 @@ events:
     desc: Dispara toda vez que os índices dos itens visíveis são atualizados, também utilizado para v-model:visible-items.
     params:
       value:
-        desc: Array de índices (0-based) dos itens atualmente visíveis na viewport.
+        desc: Array de índices dos itens atualmente visíveis na viewport.
         type: Array

--- a/ui/src/components/list-view/QasListView.vue
+++ b/ui/src/components/list-view/QasListView.vue
@@ -164,7 +164,7 @@ export default {
      * automaticamente.
      */
     hasDeleteEventListener () {
-      return this.useAutoHandleOnDelete || this.useAutoRefetchOnDelete || (!this.useStore && this.entity)
+      return this.useAutoHandleOnDelete || this.useAutoRefetchOnDelete
     },
 
     hasHeaderSlot () {
@@ -382,7 +382,7 @@ export default {
     },
 
     onDeleteResult (event) {
-      if (this.useAutoRefetchOnDelete || !this.useStore) {
+      if (this.useAutoRefetchOnDelete) {
         this.mx_fetchHandler({ ...this.mx_context, url: this.url }, this.fetchList)
         return
       }

--- a/ui/src/components/tooltip/QasTooltip.vue
+++ b/ui/src/components/tooltip/QasTooltip.vue
@@ -1,11 +1,13 @@
 <template>
-  <q-tooltip v-bind="tooltipProps" class="bg-grey-10 text-caption">
+  <q-tooltip v-if="!isDragging" v-bind="tooltipProps" class="bg-grey-10 text-caption">
     <qas-breakline :text="props.text" />
   </q-tooltip>
 </template>
 
 <script setup>
 import QasBreakline from '../breakline/QasBreakline.vue'
+
+import { inject, ref } from 'vue'
 
 defineOptions({ name: 'QasTooltip' })
 
@@ -15,6 +17,9 @@ const props = defineProps({
     default: ''
   }
 })
+
+// injects
+const isDragging = inject('isDragging', ref(false))
 
 // consts
 const tooltipProps = {

--- a/ui/src/css/components/button.scss
+++ b/ui/src/css/components/button.scss
@@ -230,33 +230,17 @@
   // Magic AI
   &--magic-ai {
     // CSS não suporta transição direta de gradient → cor sólida em background/background-clip.
-    // Para primary: usamos ::after com o gradient sobre a cor base, com transição de opacity.
     // Para secondary/tertiary: transitamos -webkit-text-fill-color de transparent → cor sólida,
     // deixando o gradient visível por baixo e criando um efeito de cross-fade.
     &#{$root}--primary:not(:disabled) {
-      background: $deep-purple-6 !important;
-      position: relative;
+      background: var(--qas-magic-ai-gradient);
+      background-size: 100%;
+      transition: background-size var(--qas-generic-transition);
 
-      .q-btn__content {
-        position: relative;
-        z-index: 1;
+      &:hover {
+        background-size: 200%;
       }
 
-      &::after {
-        background: var(--qas-magic-ai-gradient);
-        border-radius: inherit;
-        content: '';
-        inset: 0;
-        opacity: 1;
-        pointer-events: none;
-        position: absolute;
-        transition: opacity var(--qas-generic-transition);
-        z-index: 0;
-      }
-
-      &:not(:disabled):hover::after {
-        opacity: 0;
-      }
     }
 
     &#{$root}--secondary:not(:disabled) {

--- a/ui/src/css/components/button.scss
+++ b/ui/src/css/components/button.scss
@@ -226,4 +226,99 @@
   .q-focus-helper {
     display: none;
   }
+
+  // Magic AI
+  &--magic-ai {
+    // CSS não suporta transição direta de gradient → cor sólida em background/background-clip.
+    // Para primary: usamos ::after com o gradient sobre a cor base, com transição de opacity.
+    // Para secondary/tertiary: transitamos -webkit-text-fill-color de transparent → cor sólida,
+    // deixando o gradient visível por baixo e criando um efeito de cross-fade.
+    &#{$root}--primary:not(:disabled) {
+      background: $deep-purple-6 !important;
+      position: relative;
+
+      .q-btn__content {
+        position: relative;
+        z-index: 1;
+      }
+
+      &::after {
+        background: var(--qas-magic-ai-gradient);
+        border-radius: inherit;
+        content: '';
+        inset: 0;
+        opacity: 1;
+        pointer-events: none;
+        position: absolute;
+        transition: opacity var(--qas-generic-transition);
+        z-index: 0;
+      }
+
+      &:not(:disabled):hover::after {
+        opacity: 0;
+      }
+    }
+
+    &#{$root}--secondary:not(:disabled) {
+      transition: color var(--qas-generic-transition);
+
+      .q-icon,
+      .qas-btn__label {
+        background: var(--qas-magic-ai-gradient) !important;
+        background-clip: text !important;
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        border: none !important;
+        transition: -webkit-text-fill-color var(--qas-generic-transition);
+      }
+
+      &::after {
+        background: var(--qas-magic-ai-gradient);
+        border-radius: inherit;
+        content: '';
+        inset: 0;
+        mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+        mask-composite: exclude;
+        -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+        -webkit-mask-composite: xor;
+        padding: 0;
+        pointer-events: none;
+        position: absolute;
+        transition: opacity var(--qas-generic-transition);
+      }
+
+      &:hover {
+        color: $deep-purple-6 !important;
+
+        .q-icon,
+        .qas-btn__label {
+          color: $deep-purple-6 !important;
+          -webkit-text-fill-color: $deep-purple-6 !important;
+        }
+
+        &::after {
+          opacity: 0;
+        }
+      }
+    }
+
+    &#{$root}--tertiary:not(:disabled) {
+      .q-icon,
+      .qas-btn__label {
+        background: var(--qas-magic-ai-gradient);
+        background-clip: text;
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        transition: -webkit-text-fill-color var(--qas-generic-transition);
+      }
+
+      &:hover {
+        .q-icon,
+        .qas-btn__label {
+          color: $deep-purple-6 !important;
+          -webkit-text-fill-color: $deep-purple-6 !important;
+        }
+      }
+    }
+  }
 }

--- a/ui/src/css/components/item.scss
+++ b/ui/src/css/components/item.scss
@@ -54,6 +54,12 @@
     display: none;
   }
 
+  &:not(.disabled):hover .text-magic-ai {
+    background: none !important;
+    color: $deep-purple-6 !important;
+    -webkit-text-fill-color: $deep-purple-6 !important;
+  }
+
   &__section--side {
     padding-right: var(--qas-spacing-sm);
   }

--- a/ui/src/css/utils/background.scss
+++ b/ui/src/css/utils/background.scss
@@ -32,3 +32,8 @@
 .bg-position-top {
   background-position: top !important;
 }
+
+// Colors
+.bg-magic-ai {
+  background: var(--qas-magic-ai-gradient) !important;
+}

--- a/ui/src/css/utils/border.scss
+++ b/ui/src/css/utils/border.scss
@@ -19,6 +19,12 @@
 @include set-border-color(secondary-contrast, $secondary-contrast);
 @include set-border-color('grey', $border-grey);
 
+.border-magic-ai {
+  border-style: solid !important;
+  border-width: 1px !important;
+  border-image: var(--qas-magic-ai-gradient) 1 !important;
+}
+
 // Direction
 .border-top {
   border-top-width: 1px !important;

--- a/ui/src/css/utils/text.scss
+++ b/ui/src/css/utils/text.scss
@@ -13,3 +13,12 @@
 .text-no-decoration {
   text-decoration: none !important;
 }
+
+// Colors
+.text-magic-ai {
+  background: var(--qas-magic-ai-gradient);
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}

--- a/ui/src/helpers/set-scroll-gradient.js
+++ b/ui/src/helpers/set-scroll-gradient.js
@@ -174,13 +174,16 @@ export default function setScrollGradient (config = {}) {
     const elementRect = element.getBoundingClientRect()
     const parentRect = element.parentElement.getBoundingClientRect()
 
+    // pequena margem para garantir que o gradiente fique grudado ao elemento.
+    const safeArea = 1
+
     /**
      * diferença entre o bottom do pai e o bottom do filho, valor positivo significa
      * que há espaço livre abaixo do filho.
      */
     const distance = {
-      end: isVertical ? (parentRect.bottom - elementRect.bottom) : (parentRect.right - elementRect.right),
-      start: isVertical ? (elementRect.top - parentRect.top) : (elementRect.left - parentRect.left)
+      end: isVertical ? (parentRect.bottom - elementRect.bottom - safeArea) : (parentRect.right - elementRect.right - safeArea),
+      start: isVertical ? (elementRect.top - parentRect.top) - safeArea : (elementRect.left - parentRect.left) - safeArea
     }
 
     span.style[getDirection(direction)] = `${distance[direction]}px`

--- a/ui/src/index.scss
+++ b/ui/src/index.scss
@@ -13,6 +13,7 @@ $accent: var(--q-accent);
   --qas-border-grey: #{$grey-4};
   --qas-generic-border-radius: 4px;
   --qas-generic-transition: 300ms;
+  --qas-magic-ai-gradient: linear-gradient(90deg, #0F54AE 0%, #C51162 100%);
 }
 
 $background-color: var(--qas-background-color);


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## Não publicado
## BREAKING CHANGES
- `QasBoardGenerator`: Varias mudanças de comportamento e visuais no componente, revisar se nada quebra.

### Adicionado
- `QasBoardGenerator`:
  - adicionada prop `skeleton` (default `false`) para exibir cards fictícios de carregamento enquanto as colunas são buscadas.
  - adicionado suporte a lazy loading das colunas via `QasLazyLoadingComponents`, priorizando o carregamento das colunas visíveis.
  - adicionado scroll horizontal suave durante drag-and-drop, com velocidade vertical independente e melhoras no estilo da classe ghost.
  - adicionados novos métodos expostos: `refreshColumn`, `removeItemFromList`, `updateItemInList`, `refetchColumns` e `transferItemToColumn`.
  - adicionado parâmetro `isUpdatingPosition` no slot `column-item` para indicar quando o item está sendo processado pelo drag-and-drop.
  - adicionado parâmetros `header` e `columnIndex` no slot `column-item`.
- `QasLazyLoadingComponents`:
  - adicionada prop `direction` (`vertical` | `horizontal`) para suporte a listas de rolagem horizontal.
  - adicionada prop `placeholder-width` para definir a largura dos placeholders no modo horizontal.
  - adicionado `v-model:visible-items` que expõe os índices dos itens atualmente visíveis na viewport.
- `QasDialog`: adicionado slot `title` para inserir conteúdo adicional ao lado do título do card do dialog.
- `QasBtn`: adicionada prop `useMagicAiColor` que aplica gradiente de inteligência artificial (magic AI) ao botão. O comportamento varia por variante: `primary` altera o fundo, `secondary` altera texto e borda, `tertiary` altera apenas o texto. Hover usa `$secondary-contrast`.
- `QasActionsMenu`: suporte à propriedade `useMagicAiColor` nos itens da prop `list`, que aplica o gradiente de magic AI no ícone e no texto do item no dropdown. Quando o item é renderizado como botão externo (via `splitName`), as cores são aplicadas automaticamente.
- CSS: adicionadas classes utilitárias `text-magic-ai`, `bg-magic-ai` e `border-magic-ai` para aplicação do gradiente de magic AI em textos, fundos e bordas respectivamente.
- `QasDateTimeInput`: adicionado comportamento de setar hora automaticamente após digitar a data. ([#1411](https://github.com/bildvitta/asteroid/issues/1411))

### Modificado
- `QasListView`: removida lógica que acionava delete automático quando `useStore: false` e `entity` estava definido; o comportamento agora é controlado exclusivamente pelas props `useAutoHandleOnDelete` e `useAutoRefetchOnDelete`.

### Corrigido
- `helpers/set-scroll-gradient`: Corrigido pequena diferença de posicionamento do gradiente.

### Removido
- `QasBoardGenerator`: removido prop `useMarkRaw`, agora o componente faz o controle sozinho de quando vai ser ou não reativo os dados.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [x] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [x] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [x] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [x] Sim
- [ ] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
