### PR TITLE
QasBadge | Nova prop useSubtle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+### Adicionado
+- `QasBadge`: 
+  - Adicionado nova prop `use-subtle` para aplicar background sútil e com opacidade.
+  - Adicionado nova prop `icon` para ícone a esquerda do texto (apenas quando `use-subtle` ativado).
+
 ## [3.20.0-beta.25] - 02-07-2026
 ## BREAKING CHANGES 
 - `QasAlert`: Removido prop `use-box`, sendo que a prop `use-background` entrou no lugar, gerando breaking change visual, necessário validar telas na qual utilizam o alert.

--- a/docs/src/examples/QasBadge/WithSubtle.vue
+++ b/docs/src/examples/QasBadge/WithSubtle.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="container q-gutter-md q-py-lg">
+    <qas-badge v-for="(color, index) in badges" :key="index" :color="color" icon="sym_r_flag" :label="color" removable use-subtle />
+  </div>
+</template>
+
+<script setup>
+defineOptions({ name: 'WithSubtle' })
+
+const badges = [
+  'green-6',
+  'yellow-8',
+  'orange-6',
+  'red-8',
+  'green-7',
+  'light-blue-5'
+]
+</script>

--- a/docs/src/pages/components/badge.md
+++ b/docs/src/pages/components/badge.md
@@ -15,3 +15,4 @@ Componente wrapper do QBadge/QChip do quasar.
 
 <doc-example file="QasBadge/Basic" title="Básico/QBadge" />
 <doc-example file="QasBadge/Removable" title="Removível/QChip" />
+<doc-example file="QasBadge/WithSubtle" title="Background com opacidade" />

--- a/ui/src/components/badge/QasBadge.vue
+++ b/ui/src/components/badge/QasBadge.vue
@@ -1,12 +1,20 @@
 <template>
   <!-- "data-table-ignore-hover" é para não habilitar hover no texto no QasTableGenerator -->
-  <component :is="component.is" v-bind="component.props" class="q-px-sm qas-badge text-body2" data-table-ignore-hover>
-    <slot />
+  <component :is="component.is" v-bind="component.props" class="q-px-sm qas-badge text-body2" :class="componentClasses" data-table-ignore-hover :style="componentStyle">
+    <slot>
+      <div class="items-center no-wrap q-gutter-xs row">
+        <q-icon v-if="showIcon" :color="props.color" :name="props.icon" />
+
+        <div>
+          {{ props.label }}
+        </div>
+      </div>
+    </slot>
   </component>
 </template>
 
 <script setup>
-import { QChip, QBadge } from 'quasar'
+import { QChip, QBadge, colors } from 'quasar'
 
 import { baseProps } from '../../shared/badge-config'
 
@@ -17,11 +25,19 @@ defineOptions({
   inheritAttrs: false
 })
 
+// props
 const props = defineProps(baseProps)
 
+// emits
 const emit = defineEmits(['remove'])
+
+// models
 const model = defineModel({ type: Boolean, default: true })
 
+// consts
+const { getPaletteColor, hexToRgb } = colors
+
+// computeds
 const component = computed(() => {
   const isChip = props.removable
 
@@ -29,10 +45,9 @@ const component = computed(() => {
     is: isChip ? QChip : QBadge,
     props: {
       // comum
-      color: props.color,
+      color: props.useSubtle ? undefined : props.color,
       dense: true,
       textColor: props.textColor,
-      label: props.label,
 
       // somente QChip
       ...(isChip && {
@@ -53,6 +68,32 @@ const component = computed(() => {
     }
   }
 })
+
+const componentClasses = computed(() => {
+  if (!props.useSubtle) return {}
+
+  return {
+    'q-chip--subtle': props.removable,
+    'q-badge--subtle': !props.removable
+  }
+})
+
+const componentStyle = computed(() => {
+  if (!props.useSubtle) return {}
+
+  const colorHex = getPaletteColor(props.color)
+  const { r, g, b } = hexToRgb(colorHex)
+
+  return {
+    '--qas-badge-subtle-bg': `rgba(${r}, ${g}, ${b}, 0.1)`,
+    '--qas-badge-subtle-border': `rgba(${r}, ${g}, ${b}, 0.5)`
+  }
+})
+
+/**
+ * O icone só é exibido quando o badge é do tipo "subtle" e quando a prop "icon" é informada.
+ */
+const showIcon = computed(() => props.icon && props.useSubtle)
 </script>
 
 <style lang="scss">
@@ -60,5 +101,14 @@ const component = computed(() => {
   min-height: 20px;
   padding-bottom: 2px;
   padding-top: 2px;
+
+  &.q-chip--subtle,
+  &.q-badge--subtle {
+    background-color: var(--qas-badge-subtle-bg) !important;
+    border-color: var(--qas-badge-subtle-border) !important;
+    border-radius: $generic-border-radius;
+    border-style: solid;
+    border-width: 1px;
+  }
 }
 </style>

--- a/ui/src/components/badge/QasBadge.yml
+++ b/ui/src/components/badge/QasBadge.yml
@@ -4,6 +4,10 @@ meta:
   desc: Componente wrapper do QBadge/QChip do quasar.
 
 props:
+  icon:
+    desc: Ícone que terá o badge, sendo exibida APENAS quando use-subtle estiver habilitado.
+    type: String
+
   color:
     desc: Cor da badge.
     default: light-blue-2
@@ -36,6 +40,11 @@ props:
   model-value:
     desc: Model do componente (usar junto a propriedade "removable").
     default: true
+    type: Boolean
+
+  use-subtle:
+    desc: Habilita o estilo sutil do badge/chip com opacidade reduzida.
+    default: false
     type: Boolean
 
 slots:

--- a/ui/src/shared/badge-config.js
+++ b/ui/src/shared/badge-config.js
@@ -4,6 +4,11 @@ export const baseProps = {
     default: 'light-blue-2'
   },
 
+  icon: {
+    type: String,
+    default: ''
+  },
+
   label: {
     type: String,
     default: ''
@@ -25,5 +30,9 @@ export const baseProps = {
   tabindex: {
     type: [String, Number],
     default: undefined
+  },
+
+  useSubtle: {
+    type: Boolean
   }
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

### Adicionado
- `QasBadge`: 
  - Adicionado nova prop `use-subtle` para aplicar background sútil e com opacidade.
  - Adicionado nova prop `icon` para ícone a esquerda do texto (apenas quando `use-subtle` ativado).

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
