### PR TITLE
feat: Adicionado possibilidade de passar buttonProps dentro do deleteProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 - `QasAlert`: 
   - Adicionado novo status de `warning`;
   - Adicionado nova prop `use-background` para aplicar cor de fundo.
+- `QasActionsMenu`: Adicionado possibilidade de passar `buttonProps` dentro do `deleteProps`.
 
 ### Corrigido
 - `QasField | QasRadio`: Corrigido renderização dos erros no campo do tipo `QasRadio` quando utilizado pelo `QasField` ou em um `QasFormGenerator`. ([#1520](https://github.com/appnave/asteroid/issues/1520))

--- a/ui/src/components/actions-menu/composables/use-delete.js
+++ b/ui/src/components/actions-menu/composables/use-delete.js
@@ -14,10 +14,13 @@ export default function useDelete ({ color, props, qas }) {
     return {
       ...(hasDelete.value && {
         delete: {
-          color,
-          icon: props.deleteIcon,
           label: props.deleteLabel,
-          handler: () => qas.delete(props.deleteProps)
+
+          ...props.deleteProps.buttonProps,
+
+          handler: () => qas.delete(props.deleteProps),
+          color,
+          icon: props.deleteIcon
         }
       })
     }

--- a/ui/src/components/list-view/QasListView.vue
+++ b/ui/src/components/list-view/QasListView.vue
@@ -223,6 +223,7 @@ export default {
   },
 
   created () {
+    console.log('to linkado')
     this.mx_fetchHandler({ ...this.mx_context, url: this.url }, this.fetchList)
 
     this.setCurrentPage()

--- a/ui/src/components/list-view/QasListView.vue
+++ b/ui/src/components/list-view/QasListView.vue
@@ -223,7 +223,6 @@ export default {
   },
 
   created () {
-    console.log('to linkado')
     this.mx_fetchHandler({ ...this.mx_context, url: this.url }, this.fetchList)
 
     this.setCurrentPage()


### PR DESCRIPTION
### Adicionado
- `QasActionsMenu`: Adicionado possibilidade de passar `buttonProps` dentro do `deleteProps`.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
