### PR TITLE
Validação da prop disableCloseButton / Adicionado title no dialog interno do QasBoardGenerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,11 @@ Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não p
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
 ## Não publicado
-### Corrigido
-- `QasBoardGenerator`: corrigido o uso do `QasDialog` interno, onde deve ser passado um title, pois é uma prop obrigatória.
-
 ### Adicionado
 - `QasDialog` adicionado validação da prop `disableCloseButton` para desabilitar o botão, onde por padrão, caso tenha uma prop `loading` para o `ok` do dialog, será desabilitado quando o loading estiver ativo.
+
+### Corrigido
+- `QasBoardGenerator`: corrigido o uso do `QasDialog` interno, onde deve ser passado um title, pois é uma prop obrigatória.
 
 ## [3.20.0-beta.22] - 06-05-2026
 ### Modificado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+### Corrigido
+- `QasBoardGenerator`: corrigido o uso do `QasDialog` interno, onde deve ser passado um title, pois é uma prop obrigatória.
+
+### Adicionado
+- `QasDialog` adicionado validação da prop `disableCloseButton` para desabilitar o botão, onde por padrão, caso tenha uma prop `loading` para o `ok` do dialog, será desabilitado quando o loading estiver ativo.
+
 ## [3.20.0-beta.22] - 06-05-2026
 ### Modificado
 - `QasCard`: Modificado internamente para que consiga repassar outras props ou eventos pelo `expansionProps`.

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -390,6 +390,8 @@ const containerStyle = computed(() => `width: ${props.columnWidth};`)
 
 const defaultConfirmDialogProps = computed(() => {
   const defaultProps = {
+    title: 'Confirmar movimentação',
+
     ok: {
       label: 'Confirmar',
       onClick: onConfirmDrop.value,
@@ -427,6 +429,7 @@ watch(() => columnContainerElements.value, () => {
 
 // hooks
 onMounted(() => {
+  console.log('to linkado')
   if (normalizedHeaders.value.length) {
     fetchColumnsValues()
   }

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -390,7 +390,7 @@ const containerStyle = computed(() => `width: ${props.columnWidth};`)
 
 const defaultConfirmDialogProps = computed(() => {
   const defaultProps = {
-    title: 'Confirmar movimentação',
+    title: 'Confirmar mudança',
 
     ok: {
       label: 'Confirmar',

--- a/ui/src/components/board-generator/QasBoardGenerator.vue
+++ b/ui/src/components/board-generator/QasBoardGenerator.vue
@@ -429,7 +429,6 @@ watch(() => columnContainerElements.value, () => {
 
 // hooks
 onMounted(() => {
-  console.log('to linkado')
   if (normalizedHeaders.value.length) {
     fetchColumnsValues()
   }

--- a/ui/src/components/dialog/QasDialog.vue
+++ b/ui/src/components/dialog/QasDialog.vue
@@ -57,7 +57,8 @@ const props = defineProps({
   },
 
   disableCloseButton: {
-    type: Boolean
+    type: Boolean,
+    default: undefined
   },
 
   ok: {
@@ -202,7 +203,7 @@ const headerProps = computed(() => {
     buttonProps: {
       ...(props.useCloseButton && {
         color: 'grey-10',
-        disable: props.disableCloseButton,
+        disable: typeof props.disableCloseButton === 'boolean' ? props.disableCloseButton : props.ok.loading,
         icon: 'sym_r_close',
         variant: 'tertiary',
         'data-cy': 'dialog-close-btn',

--- a/ui/src/components/dialog/QasDialog.vue
+++ b/ui/src/components/dialog/QasDialog.vue
@@ -203,7 +203,7 @@ const headerProps = computed(() => {
     buttonProps: {
       ...(props.useCloseButton && {
         color: 'grey-10',
-        disable: typeof props.disableCloseButton === 'boolean' ? props.disableCloseButton : props.ok.loading,
+        disable: props.disableCloseButton ?? props.ok.loading,
         icon: 'sym_r_close',
         variant: 'tertiary',
         'data-cy': 'dialog-close-btn',


### PR DESCRIPTION
### Corrigido
- `QasBoardGenerator`: corrigido o uso do `QasDialog` interno, onde deve ser passado um title, pois é uma prop obrigatória.

### Adicionado
- `QasDialog` adicionado validação da prop `disableCloseButton` para desabilitar o botão, onde por padrão, caso tenha uma prop `loading` para o `ok` do dialog, será desabilitado quando o loading estiver ativo.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
