### PR TITLE
`QasBoardGenerator`: alterado de 4 para 8 a quantidade de colunas quando tem skeleton.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 ### Modificado
 - `QasCard`: modificado titulo, onde passou a utilizar o componente criado `QasRouterLink`.
 - `QasSelectListDialog`: adicionado campo de pesquisa para os itens selecionados. ([#1497](https://github.com/bildvitta/asteroid/issues/1497))
+- `QasBoardGenerator`: alterado de 4 para 8 a quantidade de colunas quando tem skeleton.
 
 ### Corrigido
 - `QasSelectListDialog`: corrigido problema de não buscar a próxima página ao ter todos os itens da primeira página selecionados. ([#1110](https://github.com/bildvitta/asteroid/issues/1110))

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -362,7 +362,7 @@ const columnContainerElements = computed(() => {
 const normalizedHeaders = computed(() => {
   // retorna dados fakes para criar colunas de skeleton, caso a prop skeleton seja true.
   if (props.skeleton) {
-    return Array.from({ length: 4 }).map((_, index) => {
+    return Array.from({ length: 8 }).map((_, index) => {
       return {
         [props.columnIdKey]: `${props.columnIdKey}-${index}`
       }


### PR DESCRIPTION
…rom 4 to 8

<!-- PULL REQUEST TEMPLATE -->

### Modificado
- `QasBoardGenerator`: alterado de 4 para 8 a quantidade de colunas quando tem skeleton.

<!-- (Altere de "[ ]" para "[x]" para marcar o item.) -->

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
