### PR TITLE
feat: Adicionado prop buttonProps no QasCopy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+### Adicionado
+- `QasCopy`: adicionado prop `buttonProps` para passar propriedades para o botão, sendo repassado ao `QasBtn` do componente. 
+
 ## [3.20.0-beta.15] - 01-04-2026
 ### Adicionado
 - `QasRouterLink`: adicionado componente pra controlar as rotas de overlay e rotas pra abrir em uma nova guia.

--- a/ui/src/components/copy/QasCopy.vue
+++ b/ui/src/components/copy/QasCopy.vue
@@ -7,7 +7,7 @@
       </slot>
     </span>
 
-    <qas-btn class="q-ml-xs" color="primary" :icon="props.icon" :loading="isLoading" variant="tertiary" @click.stop.prevent="copy">
+    <qas-btn class="q-ml-xs" color="primary" :icon="props.icon" :loading="isLoading" variant="tertiary" v-bind="props.buttonProps" @click.stop.prevent="copy">
       <qas-tooltip text="Copiar" />
     </qas-btn>
   </span>
@@ -41,6 +41,11 @@ const props = defineProps({
   rawText: {
     default: '',
     type: String
+  },
+
+  buttonProps: {
+    type: Object,
+    default: () => ({})
   }
 })
 

--- a/ui/src/components/copy/QasCopy.yml
+++ b/ui/src/components/copy/QasCopy.yml
@@ -21,3 +21,8 @@ props:
   raw-text:
     desc: Caso o texto a ser copiado precise ser diferente do texto a ser exibido, utilize esta propriedade.
     type: String
+
+  button-props:
+    desc: Propriedades adicionais que serão repassadas ao botão.
+    type: Object
+    default: () => ({})


### PR DESCRIPTION
### Adicionado
- `QasCopy`: adicionado prop `buttonProps` para passar propriedades para o botão, sendo repassado ao `QasBtn` do componente. 

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
