### PR TITLE
QasSelectListDialog: correção para buscar próxima página / adicionado search-input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não p
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
 ## Não publicado
+### Modificado
+- `QasSelectListDialog`: modificado componente de listagem dos itens selecionados, agora usamos o `QasSearchBox` onde terá um input de pesquisa.
+
 ### Segurança
 - Fixada versão do `axios` (removido `^`) em `package.json`, `ui/package.json` e `docs/package.json` para evitar atualizações automáticas em versões comprometidas (`0.30.4` e `1.14.1`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 ### Modificado
 - `QasSelectListDialog`: modificado componente de listagem dos itens selecionados, agora usamos o `QasSearchBox` onde terá um input de pesquisa. ([#1497](https://github.com/bildvitta/asteroid/issues/1497))
 
+### Corrigido
+- `QasSelectListDialog`: corrigido problema de não buscar a próxima página ao ter todos os itens da primeira página selecionados. ([#1110](https://github.com/bildvitta/asteroid/issues/1110))
+
 ### Segurança
 - Fixada versão do `axios` (removido `^`) em `package.json`, `ui/package.json` e `docs/package.json` para evitar atualizações automáticas em versões comprometidas (`0.30.4` e `1.14.1`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não p
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
 ## Não publicado
-### Modificado
-- `QasSelectListDialog`: modificado componente de listagem dos itens selecionados, agora usamos o `QasSearchBox` onde terá um input de pesquisa. ([#1497](https://github.com/bildvitta/asteroid/issues/1497))
+### Adicionado
+- `QasSelectListDialog`: adicionado campo de pesquisa para os itens selecionados. ([#1497](https://github.com/bildvitta/asteroid/issues/1497))
 
 ### Corrigido
 - `QasSelectListDialog`: corrigido problema de não buscar a próxima página ao ter todos os itens da primeira página selecionados. ([#1110](https://github.com/bildvitta/asteroid/issues/1110))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 
 ## Não publicado
 ### Modificado
-- `QasSelectListDialog`: modificado componente de listagem dos itens selecionados, agora usamos o `QasSearchBox` onde terá um input de pesquisa.
+- `QasSelectListDialog`: modificado componente de listagem dos itens selecionados, agora usamos o `QasSearchBox` onde terá um input de pesquisa. ([#1497](https://github.com/bildvitta/asteroid/issues/1497))
 
 ### Segurança
 - Fixada versão do `axios` (removido `^`) em `package.json`, `ui/package.json` e `docs/package.json` para evitar atualizações automáticas em versões comprometidas (`0.30.4` e `1.14.1`).

--- a/ui/src/components/search-box/QasSearchBox.vue
+++ b/ui/src/components/search-box/QasSearchBox.vue
@@ -138,7 +138,7 @@ export default {
     },
 
     hasNoOptionsOnFirstFetch () {
-      return this.mx_fetchCount === 1 && !this.mx_hasFilteredOptions
+      return this.mx_fetchCount === 1 && !this.mx_hasFilteredOptions && !this.mx_hasMorePages
     },
 
     containerHeight () {

--- a/ui/src/components/search-box/QasSearchBox.vue
+++ b/ui/src/components/search-box/QasSearchBox.vue
@@ -138,7 +138,7 @@ export default {
     },
 
     hasNoOptionsOnFirstFetch () {
-      return this.mx_fetchCount === 1 && !this.mx_hasFilteredOptions && !this.mx_hasMorePages
+      return this.mx_fetchCount === 1 && !this.mx_hasFilteredOptions && !this.mx_hasNextPage
     },
 
     containerHeight () {

--- a/ui/src/components/select-list-dialog/QasSelectListDialog.vue
+++ b/ui/src/components/select-list-dialog/QasSelectListDialog.vue
@@ -14,17 +14,19 @@
       </span>
 
       <slot name="selected-content">
-        <q-virtual-scroll #default="{ item, index }" class="app-select-list-dialog__list q-mt-md" :items="selectedOptions" separator>
-          <q-item class="q-px-none text-body1 text-grey-8">
-            <q-item-section>
-              {{ item.label }}
-            </q-item-section>
+        <qas-search-box v-model:results="searchedResults" v-bind="searchSelectedItemsBoxProps" class="q-mt-md">
+          <q-virtual-scroll #default="{ item, index }" class="app-select-list-dialog__list" :items="searchedResults" separator>
+            <q-item class="q-px-none text-body1 text-grey-8">
+              <q-item-section>
+                {{ item.label }}
+              </q-item-section>
 
-            <q-item-section avatar>
-              <qas-btn v-bind="getRemoveButtonProps({ index, option: item })" />
-            </q-item-section>
-          </q-item>
-        </q-virtual-scroll>
+              <q-item-section avatar>
+                <qas-btn v-bind="getRemoveButtonProps({ index, option: item })" />
+              </q-item-section>
+            </q-item>
+          </q-virtual-scroll>
+        </qas-search-box>
       </slot>
 
       <q-inner-loading :showing="props.loading">
@@ -132,6 +134,11 @@ const props = defineProps({
 
   useLazyLoading: {
     type: Boolean
+  },
+
+  searchPlaceholder: {
+    default: 'Pesquisar...',
+    type: String
   }
 })
 
@@ -174,6 +181,7 @@ defineExpose({ add, removeAll, remove, toggleDialog })
 
 // refs
 const model = ref([...props.modelValue])
+const searchedResults = ref([])
 
 // computeds
 const hasError = computed(() => Array.isArray(props.error) ? !!props.error.length : !!props.error)
@@ -208,6 +216,15 @@ const headerProps = computed(() => {
 
 const hasLazyLoading = computed(() => {
   return props.useLazyLoading || !!props.selectListProps?.searchBoxProps?.useLazyLoading
+})
+
+const searchSelectedItemsBoxProps = computed(() => {
+  return {
+    fuseOptions: { keys: ['label'] },
+    list: selectedOptions.value,
+    useEmptyResults: false,
+    placeholder: props.searchPlaceholder
+  }
 })
 
 watch(() => props.modelValue, newValue => {

--- a/ui/src/components/select-list-dialog/QasSelectListDialog.vue
+++ b/ui/src/components/select-list-dialog/QasSelectListDialog.vue
@@ -9,12 +9,12 @@
       v-if="canShowContainerList"
       class="q-mt-md relative-position"
     >
-      <span class="text-grey-10 text-subtitle1">
-        {{ props.listLabel }}
-      </span>
-
       <slot name="selected-content">
         <qas-search-box v-model:results="searchedResults" v-bind="searchSelectedItemsBoxProps" class="q-mt-md">
+          <span class="text-grey-10 text-subtitle1">
+            {{ props.listLabel }}
+          </span>
+
           <q-virtual-scroll #default="{ item, index }" class="app-select-list-dialog__list" :items="searchedResults" separator>
             <q-item class="q-px-none text-body1 text-grey-8">
               <q-item-section>

--- a/ui/src/components/select-list-dialog/QasSelectListDialog.yml
+++ b/ui/src/components/select-list-dialog/QasSelectListDialog.yml
@@ -55,6 +55,11 @@ props:
     type: Array
     model: true
 
+  search-placeholder:
+    desc: Placeholder do campo de busca.
+    default: Pesquisar...
+    type: String
+
   select-list-model:
     desc: Model dos itens selecionados dentro do dialog.
     type: Array
@@ -64,8 +69,8 @@ props:
 
   select-list-props:
     desc: Propriedades repassadas para o componente QasSelectList.
-    default: []
-    type: Array
+    default: {}
+    type: Object
 
   use-lazy-loading:
     desc: O componente precisa saber se o lazy-loading esta habilitado para este componente, e caso esteja usando customização pelos slots do "dialog-description", é necessário informar por esta prop.

--- a/ui/src/mixins/search-filter.js
+++ b/ui/src/mixins/search-filter.js
@@ -86,6 +86,12 @@ export default {
       return !!this.mx_filteredOptions.length
     },
 
+    mx_hasMorePages () {
+      const { lastPage, page, hasCount, hasNextPage } = this.mx_pagination
+
+      return hasCount ? !!(lastPage && page <= lastPage) : hasNextPage
+    },
+
     mx_hasOptionsToExclude () {
       return !!this.optionsToExclude.length
     }
@@ -211,6 +217,8 @@ export default {
           hasCount,
           hasNextPage
         }
+
+        console.log(this.mx_pagination, '<--- pagination after fetch')
 
         this.$emit('fetch-options-success', data)
 

--- a/ui/src/mixins/search-filter.js
+++ b/ui/src/mixins/search-filter.js
@@ -218,8 +218,6 @@ export default {
           hasNextPage
         }
 
-        console.log(this.mx_pagination, '<--- pagination after fetch')
-
         this.$emit('fetch-options-success', data)
 
         const options = this.mx_getOptions(results)

--- a/ui/src/mixins/search-filter.js
+++ b/ui/src/mixins/search-filter.js
@@ -86,7 +86,7 @@ export default {
       return !!this.mx_filteredOptions.length
     },
 
-    mx_hasMorePages () {
+    mx_hasNextPage () {
       const { lastPage, page, hasCount, hasNextPage } = this.mx_pagination
 
       return hasCount ? !!(lastPage && page <= lastPage) : hasNextPage


### PR DESCRIPTION
### Adicionado
- `QasSelectListDialog`: adicionado campo de pesquisa para os itens selecionados. ([#1497](https://github.com/bildvitta/asteroid/issues/1497))

### Corrigido
- `QasSelectListDialog`: corrigido problema de não buscar a próxima página ao ter todos os itens da primeira página selecionados. ([#1110](https://github.com/bildvitta/asteroid/issues/1110))

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
