### PR TITLE
Inserido QasTip nos fields: QasToggle | QasSelect | QasInput | QasRadio | QasCheckbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 - `QasBadge`: 
   - Adicionado nova prop `use-subtle` para aplicar background sútil e com opacidade.
   - Adicionado nova prop `icon` para ícone a esquerda do texto (apenas quando `use-subtle` ativado).
+- `QasCheckbox`, `QasInput`, `QasRadio`, `QasSelect` e `QasToggle`: adicionada nova prop `tip` para exibir conteúdo de ajuda ao lado da label.
 
 ## [3.20.0-beta.25] - 02-07-2026
 ## BREAKING CHANGES 

--- a/docs/src/examples/QasCheckbox/Options.vue
+++ b/docs/src/examples/QasCheckbox/Options.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="container q-gutter-y-lg spaced">
-    <qas-checkbox v-model="model" label="Checkbox com opções" :options />
+    <qas-checkbox v-model="model" label="Checkbox com opções" :options tip="Exemplo com tip" />
 
     <qas-checkbox v-model="model" disable label="Checkbox com opções" :options />
 
     <qas-checkbox v-model="model" error label="Checkbox com opções" :options />
 
-    <qas-checkbox v-model="model" error error-message="Mensagem de erro" label="Checkbox com opções" :options />
+    <qas-checkbox v-model="model" error error-message="Mensagem de erro" label="Checkbox com opções" :options tip="Exemplo com tip" />
 
     <qas-debugger :inspect="[model]" />
   </div>

--- a/docs/src/examples/QasInput/Basic.vue
+++ b/docs/src/examples/QasInput/Basic.vue
@@ -24,6 +24,8 @@
     </qas-input>
 
     <qas-input v-model="model" class="col-4" label="Meu input readonly" readonly />
+
+    <qas-input v-model="model" class="col-4" label="Com tip" tip="Exemplo com tip" />
   </div>
 </template>
 

--- a/docs/src/examples/QasRadio/OptionGroup.vue
+++ b/docs/src/examples/QasRadio/OptionGroup.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container spaced">
     <div>
-      <qas-radio v-model="model" label="Com opções" :options />
+      <qas-radio v-model="model" label="Com opções" :options tip="Exemplo com tip" />
     </div>
 
     <div class="q-mt-lg">

--- a/docs/src/examples/QasSelect/Basic.vue
+++ b/docs/src/examples/QasSelect/Basic.vue
@@ -11,6 +11,10 @@
     <div class="col-6">
       <qas-select v-model="model2" error error-message="Com erro" label="Meu select multiple" multiple :options />
     </div>
+
+    <div class="col-6">
+      <qas-select v-model="model2" error error-message="Com erro" label="Meu select multiple" :options tip="Exemplo com tip" />
+    </div>
   </div>
 </template>
 

--- a/docs/src/examples/QasSelect/FilterMode.vue
+++ b/docs/src/examples/QasSelect/FilterMode.vue
@@ -11,9 +11,9 @@
     <qas-box class="q-mb-lg">
       <qas-label label="Dentro de box" />
 
-      <qas-select v-model="model" v-bind="selectProps" use-filter-mode />
+      <qas-select v-model="model" v-bind="selectProps" tip="Exemplo com tip" use-filter-mode />
 
-      <qas-select v-model="model" class="q-mt-lg" error error-message="Mensagem de erro" v-bind="selectProps" use-filter-mode />
+      <qas-select v-model="model" class="q-mt-lg" error error-message="Mensagem de erro" v-bind="selectProps" tip="Exemplo com tip" use-filter-mode />
     </qas-box>
 
     <div>
