### PR TITLE
feat: correção de build dos produtos que usam vite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não p
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
 ## Não publicado
+## BREAKING CHANGES
+- Necessário alterar `quasar.conf` para utilizar os alias pelo `extendWebpack` ao invés do `chainWebpack`.
+
 ### Corrigido
 - Corrigido problema de build dos produtos que usam vite, onde foi necessário tratar os alias de imagens do leaflet.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de s
 Devemos adicionar o comentário `<!-- N/A -->` (Não adicionar), para que não precise adicionar um item do changelog ao lançar uma nova versão stable.
 Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicionados. Caso adicionado na linha, será considerado apenas ela.
 
+## Não publicado
+### Corrigido
+- Corrigido problema de build dos produtos que usam vite, onde foi necessário tratar os alias de imagens do leaflet.
+
 ## [3.20.0-beta.26] - 17-07-2026
 ### Adicionado
 - `QasDialogFilePreview`: adicionado o componente de dialog para visualizar imagens ou pdfs, com funcionalidade de download e zoom.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Caso adicionado no escopo inicial, todos os conteúdos abaixo não serão adicio
 
 ## Não publicado
 ## BREAKING CHANGES
-- Necessário alterar `quasar.conf` para utilizar os alias pelo `extendWebpack` ao invés do `chainWebpack`.
+- Necessário remover o alias `images` no `quasar.conf`, pois isso causará conflito com o alias criado por conta da biblioteca `leaflet` usado no `QasMapDraw`.
 
 ### Corrigido
 - Corrigido problema de build dos produtos que usam vite, onde foi necessário tratar os alias de imagens do leaflet.

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@appnave/quasar-app-extension-asteroid",
-  "version": "3.20.0-beta.27-alpha.1",
+  "version": "3.20.0-beta.27-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appnave/quasar-app-extension-asteroid",
-      "version": "3.20.0-beta.27-alpha.1",
+      "version": "3.20.0-beta.27-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@appnave/quasar-app-extension-asteroid": "file:",
-        "@appnave/quasar-ui-asteroid": "3.20.0-beta.27-alpha.1",
+        "@appnave/quasar-ui-asteroid": "3.20.0-beta.27-alpha.2",
         "@bildvitta/store-adapter": "^1.0.0",
         "execa": "^7.1.1",
         "fontfaceobserver": "^2.3.0",
