### PR TITLE
`QasCard`: Modificado internamente para que consiga repassar outras props ou eventos pelo `expansionProps`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+### Modificado
+- `QasCard`: Modificado internamente para que consiga repassar outras props ou eventos pelo `expansionProps`.
+
 ## [3.20.0-beta.21] - 27-04-2026
 ### Corrigido
 - `ui v3.20.0-beta.20`: Versão foi publicado sem correção do `QasSelectListDialog`.

--- a/ui/src/components/card/QasCard.vue
+++ b/ui/src/components/card/QasCard.vue
@@ -49,7 +49,7 @@
             </div>
 
             <slot v-else name="footer">
-              <q-expansion-item v-if="hasExpansion" class="full-width" dense expand-icon-class="text-grey-10" header-class="qas-card__expansion-header q-mt-sm q-pa-none" :label="props.expansionProps.label">
+              <q-expansion-item v-if="hasExpansion" class="full-width" v-bind="expansionItemProps">
                 <div class="q-mt-xs">
                   <q-separator vertical />
 
@@ -220,6 +220,16 @@ const formattedActionsMenuProps = computed(() => {
   return {
     ...props.actionsMenuProps,
     useLabel: false
+  }
+})
+
+const expansionItemProps = computed(() => {
+  return {
+    ...props.expansionProps,
+    dense: true,
+    expandIconClass: 'text-grey-10',
+    headerClass: 'qas-card__expansion-header q-mt-sm q-pa-none',
+    label: props.expansionProps.label
   }
 })
 </script>


### PR DESCRIPTION
### Modificado
- `QasCard`: Modificado internamente para que consiga repassar outras props ou eventos pelo `expansionProps`.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [x] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