@@ -128,9 +128,7 @@ const selectProps = {
 }
 
 const dialogProps = {
-  card: {
-    title: 'Selecione uma opção'
-  }
+  title: 'Selecione uma opção'
 }
 
 function toggleDialog () {

--- a/docs/src/examples/QasToggle/Basic.vue
+++ b/docs/src/examples/QasToggle/Basic.vue
@@ -5,7 +5,7 @@
     </div>
 
     <div>
-      <qas-toggle v-model="model2" label="Aceitar" />
+      <qas-toggle v-model="model2" label="Aceitar" tip="Exemplo com tip" />
     </div>
 
     <div>

--- a/ui/src/components/checkbox/QasCheckbox.vue
+++ b/ui/src/components/checkbox/QasCheckbox.vue
@@ -7,7 +7,11 @@
 
     <!-- Group -->
     <div v-else>
-      <qas-label v-if="props.label" :color="labelColor" :label="formattedLabel" margin="sm" typography="h5" />
+      <div v-if="props.label" class="items-center no-wrap q-gutter-x-xs q-mb-sm row">
+        <qas-label :color="labelColor" :label="formattedLabel" margin="none" typography="h5" />
+
+        <qas-tip v-if="props.tip" v-bind="tipProps" />
+      </div>
 
       <div class="flex q-col-gutter-md" :class="contentClasses">
         <div v-for="(option, index) in props.options" :key="index">
@@ -30,13 +34,14 @@
 <script setup>
 import QasLabel from '../label/QasLabel.vue'
 import QasErrorMessage from '../error-message/QasErrorMessage.vue'
+import QasTip from '../tip/QasTip.vue'
 
 import useErrorMessage, { baseErrorProps } from '../../composables/private/use-error-message'
 import useScreen from '../../composables/use-screen'
 
 import { getRequiredLabel } from '../../helpers'
 
-import { watch, computed, ref, onMounted, useAttrs } from 'vue'
+import { watch, computed, ref, onMounted, useAttrs, useSlots } from 'vue'
 
 defineOptions({
   name: 'QasCheckbox',
@@ -74,6 +79,11 @@ const props = defineProps({
     type: Boolean
   },
 
+  tip: {
+    type: String,
+    default: ''
+  },
+
   useAsTitle: {
     type: Boolean,
     default: false
@@ -85,6 +95,7 @@ const emit = defineEmits(['update:modelValue'])
 
 // globals
 const attrs = useAttrs()
+const slots = useSlots()
 
 // composables
 const { color } = useErrorMessage(props)
@@ -113,6 +124,7 @@ const contentClasses = computed(() => !isInline.value && 'column')
 const gutterClasses = computed(() => isInline.value ? 'q-gutter-x-md' : 'q-gutter-y-md')
 
 const hasErrorMessage = computed(() => props.errorMessage && !isSingle.value)
+const hasDefaultSlot = computed(() => !!slots.default)
 
 const model = computed({
   get () {
@@ -125,15 +137,25 @@ const model = computed({
 })
 
 const singleAttributes = computed(() => {
+  const label = !props.tip && !hasDefaultSlot.value ? props.label : undefined
+
   return {
     ...attrs,
     disable: props.disable,
-    label: props.label
+    label
   }
 })
 
 const formattedLabel = computed(() => {
   return getRequiredLabel({ label: props.label, required: props.required })
+})
+
+const tipProps = computed(() => {
+  return {
+    text: props.tip,
+
+    ...(props.error && { color: 'negative' })
+  }
 })
 
 // watch

--- a/ui/src/components/checkbox/QasCheckbox.yml
+++ b/ui/src/components/checkbox/QasCheckbox.yml
@@ -39,6 +39,11 @@ props:
     default: false
     type: Boolean
 
+  tip:
+    desc: Texto exibido no tip ao lado da label.
+    default: ''
+    type: String
+
 events:
   '@update:model-value -> function(value)':
     desc: Dispara quando o model-value altera, também usado para v-model.

--- a/ui/src/components/input/QasInput.vue
+++ b/ui/src/components/input/QasInput.vue
@@ -11,6 +11,16 @@
       />
     </template>
 
+    <template v-if="tip" #label>
+      <div class="items-center no-wrap q-gutter-x-xs row">
+        <div>
+          {{ formattedLabel }}
+        </div>
+
+        <qas-tip v-bind="tipProps" />
+      </div>
+    </template>
+
     <template v-for="(_, name) in $slots" #[name]="context">
       <slot :name="name" v-bind="context || {}" />
     </template>
@@ -34,7 +44,8 @@ export default {
   name: 'QasInput',
 
   components: {
-    QasCopy: defineAsyncComponent(() => import('../copy/QasCopy.vue'))
+    QasCopy: defineAsyncComponent(() => import('../copy/QasCopy.vue')),
+    QasTip: defineAsyncComponent(() => import('../tip/QasTip.vue'))
   },
 
   provide () {
@@ -89,6 +100,11 @@ export default {
 
     required: {
       type: Boolean
+    },
+
+    tip: {
+      type: String,
+      default: ''
     },
 
     unmaskedValue: {
@@ -234,6 +250,14 @@ export default {
             size: 'xs'
           })
         }
+      }
+    },
+
+    tipProps () {
+      return {
+        text: this.tip,
+
+        ...(this.hasError && { color: 'negative' })
       }
     }
   },

--- a/ui/src/components/input/QasInput.yml
+++ b/ui/src/components/input/QasInput.yml
@@ -52,6 +52,11 @@ props:
     default: false
     type: Boolean
 
+  tip:
+    desc: Texto exibido no tip ao lado da label.
+    default: ''
+    type: String
+
   use-remove-error-on-type:
     desc: Limpa os erros do campo caso os mesmos existam toda vez que o model atualiza.
     type: Boolean

--- a/ui/src/components/radio/QasRadio.vue
+++ b/ui/src/components/radio/QasRadio.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="qas-radio">
-    <qas-label v-if="canShowOptionGroupLabel" :color :label="props.label" margin="sm" typography="h5" />
+    <div v-if="canShowOptionGroupLabel" class="items-center no-wrap q-gutter-x-xs q-mb-sm row">
+      <qas-label :color :label="props.label" margin="none" typography="h5" />
+
+      <qas-tip v-if="props.tip" v-bind="tipProps" />
+    </div>
 
     <component :is="component.is" v-bind="component.props" />
 
@@ -11,6 +15,7 @@
 <script setup>
 import QasLabel from '../label/QasLabel.vue'
 import QasErrorMessage from '../error-message/QasErrorMessage.vue'
+import QasTip from '../tip/QasTip.vue'
 
 import useErrorMessage, { baseErrorProps } from '../../composables/private/use-error-message'
 import useScreen from '../../composables/use-screen'
@@ -27,6 +32,11 @@ const props = defineProps({
   ...baseErrorProps,
 
   label: {
+    default: '',
+    type: String
+  },
+
+  tip: {
     default: '',
     type: String
   }
@@ -46,6 +56,14 @@ const isOptionGroup = computed(() => !!attrs.options?.length)
  * Só mostra a label caso for q-option-group e tenha label vindo nas props
  */
 const canShowOptionGroupLabel = computed(() => isOptionGroup.value && !!props.label)
+
+const tipProps = computed(() => {
+  return {
+    text: props.tip,
+
+    ...(props.error && { color: 'negative' })
+  }
+})
 
 /**
  * - quando é um grupo de opções, o componente é 'QOptionGroup', caso contrário,

--- a/ui/src/components/radio/QasRadio.yml
+++ b/ui/src/components/radio/QasRadio.yml
@@ -14,5 +14,10 @@ props:
     default: ''
     type: String
 
+  tip:
+    desc: Texto exibido no tip ao lado da label.
+    default: ''
+    type: String
+
 meta:
   desc: Componente wrapper do QRadio.

--- a/ui/src/components/select/QasSelect.vue
+++ b/ui/src/components/select/QasSelect.vue
@@ -58,6 +58,16 @@
       </q-item>
     </template>
 
+    <template v-if="tip" #label>
+      <div class="items-center no-wrap q-gutter-x-xs row">
+        <div>
+          {{ formattedLabel }}
+        </div>
+
+        <qas-tip v-bind="tipProps" />
+      </div>
+    </template>
+
     <template v-for="(_, name) in $slots" #[name]="context">
       <slot :name="name" v-bind="context || {}" />
     </template>
@@ -134,6 +144,11 @@ export default {
     },
 
     prefix: {
+      type: String,
+      default: ''
+    },
+
+    tip: {
       type: String,
       default: ''
     },
@@ -232,7 +247,9 @@ export default {
     },
 
     hasError () {
-      return this.mx_hasFetchError || this.$attrs.error
+      const hasErrorAttr = this.$attrs.error === '' || !!this.$attrs.error
+
+      return this.mx_hasFetchError || hasErrorAttr
     },
 
     hasLoading () {
@@ -321,6 +338,14 @@ export default {
 
     hasIcon () {
       return this.isSearchable || !!this.icon
+    },
+
+    tipProps () {
+      return {
+        text: this.tip,
+
+        ...(this.hasError && { color: 'negative' })
+      }
     }
   },
 

--- a/ui/src/components/select/QasSelect.vue
+++ b/ui/src/components/select/QasSelect.vue
@@ -76,6 +76,7 @@
 
 <script>
 import QasBadge from '../badge/QasBadge.vue'
+import QasTip from '../tip/QasTip.vue'
 
 import { getRequiredLabel } from '../../helpers'
 import { searchFilterMixin } from '../../mixins'
@@ -88,7 +89,8 @@ export default {
   name: 'QasSelect',
 
   components: {
-    QasBadge
+    QasBadge,
+    QasTip
   },
 
   mixins: [searchFilterMixin],

--- a/ui/src/components/select/QasSelect.yml
+++ b/ui/src/components/select/QasSelect.yml
@@ -102,6 +102,11 @@ props:
     default: false
     type: Boolean
 
+  tip:
+    desc: Texto exibido no tip ao lado da label.
+    default: ''
+    type: String
+
   value-key:
     desc: O componente internamente espera receber na propriedade "options" um array de objeto contendo "label" e "value", caso o seu objeto não tenha "value" mas um "uuid" por exemplo, você pode definir esta prop "label-value" como "uuid".
     type: String

--- a/ui/src/components/toggle/QasToggle.vue
+++ b/ui/src/components/toggle/QasToggle.vue
@@ -4,12 +4,24 @@
       {{ props.title }}
     </span>
 
-    <q-toggle class="col-12 qas-toggle" v-bind="attrs" dense />
+    <q-toggle class="col-12 qas-toggle" v-bind="toggleAttrs" dense>
+      <template v-if="hasLabelTip" #default>
+        <div class="items-center no-wrap q-gutter-x-xs row">
+          <div>
+            {{ attrs.label }}
+          </div>
+
+          <qas-tip :text="props.tip" />
+        </div>
+      </template>
+    </q-toggle>
   </div>
 </template>
 
 <script setup>
-import { useAttrs } from 'vue'
+import QasTip from '../tip/QasTip.vue'
+
+import { computed, useAttrs } from 'vue'
 
 defineOptions({
   name: 'QasToggle',
@@ -20,11 +32,28 @@ const props = defineProps({
   title: {
     type: String,
     default: ''
+  },
+
+  tip: {
+    type: String,
+    default: ''
   }
 })
 
 // composables
 const attrs = useAttrs()
+
+const hasLabelTip = computed(() => !!(props.tip && attrs.label))
+
+const toggleAttrs = computed(() => {
+  const payload = { ...attrs }
+
+  if (hasLabelTip.value) {
+    payload.label = undefined
+  }
+
+  return payload
+})
 </script>
 
 <style lang="scss">

--- a/ui/src/components/toggle/QasToggle.yml
+++ b/ui/src/components/toggle/QasToggle.yml
@@ -9,3 +9,8 @@ props:
     default: ''
     desc: Título exibido acima do toggle.
 
+  tip:
+    type: String
+    default: ''
+    desc: Texto exibido no tip ao lado da label.
+

--- a/ui/src/css/components/field.scss
+++ b/ui/src/css/components/field.scss
@@ -47,6 +47,21 @@
   &__label,
   &--dense &__label {
     @include set-typography($body2);
+    pointer-events: none;
+  }
+
+  // Mantém o label sem interação, mas libera hover/click no qas-tip dentro dele.
+  &__label:has(.qas-tip) {
+    pointer-events: auto;
+
+    > * {
+      pointer-events: none;
+    }
+
+    .qas-tip,
+    .qas-tip * {
+      pointer-events: auto;
+    }
   }
 
   // pega o ícone imediato dos append e prepend, não os do q-chip por exemplo.

--- a/ui/src/css/components/field.scss
+++ b/ui/src/css/components/field.scss
@@ -47,6 +47,7 @@
   &__label,
   &--dense &__label {
     @include set-typography($body2);
+
     pointer-events: none;
   }
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

- `QasCheckbox`, `QasInput`, `QasRadio`, `QasSelect` e `QasToggle`: adicionada nova prop `tip` para exibir conteúdo de ajuda ao lado da label.
## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [x] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [ ] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [x] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [x] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [ ] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