@@ -35,9 +35,9 @@
       "link": true
     },
     "node_modules/@appnave/quasar-ui-asteroid": {
-      "version": "3.20.0-beta.27-alpha.1",
-      "resolved": "https://registry.npmjs.org/@appnave/quasar-ui-asteroid/-/quasar-ui-asteroid-3.20.0-beta.27-alpha.1.tgz",
-      "integrity": "sha512-7Z+uAlitdYDMnGvBTluiTqnBgeF/FjHpDra8xXEky7wUtrFrPa3RnAyV+SNr2EObtUZ1aEEOh0nNSGq9IzEm0A==",
+      "version": "3.20.0-beta.27-alpha.2",
+      "resolved": "https://registry.npmjs.org/@appnave/quasar-ui-asteroid/-/quasar-ui-asteroid-3.20.0-beta.27-alpha.2.tgz",
+      "integrity": "sha512-mcG/dVkp7hv+Bt/HW9NceHuDNgOhGl1v14Rc+oXn7174RkGCTRkjctzXt7RNuPq1vpiW7scBz3uxcnh3OBnJZA==",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@appnave/quasar-app-extension-asteroid",
-  "version": "3.20.0-beta.27-alpha.0",
+  "version": "3.20.0-beta.27-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appnave/quasar-app-extension-asteroid",
-      "version": "3.20.0-beta.27-alpha.0",
+      "version": "3.20.0-beta.27-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@appnave/quasar-app-extension-asteroid": "file:",
-        "@appnave/quasar-ui-asteroid": "3.20.0-beta.27-alpha.0",
+        "@appnave/quasar-ui-asteroid": "3.20.0-beta.27-alpha.1",
         "@bildvitta/store-adapter": "^1.0.0",
         "execa": "^7.1.1",
         "fontfaceobserver": "^2.3.0",
@@ -35,9 +35,9 @@
       "link": true
     },
     "node_modules/@appnave/quasar-ui-asteroid": {
-      "version": "3.20.0-beta.27-alpha.0",
-      "resolved": "https://registry.npmjs.org/@appnave/quasar-ui-asteroid/-/quasar-ui-asteroid-3.20.0-beta.27-alpha.0.tgz",
-      "integrity": "sha512-itDy5D0SLm8zbiTvMEkTAcTWX4e+BbCVb9bKjJK4UNx/gpEsG9IlgwQocOUDG7l1nlFFadrJq8WhBemZsmmEew==",
+      "version": "3.20.0-beta.27-alpha.1",
+      "resolved": "https://registry.npmjs.org/@appnave/quasar-ui-asteroid/-/quasar-ui-asteroid-3.20.0-beta.27-alpha.1.tgz",
+      "integrity": "sha512-7Z+uAlitdYDMnGvBTluiTqnBgeF/FjHpDra8xXEky7wUtrFrPa3RnAyV+SNr2EObtUZ1aEEOh0nNSGq9IzEm0A==",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/app-extension/package-lock.json
+++ b/app-extension/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@appnave/quasar-app-extension-asteroid",
-  "version": "3.20.0-beta.26",
+  "version": "3.20.0-beta.27-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appnave/quasar-app-extension-asteroid",
-      "version": "3.20.0-beta.26",
+      "version": "3.20.0-beta.27-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@appnave/quasar-app-extension-asteroid": "file:",
-        "@appnave/quasar-ui-asteroid": "3.20.0-beta.26",
+        "@appnave/quasar-ui-asteroid": "3.20.0-beta.27-alpha.0",
         "@bildvitta/store-adapter": "^1.0.0",
         "execa": "^7.1.1",
         "fontfaceobserver": "^2.3.0",
@@ -35,9 +35,9 @@
       "link": true
     },
     "node_modules/@appnave/quasar-ui-asteroid": {
-      "version": "3.20.0-beta.26",
-      "resolved": "https://registry.npmjs.org/@appnave/quasar-ui-asteroid/-/quasar-ui-asteroid-3.20.0-beta.26.tgz",
-      "integrity": "sha512-IfyQfg+TUZ2TpeOYfnSYTv35SXnYWcHFe7IhlPyiRfLxcSQ/CoWFzlrxKMVWN+bLMWAazJJvtHP4XlBu37Z/kg==",
+      "version": "3.20.0-beta.27-alpha.0",
+      "resolved": "https://registry.npmjs.org/@appnave/quasar-ui-asteroid/-/quasar-ui-asteroid-3.20.0-beta.27-alpha.0.tgz",
+      "integrity": "sha512-itDy5D0SLm8zbiTvMEkTAcTWX4e+BbCVb9bKjJK4UNx/gpEsG9IlgwQocOUDG7l1nlFFadrJq8WhBemZsmmEew==",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@appnave/quasar-app-extension-asteroid",
   "description": "Asteroid",
-  "version": "3.20.0-beta.27-alpha.1",
+  "version": "3.20.0-beta.27-alpha.2",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "src/index.js",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@appnave/quasar-app-extension-asteroid": "file:",
-    "@appnave/quasar-ui-asteroid": "3.20.0-beta.27-alpha.1",
+    "@appnave/quasar-ui-asteroid": "3.20.0-beta.27-alpha.2",
     "@bildvitta/store-adapter": "^1.0.0",
     "execa": "^7.1.1",
     "fontfaceobserver": "^2.3.0",

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@appnave/quasar-app-extension-asteroid",
   "description": "Asteroid",
-  "version": "3.20.0-beta.27-alpha.0",
+  "version": "3.20.0-beta.27-alpha.1",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "src/index.js",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@appnave/quasar-app-extension-asteroid": "file:",
-    "@appnave/quasar-ui-asteroid": "3.20.0-beta.27-alpha.0",
+    "@appnave/quasar-ui-asteroid": "3.20.0-beta.27-alpha.1",
     "@bildvitta/store-adapter": "^1.0.0",
     "execa": "^7.1.1",
     "fontfaceobserver": "^2.3.0",

--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@appnave/quasar-app-extension-asteroid",
   "description": "Asteroid",
-  "version": "3.20.0-beta.26",
+  "version": "3.20.0-beta.27-alpha.0",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "src/index.js",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@appnave/quasar-app-extension-asteroid": "file:",
-    "@appnave/quasar-ui-asteroid": "3.20.0-beta.26",
+    "@appnave/quasar-ui-asteroid": "3.20.0-beta.27-alpha.0",
     "@bildvitta/store-adapter": "^1.0.0",
     "execa": "^7.1.1",
     "fontfaceobserver": "^2.3.0",

--- a/app-extension/src/index.js
+++ b/app-extension/src/index.js
@@ -109,7 +109,18 @@ export default async function (api) {
     api.compatibleWith('@quasar/app-vite', '^2.0.0')
 
     api.extendViteConf(viteConf => {
-      Object.assign(viteConf.resolve.alias, alias)
+      /**
+       * Corrige os paths das imagens do Leaflet para que sejam resolvidas corretamente, uma vez que o Leaflet
+       * utiliza imagens que são referenciadas diretamente em seu código, e não é possível alterar isso.
+       * Dessa forma, é necessário configurar os aliases para que o vite consiga resolver os paths corretamente.
+       */
+      const leafletImageAliases = {
+        'images/layers.png': api.resolve.app('node_modules/leaflet/dist/images/layers.png'),
+        'images/layers-2x.png': api.resolve.app('node_modules/leaflet/dist/images/layers-2x.png'),
+        'images/marker-icon.png': api.resolve.app('node_modules/leaflet/dist/images/marker-icon.png')
+      }
+
+      viteConf.resolve.alias = Object.assign(leafletImageAliases, viteConf.resolve.alias, alias)
 
       // optimizeDeps (necessário para funcionamento do QasMap)
       viteConf.optimizeDeps = viteConf.optimizeDeps || {}

--- a/app-extension/src/index.js
+++ b/app-extension/src/index.js
@@ -112,17 +112,6 @@ export default async function (api) {
     api.compatibleWith('@quasar/app-vite', '^2.0.0')
 
     api.extendViteConf(viteConf => {
-      /**
-       * Corrige os paths das imagens do Leaflet para que sejam resolvidas corretamente, uma vez que o Leaflet
-       * utiliza imagens que são referenciadas diretamente em seu código, e não é possível alterar isso.
-       * Dessa forma, é necessário configurar os aliases para que o vite consiga resolver os paths corretamente.
-       */
-      // const leafletImageAliases = {
-      //   'images/layers.png': api.resolve.app('node_modules/leaflet/dist/images/layers.png'),
-      //   'images/layers-2x.png': api.resolve.app('node_modules/leaflet/dist/images/layers-2x.png'),
-      //   'images/marker-icon.png': api.resolve.app('node_modules/leaflet/dist/images/marker-icon.png')
-      // }
-
       Object.assign(viteConf.resolve.alias, alias)
 
       // optimizeDeps (necessário para funcionamento do QasMap)
@@ -151,18 +140,6 @@ export default async function (api) {
   }
 
   api.compatibleWith('@quasar/app', '^3.10.0 || ^4.0.0')
-
-  /**
-   * Corrige os paths das imagens do Leaflet para que sejam resolvidas corretamente, uma vez que o Leaflet
-   * utiliza imagens que são referenciadas diretamente em seu código, e não é possível alterar isso.
-   * Dessa forma, é necessário configurar os aliases para que o webpack consiga resolver os paths corretamente.
-   */
-  // api.chainWebpack(chain => {
-  //   chain.resolve.alias
-  //     .set('images/layers.png', api.resolve.app('node_modules/leaflet/dist/images/layers.png'))
-  //     .set('images/layers-2x.png', api.resolve.app('node_modules/leaflet/dist/images/layers-2x.png'))
-  //     .set('images/marker-icon.png', api.resolve.app('node_modules/leaflet/dist/images/marker-icon.png'))
-  // })
 
   api.extendWebpack(webpack => {
     Object.assign(webpack.resolve.alias, alias)

--- a/app-extension/src/index.js
+++ b/app-extension/src/index.js
@@ -102,7 +102,10 @@ export default async function (api) {
     'asteroid-config-app': asteroidConfigPath,
     'vue-router': api.resolve.app(vueRouter),
     asteroid: api.resolve.app(asteroid),
-    quasar: api.resolve.app(quasar)
+    quasar: api.resolve.app(quasar),
+    'images/layers.png': api.resolve.app('node_modules/leaflet/dist/images/layers.png'),
+    'images/layers-2x.png': api.resolve.app('node_modules/leaflet/dist/images/layers-2x.png'),
+    'images/marker-icon.png': api.resolve.app('node_modules/leaflet/dist/images/marker-icon.png')
   }
 
   if (api.hasVite) {
@@ -114,13 +117,13 @@ export default async function (api) {
        * utiliza imagens que são referenciadas diretamente em seu código, e não é possível alterar isso.
        * Dessa forma, é necessário configurar os aliases para que o vite consiga resolver os paths corretamente.
        */
-      const leafletImageAliases = {
-        'images/layers.png': api.resolve.app('node_modules/leaflet/dist/images/layers.png'),
-        'images/layers-2x.png': api.resolve.app('node_modules/leaflet/dist/images/layers-2x.png'),
-        'images/marker-icon.png': api.resolve.app('node_modules/leaflet/dist/images/marker-icon.png')
-      }
+      // const leafletImageAliases = {
+      //   'images/layers.png': api.resolve.app('node_modules/leaflet/dist/images/layers.png'),
+      //   'images/layers-2x.png': api.resolve.app('node_modules/leaflet/dist/images/layers-2x.png'),
+      //   'images/marker-icon.png': api.resolve.app('node_modules/leaflet/dist/images/marker-icon.png')
+      // }
 
-      viteConf.resolve.alias = Object.assign(leafletImageAliases, viteConf.resolve.alias, alias)
+      Object.assign(viteConf.resolve.alias, alias)
 
       // optimizeDeps (necessário para funcionamento do QasMap)
       viteConf.optimizeDeps = viteConf.optimizeDeps || {}
@@ -154,12 +157,12 @@ export default async function (api) {
    * utiliza imagens que são referenciadas diretamente em seu código, e não é possível alterar isso.
    * Dessa forma, é necessário configurar os aliases para que o webpack consiga resolver os paths corretamente.
    */
-  api.chainWebpack(chain => {
-    chain.resolve.alias
-      .set('images/layers.png', api.resolve.app('node_modules/leaflet/dist/images/layers.png'))
-      .set('images/layers-2x.png', api.resolve.app('node_modules/leaflet/dist/images/layers-2x.png'))
-      .set('images/marker-icon.png', api.resolve.app('node_modules/leaflet/dist/images/marker-icon.png'))
-  })
+  // api.chainWebpack(chain => {
+  //   chain.resolve.alias
+  //     .set('images/layers.png', api.resolve.app('node_modules/leaflet/dist/images/layers.png'))
+  //     .set('images/layers-2x.png', api.resolve.app('node_modules/leaflet/dist/images/layers-2x.png'))
+  //     .set('images/marker-icon.png', api.resolve.app('node_modules/leaflet/dist/images/marker-icon.png'))
+  // })
 
   api.extendWebpack(webpack => {
     Object.assign(webpack.resolve.alias, alias)

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appnave/asteroid-docs",
-  "version": "3.20.0-beta.27-alpha.0",
+  "version": "3.20.0-beta.27-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appnave/asteroid-docs",
-      "version": "3.20.0-beta.27-alpha.0",
+      "version": "3.20.0-beta.27-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-js": "^1.9.2",
@@ -50,7 +50,7 @@
     },
     "../ui": {
       "name": "@appnave/quasar-ui-asteroid",
-      "version": "3.20.0-beta.26",
+      "version": "3.20.0-beta.27-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appnave/asteroid-docs",
-  "version": "3.20.0-beta.27-alpha.1",
+  "version": "3.20.0-beta.27-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appnave/asteroid-docs",
-      "version": "3.20.0-beta.27-alpha.1",
+      "version": "3.20.0-beta.27-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-js": "^1.9.2",
@@ -50,7 +50,7 @@
     },
     "../ui": {
       "name": "@appnave/quasar-ui-asteroid",
-      "version": "3.20.0-beta.27-alpha.0",
+      "version": "3.20.0-beta.27-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appnave/asteroid-docs",
-  "version": "3.20.0-beta.26",
+  "version": "3.20.0-beta.27-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appnave/asteroid-docs",
-      "version": "3.20.0-beta.26",
+      "version": "3.20.0-beta.27-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-js": "^1.9.2",
@@ -50,7 +50,7 @@
     },
     "../ui": {
       "name": "@appnave/quasar-ui-asteroid",
-      "version": "3.20.0-beta.26-alpha.9",
+      "version": "3.20.0-beta.26",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@appnave/asteroid-docs",
   "description": "Asteroid",
-  "version": "3.20.0-beta.27-alpha.0",
+  "version": "3.20.0-beta.27-alpha.1",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "productName": "Asteroid Docs",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@appnave/asteroid-docs",
   "description": "Asteroid",
-  "version": "3.20.0-beta.27-alpha.1",
+  "version": "3.20.0-beta.27-alpha.2",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "productName": "Asteroid Docs",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@appnave/asteroid-docs",
   "description": "Asteroid",
-  "version": "3.20.0-beta.26",
+  "version": "3.20.0-beta.27-alpha.0",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "productName": "Asteroid Docs",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appnave/asteroid",
-  "version": "3.20.0-beta.26",
+  "version": "3.20.0-beta.27-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@appnave/asteroid",
-      "version": "3.20.0-beta.26",
+      "version": "3.20.0-beta.27-alpha.0",
       "license": "MIT",
       "devDependencies": {
         "@appnave/quasar-ui-asteroid": "file:ui",
@@ -6802,7 +6802,7 @@
     },
     "ui": {
       "name": "@appnave/quasar-ui-asteroid",
-      "version": "3.20.0-beta.26-alpha.9",
+      "version": "3.20.0-beta.26",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appnave/asteroid",
-  "version": "3.20.0-beta.27-alpha.1",
+  "version": "3.20.0-beta.27-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@appnave/asteroid",
-      "version": "3.20.0-beta.27-alpha.1",
+      "version": "3.20.0-beta.27-alpha.2",
       "license": "MIT",
       "devDependencies": {
         "@appnave/quasar-ui-asteroid": "file:ui",
@@ -6802,7 +6802,7 @@
     },
     "ui": {
       "name": "@appnave/quasar-ui-asteroid",
-      "version": "3.20.0-beta.27-alpha.0",
+      "version": "3.20.0-beta.27-alpha.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appnave/asteroid",
-  "version": "3.20.0-beta.27-alpha.0",
+  "version": "3.20.0-beta.27-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@appnave/asteroid",
-      "version": "3.20.0-beta.27-alpha.0",
+      "version": "3.20.0-beta.27-alpha.1",
       "license": "MIT",
       "devDependencies": {
         "@appnave/quasar-ui-asteroid": "file:ui",
@@ -6802,7 +6802,7 @@
     },
     "ui": {
       "name": "@appnave/quasar-ui-asteroid",
-      "version": "3.20.0-beta.26",
+      "version": "3.20.0-beta.27-alpha.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@appnave/asteroid",
   "description": "Asteroid",
-  "version": "3.20.0-beta.26",
+  "version": "3.20.0-beta.27-alpha.0",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@appnave/asteroid",
   "description": "Asteroid",
-  "version": "3.20.0-beta.27-alpha.0",
+  "version": "3.20.0-beta.27-alpha.1",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@appnave/asteroid",
   "description": "Asteroid",
-  "version": "3.20.0-beta.27-alpha.1",
+  "version": "3.20.0-beta.27-alpha.2",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "scripts": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appnave/quasar-ui-asteroid",
-  "version": "3.20.0-beta.26",
+  "version": "3.20.0-beta.27-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@appnave/quasar-ui-asteroid",
-      "version": "3.20.0-beta.26",
+      "version": "3.20.0-beta.27-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appnave/quasar-ui-asteroid",
-  "version": "3.20.0-beta.27-alpha.0",
+  "version": "3.20.0-beta.27-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@appnave/quasar-ui-asteroid",
-      "version": "3.20.0-beta.27-alpha.0",
+      "version": "3.20.0-beta.27-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appnave/quasar-ui-asteroid",
-  "version": "3.20.0-beta.27-alpha.1",
+  "version": "3.20.0-beta.27-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@appnave/quasar-ui-asteroid",
-      "version": "3.20.0-beta.27-alpha.1",
+      "version": "3.20.0-beta.27-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@bildvitta/composables": "^1.0.0-beta.7",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@appnave/quasar-ui-asteroid",
   "description": "Asteroid",
-  "version": "3.20.0-beta.26",
+  "version": "3.20.0-beta.27-alpha.0",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "./src/asteroid.js",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@appnave/quasar-ui-asteroid",
   "description": "Asteroid",
-  "version": "3.20.0-beta.27-alpha.0",
+  "version": "3.20.0-beta.27-alpha.1",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "./src/asteroid.js",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@appnave/quasar-ui-asteroid",
   "description": "Asteroid",
-  "version": "3.20.0-beta.27-alpha.1",
+  "version": "3.20.0-beta.27-alpha.2",
   "author": "Bild & Vitta <systemteam@bild.com.br>",
   "license": "MIT",
   "main": "./src/asteroid.js",


### PR DESCRIPTION
### Corrigido
- Corrigido problema de build dos produtos que usam vite, onde foi necessário tratar os alias de imagens do leaflet.

## Versão do asteroid

- [ ] v2 -> a partir da branch `v2`.
- [x] v3-beta.x -> a partir da branch `develop`.
- [ ] v3-stable -> a partir da branch `main`.

## Tipo de alteração

- [ ] Adicionado | Added (novos componentes e/ou funcionalidades);
- [ ] Modificado | Changed (alterações que podem ou não conter _breaking changes_);
- [x] Corrigido | Fixed (correção de bugs, typos, etc);
- [ ] Removido | removed (remoção de algum componente e/ou funcionalidade).

## O que foi alterado/adicionado

- [ ] CSS
- [ ] Componentes
- [ ] Composables (v3)
- [ ] Diretivas
- [ ] Documentação
- [ ] Helpers
- [ ] Mixins
- [ ] Paginas
- [ ] Plugins
- [ ] Testes
- [x] Outros

Este _pull request_ introduz algum _breaking change_?

- [ ] Sim
- [x] Não

## Checklist

- [x] Foi discutida anteriormente com os times de Frontend e Design;
- [x] Foi testado manualmente no ambiente de desenvolvimento (`/docs` se v3 ou `ui/dev` se v2);
- [x] Foi constatado que esta modificação não gerou erros ou alertas no Console;
- [x] Foi verificado se o código segue os padrões de escrita e validado com o ESLint;
- [ ] Foi escrito teste automatizado;
- [x] Foi atualizada e testada a documentação;
- [x] Foi atualizado o _changelog_ seguindo o padrão "Keep a Changelog";
- [x] Fiz meu próprio _code review_ antes de abrir este _pull request_.
